### PR TITLE
Re #23 - The TCA_ACT_OPTIONS type should also indicate NLM_F_NESTED

### DIFF
--- a/src/rtnl/tc/nlas/action/mod.rs
+++ b/src/rtnl/tc/nlas/action/mod.rs
@@ -7,7 +7,7 @@ use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
 
 use netlink_packet_utils::{
-    nla::{self, DefaultNla, NlaBuffer, NlasIterator},
+    nla::{self, DefaultNla, NlaBuffer, NlasIterator, NLA_F_NESTED},
     parsers::{parse_string, parse_u32},
     traits::{Emitable, Parseable, ParseableParametrized},
     DecodeError,
@@ -148,7 +148,7 @@ impl nla::Nla for ActNla {
         match self {
             Unspec(_) => TCA_ACT_UNSPEC,
             Kind(_) => TCA_ACT_KIND,
-            Options(_) => TCA_ACT_OPTIONS,
+            Options(_) => TCA_ACT_OPTIONS | NLA_F_NESTED,
             Index(_) => TCA_ACT_INDEX,
             Stats(_) => TCA_ACT_STATS,
             Cookie(_) => TCA_ACT_COOKIE,

--- a/src/rtnl/tc/nlas/test.rs
+++ b/src/rtnl/tc/nlas/test.rs
@@ -69,7 +69,7 @@ use netlink_packet_utils::{
                         3, 0, // TCA_STATS_QUEUE
                             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                     72, 0,
-                    2, 0, // TCA_ACT_OPTIONS
+                    2, 128, // TCA_ACT_OPTIONS, NLM_F_NESTED
                         32, 0,
                         2, 0, // TCA_MIRRED_PARMS
                             1, 0, 0, 0,


### PR DESCRIPTION
The only place it's used in iproute2 is when setting Parm for an action, and in that spot it is always marked as nested.