### PR TITLE
netlink-packet-route: extract link instance from the link message

### DIFF
--- a/src/rtnl/link/link_attr/link_attrs.rs
+++ b/src/rtnl/link/link_attr/link_attrs.rs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT
+
+use std::os::unix::io::RawFd;
+
+use crate::nlas::link::State;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum Namespace {
+    NetNsPid(u32),
+    #[allow(dead_code)]
+    NetNsFd(RawFd),
+}
+impl Default for Namespace {
+    fn default() -> Self {
+        Self::NetNsPid(0)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum LinkStatistics {
+    #[allow(dead_code)]
+    Stats(LinkStatistics32),
+    Stats64(LinkStatistics64),
+}
+impl Default for LinkStatistics {
+    fn default() -> Self {
+        Self::Stats64(LinkStatistics64::default())
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
+pub struct LinkStatistics32 {
+    pub rx_packets: u32,
+    pub tx_packets: u32,
+    pub rx_bytes: u32,
+    pub tx_bytes: u32,
+    pub rx_errors: u32,
+    pub tx_errors: u32,
+    pub rx_dropped: u32,
+    pub tx_dropped: u32,
+    pub multicast: u32,
+    pub collisions: u32,
+    pub rx_length_errors: u32,
+    pub rx_over_errors: u32,
+    pub rx_crc_errors: u32,
+    pub rx_frame_errors: u32,
+    pub rx_fifo_errors: u32,
+    pub rx_missed_errors: u32,
+    pub tx_aborted_errors: u32,
+    pub tx_carrier_errors: u32,
+    pub tx_fifo_errors: u32,
+    pub tx_heartbeat_errors: u32,
+    pub tx_window_errors: u32,
+    pub rx_compressed: u32,
+    pub tx_compressed: u32,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
+pub struct LinkStatistics64 {
+    pub rx_packets: u64,
+    pub tx_packets: u64,
+    pub rx_bytes: u64,
+    pub tx_bytes: u64,
+    pub rx_errors: u64,
+    pub tx_errors: u64,
+    pub rx_dropped: u64,
+    pub tx_dropped: u64,
+    pub multicast: u64,
+    pub collisions: u64,
+    pub rx_length_errors: u64,
+    pub rx_over_errors: u64,
+    pub rx_crc_errors: u64,
+    pub rx_frame_errors: u64,
+    pub rx_fifo_errors: u64,
+    pub rx_missed_errors: u64,
+    pub tx_aborted_errors: u64,
+    pub tx_carrier_errors: u64,
+    pub tx_fifo_errors: u64,
+    pub tx_heartbeat_errors: u64,
+    pub tx_window_errors: u64,
+    pub rx_compressed: u64,
+    pub tx_compressed: u64,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
+pub struct LinkXdp {
+    pub fd: RawFd,
+    pub attached: bool,
+    pub flags: u32,
+    pub prog_id: u32,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct OperState(State);
+impl Default for OperState {
+    fn default() -> Self {
+        Self(State::Unknown)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
+pub struct LinkAttrs {
+    pub index: u32,
+    pub mtu: u32,
+    pub txq_len: u32,
+
+    pub name: String,
+    pub hardware_addr: Vec<u8>,
+    pub flags: u32,
+    pub parent_index: u32,
+    pub master_index: u32,
+    pub namespace: Namespace,
+    pub alias: String,
+    pub statistics: LinkStatistics,
+    pub promisc: u32,
+    pub xdp: LinkXdp,
+    pub link_layer_type: u16,
+    pub proto_info: Vec<u8>,
+    pub oper_state: OperState,
+    pub net_ns_id: i32,
+    pub num_tx_queues: u32,
+    pub num_rx_queues: u32,
+    pub gso_max_size: u32,
+    pub gso_max_seqs: u32,
+    pub vfs: Vec<u8>,
+    pub group: u32,
+}

--- a/src/rtnl/link/link_attr/links.rs
+++ b/src/rtnl/link/link_attr/links.rs
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+
+use super::link_attrs::LinkAttrs;
+
+pub trait Link: Send + Sync {
+    fn attrs(&self) -> &LinkAttrs;
+    fn set_attrs(&mut self, attr: LinkAttrs);
+    fn r#type(&self) -> &str;
+}
+
+macro_rules! impl_network_dev {
+    ($r_type: literal , $r_struct: ty) => {
+        impl Link for $r_struct {
+            fn attrs(&self) -> &LinkAttrs {
+                self.attrs.as_ref().unwrap()
+            }
+            fn set_attrs(&mut self, attr: LinkAttrs) {
+                self.attrs = Some(attr);
+            }
+            fn r#type(&self) -> &'static str {
+                $r_type
+            }
+        }
+    };
+}
+
+macro_rules! define_and_impl_network_dev {
+    ($r_type: literal , $r_struct: tt) => {
+        #[derive(Debug, PartialEq, Eq, Clone, Default)]
+        pub struct $r_struct {
+            attrs: Option<LinkAttrs>,
+        }
+
+        impl_network_dev!($r_type, $r_struct);
+    };
+}
+
+define_and_impl_network_dev!("device", Device);
+define_and_impl_network_dev!("tuntap", Tuntap);
+define_and_impl_network_dev!("veth", Veth);
+define_and_impl_network_dev!("ipvlan", IpVlan);
+define_and_impl_network_dev!("macvlan", MacVlan);
+define_and_impl_network_dev!("vlan", Vlan);
+
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
+pub struct Bridge {
+    attrs: Option<LinkAttrs>,
+    pub multicast_snooping: bool,
+    pub hello_time: u32,
+    pub vlan_filtering: bool,
+}
+
+impl_network_dev!("bridge", Bridge);

--- a/src/rtnl/link/link_attr/mod.rs
+++ b/src/rtnl/link/link_attr/mod.rs
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: MIT
+
+mod link_attrs;
+pub use link_attrs::LinkAttrs;
+pub mod links;

--- a/src/rtnl/link/mod.rs
+++ b/src/rtnl/link/mod.rs
@@ -2,7 +2,8 @@
 
 mod buffer;
 mod header;
+mod link_attr;
 mod message;
 pub mod nlas;
-
 pub use self::{buffer::*, header::*, message::*};
+pub use link_attr::{links::Link, LinkAttrs};

--- a/src/rtnl/link/nlas/bridge.rs
+++ b/src/rtnl/link/nlas/bridge.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     constants::*,
+    link::link_attr::links::Bridge,
     nlas::{DefaultNla, Nla, NlaBuffer, NlasIterator, NLA_F_NESTED},
     parsers::{
         parse_ip, parse_mac, parse_u16, parse_u16_be, parse_u32, parse_u64,
@@ -611,6 +612,28 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     }
 }
 
+pub(crate) struct VecInfoBridge(pub(crate) Vec<InfoBridge>);
+
+impl VecInfoBridge {
+    pub fn parse_bridge(self) -> Bridge {
+        let mut bridge = Bridge::default();
+        for ib in self.0 {
+            match ib {
+                InfoBridge::HelloTime(ht) => {
+                    bridge.hello_time = ht;
+                }
+                InfoBridge::MulticastSnooping(m) => {
+                    bridge.multicast_snooping = m == 1;
+                }
+                InfoBridge::VlanFiltering(v) => {
+                    bridge.vlan_filtering = v == 1;
+                }
+                _ => {}
+            }
+        }
+        bridge
+    }
+}
 #[cfg(test)]
 mod tests {
     use crate::{


### PR DESCRIPTION
1. This pr support transfer the link message into a link instance for different kind of endpoints.
2. The link instance implement the trait to get and set attribute, and also get the link type.

Fixes:#6
Signed-off-by: Zhongtao Hu <zhongtaohu.tim@linux.alibaba.com>