### PR TITLE
bridge: Fix constants of bridge VLAN

### DIFF
--- a/src/rtnl/constants.rs
+++ b/src/rtnl/constants.rs
@@ -408,11 +408,13 @@ pub const BRIDGE_FLAGS_MASTER: u16 = 1; /* Bridge command to/from master */
 pub const BRIDGE_FLAGS_SELF: u16 = 2; /* Bridge command to/from lowerdev */
 
 pub const IFLA_BRIDGE_VLAN_INFO: u16 = 2;
-pub const BRIDGE_VLAN_INFO_MASTER: u16 = 1;
-pub const BRIDGE_VLAN_INFO_PVID: u16 = 4;
-pub const BRIDGE_VLAN_INFO_UNTAGGED: u16 = 8;
-pub const BRIDGE_VLAN_INFO_RANGE_BEGIN: u16 = 16;
-pub const BRIDGE_VLAN_INFO_RANGE_END: u16 = 32;
+pub const BRIDGE_VLAN_INFO_MASTER: u16 = 1 << 0;
+pub const BRIDGE_VLAN_INFO_PVID: u16 = 1 << 1;
+pub const BRIDGE_VLAN_INFO_UNTAGGED: u16 = 1 << 2;
+pub const BRIDGE_VLAN_INFO_RANGE_BEGIN: u16 = 1 << 3;
+pub const BRIDGE_VLAN_INFO_RANGE_END: u16 = 1 << 4;
+pub const BRIDGE_VLAN_INFO_BRENTRY: u16 = 1 << 5;
+pub const BRIDGE_VLAN_INFO_ONLY_OPTS: u16 = 1 << 6;
 
 pub const IFLA_BR_UNSPEC: u16 = 0;
 pub const IFLA_BR_FORWARD_DELAY: u16 = 1;


### PR DESCRIPTION
Fixed these constants:
 * `BRIDGE_VLAN_INFO_PVID`
 * `BRIDGE_VLAN_INFO_UNTAGGED`
 * `BRIDGE_VLAN_INFO_RANGE_BEGIN`
 * `BRIDGE_VLAN_INFO_RANGE_END`

Added these constants:
 * `BRIDGE_VLAN_INFO_BRENTRY`
 * `BRIDGE_VLAN_INFO_ONLY_OPTS`

Changed to align with expression ` 1 << n` instead of human calculated
value.