### PR TITLE
Remove non_exhaustive annotation from structs (fixes #25)

### DIFF
--- a/src/rtnl/address/message.rs
+++ b/src/rtnl/address/message.rs
@@ -16,7 +16,6 @@ pub struct AddressMessage {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
-#[non_exhaustive]
 pub struct AddressHeader {
     pub family: u8,
     pub prefix_len: u8,

--- a/src/rtnl/link/header.rs
+++ b/src/rtnl/link/header.rs
@@ -27,7 +27,6 @@ use crate::{LinkMessageBuffer, LINK_HEADER_LEN};
 ///
 /// `LinkHeader` exposes all these fields except for the "reserved" one.
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
-#[non_exhaustive]
 pub struct LinkHeader {
     /// Address family: one of the `AF_*` constants.
     pub interface_family: u8,

--- a/src/rtnl/neighbour/header.rs
+++ b/src/rtnl/neighbour/header.rs
@@ -22,7 +22,6 @@ use crate::{NeighbourMessageBuffer, NEIGHBOUR_HEADER_LEN};
 ///
 /// `NeighbourHeader` exposes all these fields.
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
-#[non_exhaustive]
 pub struct NeighbourHeader {
     pub family: u8,
     pub ifindex: u32,

--- a/src/rtnl/neighbour_table/header.rs
+++ b/src/rtnl/neighbour_table/header.rs
@@ -8,7 +8,6 @@ use netlink_packet_utils::{
 use super::buffer::{NeighbourTableMessageBuffer, NEIGHBOUR_TABLE_HEADER_LEN};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-#[non_exhaustive]
 pub struct NeighbourTableHeader {
     pub family: u8,
 }

--- a/src/rtnl/nsid/header.rs
+++ b/src/rtnl/nsid/header.rs
@@ -8,7 +8,6 @@ use netlink_packet_utils::{
 use super::{NsidMessageBuffer, NSID_HEADER_LEN};
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
-#[non_exhaustive]
 pub struct NsidHeader {
     pub rtgen_family: u8,
 }

--- a/src/rtnl/route/header.rs
+++ b/src/rtnl/route/header.rs
@@ -84,7 +84,6 @@ impl Default for RouteFlags {
 /// }
 /// ```
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Default)]
-#[non_exhaustive]
 pub struct RouteHeader {
     /// Address family of the route: either [`AF_INET`] for IPv4 prefixes, or
     /// [`AF_INET6`] for IPv6 prefixes.

--- a/src/rtnl/rule/header.rs
+++ b/src/rtnl/rule/header.rs
@@ -30,7 +30,6 @@ impl Default for RuleFlags {
 // see https://github.com/torvalds/linux/blob/master/include/uapi/linux/fib_rules.h
 // see https://github.com/torvalds/linux/blob/master/include/net/fib_rules.h
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
-#[non_exhaustive]
 pub struct RuleHeader {
     /// Address family: one of the `AF_*` constants.
     pub family: u8,

--- a/src/rtnl/tc/message.rs
+++ b/src/rtnl/tc/message.rs
@@ -43,7 +43,6 @@ impl TcMessage {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
-#[non_exhaustive]
 pub struct TcHeader {
     pub family: u8,
     // Interface index


### PR DESCRIPTION
Partially reverts #11 

It's fine to have this on enums for safety, but the annotation doesn't make sense on transparent pub structs like these. The structs provided here are mirrors of `repr(C)` ABI structs which are not going to trivially change upstream. These are critical for using the library, and marking them `non_exhaustive` makes it impossible for crate users to create these structs immutably.