### PR TITLE
New release 0.15.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,22 @@
 # Changelog
+## [0.15.0] - 2023-01-28
+### Breaking changes
+ - Removed these reexports. (8784586)
+    * `netlink_packet_route::ErrorMessage`
+    * `netlink_packet_route::NetlinkBuffer`
+    * `netlink_packet_route::NetlinkHeader`
+    * `netlink_packet_route::NetlinkMessage`
+    * `netlink_packet_route::NetlinkPayload`
+    * `netlink_packet_route::traits`
+    * `netlink_packet_route::DecodeError`
+ - Remove internal fuzz sub-crate. (f2ffa9d)
+
+### New features
+ - N/A
+
+### Bug fixes
+ - N/A
+
 ## [0.14.1] - 2023-01-28
 ### Breaking changes
  - N/A

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-packet-route"
-version = "0.14.1"
+version = "0.15.0"
 edition = "2018"
 
 homepage = "https://github.com/rust-netlink/netlink-packet-route"


### PR DESCRIPTION
=== Breaking changes
 - Removed these reexports. (8784586)
    * `netlink_packet_route::ErrorMessage`
    * `netlink_packet_route::NetlinkBuffer`
    * `netlink_packet_route::NetlinkHeader`
    * `netlink_packet_route::NetlinkMessage`
    * `netlink_packet_route::NetlinkPayload`
    * `netlink_packet_route::traits`
    * `netlink_packet_route::DecodeError`
 - Remove internal fuzz sub-crate. (f2ffa9d)

=== New features
 - N/A

=== Bug fixes
 - N/A