### PR TITLE
LinkAddRequest: Allow adding XFRM tunnel with if_id mark

### DIFF
--- a/src/rtnl/constants.rs
+++ b/src/rtnl/constants.rs
@@ -487,6 +487,9 @@ pub const IFLA_IPOIB_MODE: u16 = 2;
 pub const IFLA_IPOIB_UMCAST: u16 = 3;
 pub const VETH_INFO_UNSPEC: u16 = 0;
 pub const VETH_INFO_PEER: u16 = 1;
+pub const IFLA_XFRM_UNSPEC: u16 = 0;
+pub const IFLA_XFRM_LINK: u16 = 1;
+pub const IFLA_XFRM_IF_ID: u16 = 2;
 
 pub const ARPHRD_NETROM: u16 = 0;
 pub const ARPHRD_ETHER: u16 = 1;


### PR DESCRIPTION
Add support to create XFRM tunnel
This is equivalent to `ip link add name NAME type xfrm if_id NUMBER`

Depends upon: https://github.com/rust-netlink/rtnetlink/pull/6

Signed-off-by: Michael Richardson <mcr@sandelman.ca>