### PR TITLE
Mark all public struct/enum as `non_exhaustive`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 homepage = "https://github.com/rust-netlink/netlink-packet-route"
 keywords = ["netlink", "linux"]
 license = "MIT"
-readme = "../README.md"
+readme = "README.md"
 repository = "https://github.com/rust-netlink/netlink-packet-route"
 description = "netlink packet types"
 

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,25 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+Distributions of all or part of the Software intended to be used by the
+recipients as they would use the unmodified Software, containing modifications
+that substantially alter, remove, or disable functionality of the Software,
+outside of the documented configuration mechanisms provided by the Software,
+shall be modified such that the Original Author's bug reporting email addresses
+and urls are either replaced with the contact information of the parties
+responsible for the changes, or removed entirely.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# netlink-packet-route
+
+Rust crate providing netlink message parsing and generating support for the
+[netlink route protocol][1].
+
+Rust crate document could be found at [docs.rs][2].
+
+[1]: https://www.man7.org/linux/man-pages/man7/rtnetlink.7.html
+[2]: https://docs.rs/netlink-packet-route/

--- a/examples/dump_neighbours.rs
+++ b/examples/dump_neighbours.rs
@@ -30,7 +30,7 @@ fn main() {
     let mut buf = vec![0; req.header.length as usize];
     req.serialize(&mut buf[..]);
 
-    println!(">>> {:?}", req);
+    println!(">>> {req:?}");
     socket.send(&buf[..], 0).unwrap();
 
     let mut receive_buffer = vec![0; 4096];
@@ -56,7 +56,7 @@ fn main() {
                     }
                 }
                 NetlinkPayload::Error(err) => {
-                    eprintln!("Received a netlink error message: {:?}", err);
+                    eprintln!("Received a netlink error message: {err:?}");
                     return;
                 }
                 _ => {}
@@ -129,5 +129,5 @@ fn print_entry(entry: NeighbourMessage) {
         })
         .unwrap();
 
-    println!("{:<30} {:<20} ({})", dest, lladdr, state);
+    println!("{dest:<30} {lladdr:<20} ({state})");
 }

--- a/examples/dump_packet_link_bridge_vlan.rs
+++ b/examples/dump_packet_link_bridge_vlan.rs
@@ -33,7 +33,7 @@ fn main() {
     assert!(buf.len() == packet.buffer_len());
     packet.serialize(&mut buf[..]);
 
-    println!(">>> {:?}", packet);
+    println!(">>> {packet:?}");
     socket.send(&buf[..], 0).unwrap();
 
     let mut receive_buffer = vec![0; 4096];
@@ -63,7 +63,7 @@ fn main() {
             let rx_packet: NetlinkMessage<RtnlMessage> =
                 NetlinkMessage::deserialize(bytes).unwrap();
 
-            println!("<<< {:?}", rx_packet);
+            println!("<<< {rx_packet:?}");
 
             if rx_packet.payload == NetlinkPayload::Done {
                 println!("Done!");

--- a/examples/dump_packet_links.rs
+++ b/examples/dump_packet_links.rs
@@ -29,7 +29,7 @@ fn main() {
     assert!(buf.len() == packet.buffer_len());
     packet.serialize(&mut buf[..]);
 
-    println!(">>> {:?}", packet);
+    println!(">>> {packet:?}");
     socket.send(&buf[..], 0).unwrap();
 
     let mut receive_buffer = vec![0; 4096];
@@ -59,7 +59,7 @@ fn main() {
             let rx_packet: NetlinkMessage<RtnlMessage> =
                 NetlinkMessage::deserialize(bytes).unwrap();
 
-            println!("<<< {:?}", rx_packet);
+            println!("<<< {rx_packet:?}");
 
             if rx_packet.payload == NetlinkPayload::Done {
                 println!("Done!");

--- a/examples/dump_rules.rs
+++ b/examples/dump_rules.rs
@@ -33,9 +33,9 @@ fn main() {
 
     packet.serialize(&mut buf[..]);
 
-    println!(">>> {:?}", packet);
+    println!(">>> {packet:?}");
     if let Err(e) = socket.send(&buf[..], 0) {
-        println!("SEND ERROR {}", e);
+        println!("SEND ERROR {e}");
     }
 
     let mut receive_buffer = vec![0; 4096];
@@ -48,7 +48,7 @@ fn main() {
             let bytes = &receive_buffer[offset..];
             let rx_packet =
                 <NetlinkMessage<RtnlMessage>>::deserialize(bytes).unwrap();
-            println!("<<< {:?}", rx_packet);
+            println!("<<< {rx_packet:?}");
 
             if rx_packet.payload == NetlinkPayload::Done {
                 println!("Done!");

--- a/examples/new_rule.rs
+++ b/examples/new_rule.rs
@@ -37,7 +37,7 @@ fn main() {
 
     msg.serialize(&mut buf[..msg.buffer_len()]);
 
-    println!(">>> {:?}", msg);
+    println!(">>> {msg:?}");
 
     socket
         .send(&buf, 0)
@@ -48,10 +48,10 @@ fn main() {
     while let Ok(_size) = socket.recv(&mut receive_buffer, 0) {
         let bytes = &receive_buffer[..];
         let rx_packet = <NetlinkMessage<RtnlMessage>>::deserialize(bytes);
-        println!("<<< {:?}", rx_packet);
+        println!("<<< {rx_packet:?}");
         if let Ok(rx_packet) = rx_packet {
             if let NetlinkPayload::Error(e) = rx_packet.payload {
-                eprintln!("{:?}", e);
+                eprintln!("{e:?}");
             } else {
                 return;
             }

--- a/src/rtnl/address/message.rs
+++ b/src/rtnl/address/message.rs
@@ -9,12 +9,14 @@ use crate::{
 };
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[non_exhaustive]
 pub struct AddressMessage {
     pub header: AddressHeader,
     pub nlas: Vec<Nla>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[non_exhaustive]
 pub struct AddressHeader {
     pub family: u8,
     pub prefix_len: u8,

--- a/src/rtnl/address/nlas/cache_info.rs
+++ b/src/rtnl/address/nlas/cache_info.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+#[non_exhaustive]
 pub struct CacheInfo {
     pub ifa_preferred: i32,
     pub ifa_valid: i32,

--- a/src/rtnl/address/nlas/mod.rs
+++ b/src/rtnl/address/nlas/mod.rs
@@ -17,6 +17,7 @@ use crate::{
 };
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum Nla {
     Unspec(Vec<u8>),
     Address(Vec<u8>),

--- a/src/rtnl/address/nlas/mod.rs
+++ b/src/rtnl/address/nlas/mod.rs
@@ -122,7 +122,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nla {
             }
             kind => Other(
                 DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {}", kind))?,
+                    .context(format!("unknown NLA type {kind}"))?,
             ),
         })
     }

--- a/src/rtnl/buffer.rs
+++ b/src/rtnl/buffer.rs
@@ -174,7 +174,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
                 }
             }
 
-            _ => return Err(format!("Unknown message type: {}", message_type).into()),
+            _ => return Err(format!("Unknown message type: {message_type}").into()),
         };
         Ok(message)
     }

--- a/src/rtnl/link/header.rs
+++ b/src/rtnl/link/header.rs
@@ -25,6 +25,7 @@ use crate::{
 ///
 /// `LinkHeader` exposes all these fields except for the "reserved" one.
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[non_exhaustive]
 pub struct LinkHeader {
     /// Address family: one of the `AF_*` constants.
     pub interface_family: u8,

--- a/src/rtnl/link/message.rs
+++ b/src/rtnl/link/message.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[non_exhaustive]
 pub struct LinkMessage {
     pub header: LinkHeader,
     pub nlas: Vec<Nla>,

--- a/src/rtnl/link/nlas/af_spec_bridge.rs
+++ b/src/rtnl/link/nlas/af_spec_bridge.rs
@@ -15,6 +15,7 @@ use crate::{
 use byteorder::{ByteOrder, NativeEndian};
 
 #[derive(Clone, Eq, PartialEq, Debug)]
+#[non_exhaustive]
 pub enum AfSpecBridge {
     Flags(u16),
     VlanInfo(BridgeVlanInfo),
@@ -75,6 +76,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for AfSpecBridge {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
+#[non_exhaustive]
 pub struct BridgeVlanInfo {
     pub flags: u16,
     pub vid: u16,

--- a/src/rtnl/link/nlas/af_spec_bridge.rs
+++ b/src/rtnl/link/nlas/af_spec_bridge.rs
@@ -68,7 +68,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for AfSpecBridge {
             ),
             kind => Other(
                 DefaultNla::parse(buf)
-                    .context(format!("Unknown NLA type {}", kind))?,
+                    .context(format!("Unknown NLA type {kind}"))?,
             ),
         })
     }
@@ -95,18 +95,15 @@ impl TryFrom<&[u8]> for BridgeVlanInfo {
         if raw.len() == 4 {
             Ok(Self {
                 flags: parse_u16(&raw[0..2]).context(format!(
-                    "Invalid IFLA_BRIDGE_VLAN_INFO value: {:?}",
-                    raw
+                    "Invalid IFLA_BRIDGE_VLAN_INFO value: {raw:?}"
                 ))?,
                 vid: parse_u16(&raw[2..4]).context(format!(
-                    "Invalid IFLA_BRIDGE_VLAN_INFO value: {:?}",
-                    raw
+                    "Invalid IFLA_BRIDGE_VLAN_INFO value: {raw:?}"
                 ))?,
             })
         } else {
             Err(DecodeError::from(format!(
-                "Invalid IFLA_BRIDGE_VLAN_INFO value, expecting [u8;4], but got {:?}",
-                raw
+                "Invalid IFLA_BRIDGE_VLAN_INFO value, expecting [u8;4], but got {raw:?}"
             )))
         }
     }

--- a/src/rtnl/link/nlas/af_spec_inet.rs
+++ b/src/rtnl/link/nlas/af_spec_inet.rs
@@ -255,7 +255,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for AfSpecInet {
             AF_ALG => Alg(payload.to_vec()),
             kind => Other(
                 DefaultNla::parse(buf)
-                    .context(format!("Unknown NLA type {}", kind))?,
+                    .context(format!("Unknown NLA type {kind}"))?,
             ),
         })
     }

--- a/src/rtnl/link/nlas/af_spec_inet.rs
+++ b/src/rtnl/link/nlas/af_spec_inet.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 
 #[derive(Clone, Eq, PartialEq, Debug)]
+#[non_exhaustive]
 pub enum AfSpecInet {
     Unspec(Vec<u8>),
     Unix(Vec<u8>),

--- a/src/rtnl/link/nlas/bond.rs
+++ b/src/rtnl/link/nlas/bond.rs
@@ -16,6 +16,7 @@ use std::{
 };
 
 #[derive(Debug, Clone, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum BondAdInfo {
     Aggregator(u16),
     NumPorts(u16),
@@ -152,6 +153,7 @@ impl Nla for BondIpAddrNla {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum InfoBond {
     Mode(u8),
     ActiveSlave(u32),

--- a/src/rtnl/link/nlas/bridge.rs
+++ b/src/rtnl/link/nlas/bridge.rs
@@ -559,14 +559,12 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                 Ok(v) => {
                     return Err(DecodeError::from(format!(
                         "Invalid BRIDGE_QUERIER_IP_ADDRESS, \
-                        expecting IPv4 address, but got {}",
-                        v
+                        expecting IPv4 address, but got {v}"
                     )))
                 }
                 Err(e) => {
                     return Err(DecodeError::from(format!(
-                        "Invalid BRIDGE_QUERIER_IP_ADDRESS {}",
-                        e
+                        "Invalid BRIDGE_QUERIER_IP_ADDRESS {e}"
                     )))
                 }
             },
@@ -575,14 +573,12 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                 Ok(v) => {
                     return Err(DecodeError::from(format!(
                         "Invalid BRIDGE_QUERIER_IPV6_ADDRESS, \
-                        expecting IPv6 address, but got {}",
-                        v
+                        expecting IPv6 address, but got {v}"
                     )));
                 }
                 Err(e) => {
                     return Err(DecodeError::from(format!(
-                        "Invalid BRIDGE_QUERIER_IPV6_ADDRESS {}",
-                        e
+                        "Invalid BRIDGE_QUERIER_IPV6_ADDRESS {e}"
                     )));
                 }
             },
@@ -605,7 +601,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
 
             kind => Other(
                 DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {}", kind))?,
+                    .context(format!("unknown NLA type {kind}"))?,
             ),
         })
     }

--- a/src/rtnl/link/nlas/bridge.rs
+++ b/src/rtnl/link/nlas/bridge.rs
@@ -24,6 +24,7 @@ const BRIDGE_QUERIER_IPV6_PORT: u16 = 6;
 const BRIDGE_QUERIER_IPV6_OTHER_TIMER: u16 = 7;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum InfoBridge {
     Unspec(Vec<u8>),
     GroupAddr([u8; 6]),
@@ -498,6 +499,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoBridge {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum BridgeQuerierState {
     Ipv4Address(Ipv4Addr),
     Ipv4Port(u32),

--- a/src/rtnl/link/nlas/inet/dev_conf.rs
+++ b/src/rtnl/link/nlas/inet/dev_conf.rs
@@ -42,6 +42,7 @@ buffer!(InetDevConfBuffer(DEV_CONF_LEN) {
 });
 
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]
+#[non_exhaustive]
 pub struct InetDevConf {
     pub forwarding: i32,
     pub mc_forwarding: i32,

--- a/src/rtnl/link/nlas/inet/mod.rs
+++ b/src/rtnl/link/nlas/inet/mod.rs
@@ -62,7 +62,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Inet {
             IFLA_INET_CONF => DevConf(payload.to_vec()),
             kind => Other(
                 DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {}", kind))?,
+                    .context(format!("unknown NLA type {kind}"))?,
             ),
         })
     }

--- a/src/rtnl/link/nlas/inet/mod.rs
+++ b/src/rtnl/link/nlas/inet/mod.rs
@@ -13,6 +13,7 @@ mod dev_conf;
 pub use self::dev_conf::*;
 
 #[derive(Clone, Eq, PartialEq, Debug)]
+#[non_exhaustive]
 pub enum Inet {
     DevConf(Vec<u8>),
     Unspec(Vec<u8>),

--- a/src/rtnl/link/nlas/inet6/cache.rs
+++ b/src/rtnl/link/nlas/inet6/cache.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]
+#[non_exhaustive]
 pub struct Inet6CacheInfo {
     pub max_reasm_len: i32,
     pub tstamp: i32,

--- a/src/rtnl/link/nlas/inet6/dev_conf.rs
+++ b/src/rtnl/link/nlas/inet6/dev_conf.rs
@@ -189,6 +189,7 @@ impl Emitable for Inet6DevConf {
 }
 
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]
+#[non_exhaustive]
 pub struct Inet6DevConf {
     pub forwarding: i32,
     pub hoplimit: i32,

--- a/src/rtnl/link/nlas/inet6/icmp6_stats.rs
+++ b/src/rtnl/link/nlas/inet6/icmp6_stats.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]
+#[non_exhaustive]
 pub struct Icmp6Stats {
     pub num: i64,
     pub in_msgs: i64,

--- a/src/rtnl/link/nlas/inet6/mod.rs
+++ b/src/rtnl/link/nlas/inet6/mod.rs
@@ -21,6 +21,7 @@ mod stats;
 pub use self::stats::*;
 
 #[derive(Clone, Eq, PartialEq, Debug)]
+#[non_exhaustive]
 pub enum Inet6 {
     Flags(u32),
     CacheInfo(Vec<u8>),

--- a/src/rtnl/link/nlas/inet6/mod.rs
+++ b/src/rtnl/link/nlas/inet6/mod.rs
@@ -109,7 +109,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Inet6 {
             ),
             kind => Other(
                 DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {}", kind))?,
+                    .context(format!("unknown NLA type {kind}"))?,
             ),
         })
     }

--- a/src/rtnl/link/nlas/inet6/stats.rs
+++ b/src/rtnl/link/nlas/inet6/stats.rs
@@ -46,6 +46,7 @@ buffer!(Inet6StatsBuffer(INET6_STATS_LEN) {
 });
 
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]
+#[non_exhaustive]
 pub struct Inet6Stats {
     pub num: i64,
     pub in_pkts: i64,

--- a/src/rtnl/link/nlas/link_infos.rs
+++ b/src/rtnl/link/nlas/link_infos.rs
@@ -40,6 +40,7 @@ const WIREGUARD: &str = "wireguard";
 const XFRM: &str = "xfrm";
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum Info {
     Unspec(Vec<u8>),
     Xstats(Vec<u8>),
@@ -314,6 +315,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for VecInfo {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum InfoData {
     Bridge(Vec<InfoBridge>),
     Tun(Vec<u8>),
@@ -415,6 +417,7 @@ impl Nla for InfoData {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum InfoKind {
     Dummy,
     Ifb,
@@ -557,6 +560,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoKind {
 
 // https://elixir.bootlin.com/linux/v5.9.8/source/drivers/net/vxlan.c#L3332
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum InfoVxlan {
     Unspec(Vec<u8>),
     Id(u32),
@@ -827,6 +831,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoVxlan {
 
 // https://elixir.bootlin.com/linux/latest/source/net/8021q/vlan_netlink.c#L21
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum InfoVlan {
     Unspec(Vec<u8>),
     Id(u16),
@@ -913,6 +918,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoVlan {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum InfoIpoib {
     Unspec(Vec<u8>),
     Pkey(u16),
@@ -979,6 +985,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoIpoib {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum VethInfo {
     Unspec(Vec<u8>),
     Peer(LinkMessage),
@@ -1035,6 +1042,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for VethInfo {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum InfoIpVlan {
     Unspec(Vec<u8>),
     Mode(u16),
@@ -1095,6 +1103,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoIpVlan {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum InfoXfrmTun {
     Unspec(Vec<u8>),
     Link(u32),
@@ -1155,6 +1164,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoXfrmTun {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum InfoVrf {
     TableId(u32),
     Other(DefaultNla),
@@ -1203,6 +1213,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoVrf {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum InfoMacVlan {
     Unspec(Vec<u8>),
     Mode(u32),
@@ -1303,6 +1314,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoMacVlan {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum InfoMacVtap {
     Unspec(Vec<u8>),
     Mode(u32),

--- a/src/rtnl/link/nlas/link_infos.rs
+++ b/src/rtnl/link/nlas/link_infos.rs
@@ -972,7 +972,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoIpoib {
             ),
             kind => Other(
                 DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {}", kind))?,
+                    .context(format!("unknown NLA type {kind}"))?,
             ),
         })
     }
@@ -1028,7 +1028,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for VethInfo {
             }
             kind => Other(
                 DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {}", kind))?,
+                    .context(format!("unknown NLA type {kind}"))?,
             ),
         })
     }
@@ -1088,7 +1088,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoIpVlan {
             ),
             kind => Other(
                 DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {}", kind))?,
+                    .context(format!("unknown NLA type {kind}"))?,
             ),
         })
     }
@@ -1148,7 +1148,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoXfrmTun {
             ),
             kind => Other(
                 DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {}", kind))?,
+                    .context(format!("unknown NLA type {kind}"))?,
             ),
         })
     }
@@ -1196,7 +1196,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoVrf {
             ),
             kind => Other(
                 DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {}", kind))?,
+                    .context(format!("unknown NLA type {kind}"))?,
             ),
         })
     }
@@ -1296,7 +1296,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoMacVlan {
             ),
             kind => Other(
                 DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {}", kind))?,
+                    .context(format!("unknown NLA type {kind}"))?,
             ),
         })
     }
@@ -1396,7 +1396,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoMacVtap {
             ),
             kind => Other(
                 DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {}", kind))?,
+                    .context(format!("unknown NLA type {kind}"))?,
             ),
         })
     }

--- a/src/rtnl/link/nlas/link_state.rs
+++ b/src/rtnl/link/nlas/link_state.rs
@@ -3,6 +3,7 @@
 use crate::constants::*;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum State {
     /// Status can't be determined
     Unknown,

--- a/src/rtnl/link/nlas/map.rs
+++ b/src/rtnl/link/nlas/map.rs
@@ -16,6 +16,7 @@ buffer!(MapBuffer(LINK_MAP_LEN) {
 });
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[non_exhaustive]
 pub struct Map {
     pub memory_start: u64,
     pub memory_end: u64,

--- a/src/rtnl/link/nlas/mod.rs
+++ b/src/rtnl/link/nlas/mod.rs
@@ -53,6 +53,7 @@ use crate::{
 };
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum Nla {
     // Vec<u8>
     Unspec(Vec<u8>),

--- a/src/rtnl/link/nlas/mod.rs
+++ b/src/rtnl/link/nlas/mod.rs
@@ -577,7 +577,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> ParseableParametrized<NlaBuffer<&'a T>, u16>
 
             kind => Other(
                 DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {}", kind))?,
+                    .context(format!("unknown NLA type {kind}"))?,
             ),
         })
     }

--- a/src/rtnl/link/nlas/prop_list.rs
+++ b/src/rtnl/link/nlas/prop_list.rs
@@ -57,7 +57,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Prop {
             ),
             kind => Prop::Other(
                 DefaultNla::parse(buf)
-                    .context(format!("Unknown NLA type {}", kind))?,
+                    .context(format!("Unknown NLA type {kind}"))?,
             ),
         })
     }

--- a/src/rtnl/link/nlas/prop_list.rs
+++ b/src/rtnl/link/nlas/prop_list.rs
@@ -11,6 +11,7 @@ use crate::{
 use anyhow::Context;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum Prop {
     AltIfName(String),
     Other(DefaultNla),

--- a/src/rtnl/link/nlas/stats.rs
+++ b/src/rtnl/link/nlas/stats.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[non_exhaustive]
 pub struct Stats {
     /// total packets received
     pub rx_packets: u32,

--- a/src/rtnl/link/nlas/stats64.rs
+++ b/src/rtnl/link/nlas/stats64.rs
@@ -34,6 +34,7 @@ buffer!(Stats64Buffer(LINK_STATS64_LEN) {
 });
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[non_exhaustive]
 pub struct Stats64 {
     /// total packets received
     pub rx_packets: u64,

--- a/src/rtnl/message.rs
+++ b/src/rtnl/message.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum RtnlMessage {
     NewLink(LinkMessage),
     DelLink(LinkMessage),

--- a/src/rtnl/neighbour/header.rs
+++ b/src/rtnl/neighbour/header.rs
@@ -20,6 +20,7 @@ use crate::{
 ///
 /// `NeighbourHeader` exposes all these fields.
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[non_exhaustive]
 pub struct NeighbourHeader {
     pub family: u8,
     pub ifindex: u32,

--- a/src/rtnl/neighbour/message.rs
+++ b/src/rtnl/neighbour/message.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[non_exhaustive]
 pub struct NeighbourMessage {
     pub header: NeighbourHeader,
     pub nlas: Vec<Nla>,

--- a/src/rtnl/neighbour/nlas/cache_info.rs
+++ b/src/rtnl/neighbour/nlas/cache_info.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[non_exhaustive]
 pub struct CacheInfo {
     pub confirmed: u32,
     pub used: u32,

--- a/src/rtnl/neighbour/nlas/mod.rs
+++ b/src/rtnl/neighbour/nlas/mod.rs
@@ -15,6 +15,7 @@ use crate::{
 };
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum Nla {
     Unspec(Vec<u8>),
     Destination(Vec<u8>),

--- a/src/rtnl/neighbour_table/header.rs
+++ b/src/rtnl/neighbour_table/header.rs
@@ -8,6 +8,7 @@ use crate::{
 use super::buffer::{NeighbourTableMessageBuffer, NEIGHBOUR_TABLE_HEADER_LEN};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub struct NeighbourTableHeader {
     pub family: u8,
 }

--- a/src/rtnl/neighbour_table/message.rs
+++ b/src/rtnl/neighbour_table/message.rs
@@ -8,6 +8,7 @@ use crate::{
 use anyhow::Context;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub struct NeighbourTableMessage {
     pub header: NeighbourTableHeader,
     pub nlas: Vec<Nla>,

--- a/src/rtnl/neighbour_table/nlas/config.rs
+++ b/src/rtnl/neighbour_table/nlas/config.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[non_exhaustive]
 pub struct Config {
     pub key_len: u16,
     pub entry_size: u16,

--- a/src/rtnl/neighbour_table/nlas/mod.rs
+++ b/src/rtnl/neighbour_table/nlas/mod.rs
@@ -18,6 +18,7 @@ use crate::{
 };
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum Nla {
     Unspec(Vec<u8>),
     // FIXME: parse this nla

--- a/src/rtnl/neighbour_table/nlas/mod.rs
+++ b/src/rtnl/neighbour_table/nlas/mod.rs
@@ -107,7 +107,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nla {
             ),
             kind => Other(
                 DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {}", kind))?,
+                    .context(format!("unknown NLA type {kind}"))?,
             ),
         })
     }

--- a/src/rtnl/neighbour_table/nlas/stats.rs
+++ b/src/rtnl/neighbour_table/nlas/stats.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[non_exhaustive]
 pub struct Stats {
     pub allocs: u64,
     pub destroys: u64,

--- a/src/rtnl/nsid/header.rs
+++ b/src/rtnl/nsid/header.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[non_exhaustive]
 pub struct NsidHeader {
     pub rtgen_family: u8,
 }

--- a/src/rtnl/nsid/message.rs
+++ b/src/rtnl/nsid/message.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[non_exhaustive]
 pub struct NsidMessage {
     pub header: NsidHeader,
     pub nlas: Vec<Nla>,

--- a/src/rtnl/nsid/nlas.rs
+++ b/src/rtnl/nsid/nlas.rs
@@ -69,7 +69,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nla {
             NETNSA_FD => Fd(parse_u32(payload).context("invalid NETNSA_FD")?),
             kind => Other(
                 DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {}", kind))?,
+                    .context(format!("unknown NLA type {kind}"))?,
             ),
         })
     }

--- a/src/rtnl/nsid/nlas.rs
+++ b/src/rtnl/nsid/nlas.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum Nla {
     Unspec(Vec<u8>),
     Id(i32),

--- a/src/rtnl/route/header.rs
+++ b/src/rtnl/route/header.rs
@@ -8,7 +8,8 @@ use crate::{
 
 bitflags! {
     /// Flags that can be set in a `RTM_GETROUTE` ([`RtnlMessage::GetRoute`]) message.
-    pub struct RouteFlags: u32 {
+    #[non_exhaustive]
+pub struct RouteFlags: u32 {
         /// If the route changes, notify the user via rtnetlink
         const RTM_F_NOTIFY = RTM_F_NOTIFY;
         /// This route is cloned. Cloned routes are routes coming from the cache instead of the
@@ -82,6 +83,7 @@ impl Default for RouteFlags {
 /// }
 /// ```
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Default)]
+#[non_exhaustive]
 pub struct RouteHeader {
     /// Address family of the route: either [`AF_INET`] for IPv4 prefixes, or
     /// [`AF_INET6`] for IPv6 prefixes.

--- a/src/rtnl/route/message.rs
+++ b/src/rtnl/route/message.rs
@@ -9,6 +9,7 @@ use anyhow::Context;
 use std::net::IpAddr;
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[non_exhaustive]
 pub struct RouteMessage {
     pub header: RouteHeader,
     pub nlas: Vec<Nla>,

--- a/src/rtnl/route/nlas/cache_info.rs
+++ b/src/rtnl/route/nlas/cache_info.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[non_exhaustive]
 pub struct CacheInfo {
     pub clntref: u32,
     pub last_use: u32,

--- a/src/rtnl/route/nlas/metrics.rs
+++ b/src/rtnl/route/nlas/metrics.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum Metrics {
     Unspec(Vec<u8>),
     Lock(u32),

--- a/src/rtnl/route/nlas/mfc_stats.rs
+++ b/src/rtnl/route/nlas/mfc_stats.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[non_exhaustive]
 pub struct MfcStats {
     pub packets: u64,
     pub bytes: u64,

--- a/src/rtnl/route/nlas/mod.rs
+++ b/src/rtnl/route/nlas/mod.rs
@@ -32,6 +32,7 @@ use crate::traits::Emitable;
 /// Netlink attributes for `RTM_NEWROUTE`, `RTM_DELROUTE`,
 /// `RTM_GETROUTE` messages.
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum Nla {
     #[cfg(not(feature = "rich_nlas"))]
     Metrics(Vec<u8>),

--- a/src/rtnl/route/nlas/mpls_ip_tunnel.rs
+++ b/src/rtnl/route/nlas/mpls_ip_tunnel.rs
@@ -12,6 +12,7 @@ use crate::{
 
 /// Netlink attributes for `RTA_ENCAP` with `RTA_ENCAP_TYPE` set to
 /// `LWTUNNEL_ENCAP_MPLS`.
+#[non_exhaustive]
 pub enum MplsIpTunnel {
     Destination(Vec<u8>),
     Ttl(u8),

--- a/src/rtnl/route/nlas/next_hops.rs
+++ b/src/rtnl/route/nlas/next_hops.rs
@@ -45,8 +45,7 @@ impl<T: AsRef<[u8]>> NextHopBuffer<T> {
         let len = self.buffer.as_ref().len();
         if len < PAYLOAD_OFFSET {
             return Err(format!(
-                "invalid NextHopBuffer: length {} < {}",
-                len, PAYLOAD_OFFSET
+                "invalid NextHopBuffer: length {len} < {PAYLOAD_OFFSET}"
             )
             .into());
         }

--- a/src/rtnl/route/nlas/next_hops.rs
+++ b/src/rtnl/route/nlas/next_hops.rs
@@ -13,7 +13,8 @@ use crate::{
 };
 
 bitflags! {
-    pub struct NextHopFlags: u8 {
+    #[non_exhaustive]
+pub struct NextHopFlags: u8 {
         const RTNH_F_EMPTY = 0;
         const RTNH_F_DEAD = constants::RTNH_F_DEAD;
         const RTNH_F_PERVASIVE = constants::RTNH_F_PERVASIVE;
@@ -72,6 +73,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> NextHopBuffer<&'a T> {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
+#[non_exhaustive]
 pub struct NextHop {
     /// Next-hop flags (see [`NextHopFlags`])
     pub flags: NextHopFlags,

--- a/src/rtnl/rule/header.rs
+++ b/src/rtnl/rule/header.rs
@@ -8,7 +8,8 @@ use crate::{
 };
 
 bitflags! {
-    pub struct RuleFlags: u32 {
+    #[non_exhaustive]
+pub struct RuleFlags: u32 {
         const FIB_RULE_PERMANENT = FIB_RULE_PERMANENT;
         const FIB_RULE_INVERT = FIB_RULE_INVERT;
         const FIB_RULE_UNRESOLVED = FIB_RULE_UNRESOLVED;
@@ -28,6 +29,7 @@ impl Default for RuleFlags {
 // see https://github.com/torvalds/linux/blob/master/include/uapi/linux/fib_rules.h
 // see https://github.com/torvalds/linux/blob/master/include/net/fib_rules.h
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[non_exhaustive]
 pub struct RuleHeader {
     /// Address family: one of the `AF_*` constants.
     pub family: u8,

--- a/src/rtnl/rule/message.rs
+++ b/src/rtnl/rule/message.rs
@@ -8,6 +8,7 @@ use crate::{
 use anyhow::Context;
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[non_exhaustive]
 pub struct RuleMessage {
     pub header: RuleHeader,
     pub nlas: Vec<Nla>,

--- a/src/rtnl/rule/nlas/mod.rs
+++ b/src/rtnl/rule/nlas/mod.rs
@@ -17,6 +17,7 @@ use crate::{
 use anyhow::Context;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum Nla {
     Unspec(Vec<u8>),
     /// destination address

--- a/src/rtnl/tc/message.rs
+++ b/src/rtnl/tc/message.rs
@@ -14,6 +14,7 @@ use crate::{
 };
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[non_exhaustive]
 pub struct TcMessage {
     pub header: TcHeader,
     pub nlas: Vec<Nla>,
@@ -41,6 +42,7 @@ impl TcMessage {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[non_exhaustive]
 pub struct TcHeader {
     pub family: u8,
     // Interface index

--- a/src/rtnl/tc/nlas/action/mirred.rs
+++ b/src/rtnl/tc/nlas/action/mirred.rs
@@ -17,6 +17,7 @@ pub const KIND: &str = "mirred";
 pub const TC_MIRRED_BUF_LEN: usize = TC_GEN_BUF_LEN + 8;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum Nla {
     Unspec(Vec<u8>),
     Tm(Vec<u8>),
@@ -71,6 +72,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nla {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[non_exhaustive]
 pub struct TcMirred {
     pub index: u32,
     pub capab: u32,

--- a/src/rtnl/tc/nlas/action/mod.rs
+++ b/src/rtnl/tc/nlas/action/mod.rs
@@ -16,6 +16,7 @@ use crate::{
 pub const TC_GEN_BUF_LEN: usize = 20;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub struct Action {
     pub tab: u16,
     pub nlas: Vec<ActNla>,
@@ -100,6 +101,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Action {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum ActNla {
     Unspec(Vec<u8>),
     Kind(String),
@@ -154,6 +156,7 @@ impl nlas::Nla for ActNla {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum ActOpt {
     Mirred(mirred::Nla),
     // Other options
@@ -209,6 +212,7 @@ where
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[non_exhaustive]
 pub struct TcGen {
     pub index: u32,
     pub capab: u32,

--- a/src/rtnl/tc/nlas/filter/u32.rs
+++ b/src/rtnl/tc/nlas/filter/u32.rs
@@ -24,6 +24,7 @@ const U32_SEL_BUF_LEN: usize = 16;
 const U32_KEY_BUF_LEN: usize = 16;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum Nla {
     Unspec(Vec<u8>),
     ClassId(u32),
@@ -137,6 +138,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nla {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[non_exhaustive]
 pub struct Sel {
     pub flags: u8,
     pub offshift: u8,
@@ -218,6 +220,7 @@ impl<T: AsRef<[u8]> + ?Sized> Parseable<SelBuffer<&T>> for Sel {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[non_exhaustive]
 pub struct Key {
     pub mask: u32,
     pub val: u32,

--- a/src/rtnl/tc/nlas/mod.rs
+++ b/src/rtnl/tc/nlas/mod.rs
@@ -32,6 +32,7 @@ use crate::{
 };
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum Nla {
     /// Unspecified
     Unspec(Vec<u8>),
@@ -118,6 +119,7 @@ impl nlas::Nla for Nla {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum Stats2 {
     StatsApp(Vec<u8>),
     StatsBasic(Vec<u8>),

--- a/src/rtnl/tc/nlas/options.rs
+++ b/src/rtnl/tc/nlas/options.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum TcOpt {
     // Qdisc specific options
     Ingress,

--- a/src/rtnl/tc/nlas/stats.rs
+++ b/src/rtnl/tc/nlas/stats.rs
@@ -7,6 +7,7 @@ use crate::{
 
 /// Generic queue statistics
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[non_exhaustive]
 pub struct Stats {
     /// Number of enqueued bytes
     pub bytes: u64,

--- a/src/rtnl/tc/nlas/stats_basic.rs
+++ b/src/rtnl/tc/nlas/stats_basic.rs
@@ -7,6 +7,7 @@ use crate::{
 
 /// Byte/Packet throughput statistics
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[non_exhaustive]
 pub struct StatsBasic {
     /// number of seen bytes
     pub bytes: u64,

--- a/src/rtnl/tc/nlas/stats_queue.rs
+++ b/src/rtnl/tc/nlas/stats_queue.rs
@@ -7,6 +7,7 @@ use crate::{
 
 /// Queuing statistics
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[non_exhaustive]
 pub struct StatsQueue {
     /// queue length
     pub qlen: u32,


### PR DESCRIPTION
All the public struct/enum in nmstate might add members/type, hence marking
them as non_exhaustive which will prevent API user from in-compatibility
usage.

This allows us to only preserve API compatibility when adding new member to
struct or enum.

Please refer to
https://doc.rust-lang.org/reference/attributes/type_system.html for more
detail.