### PR TITLE
[API break] Change slave to port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 Cargo.lock
 target
 vendor/
+tags
 
 *.swp

--- a/src/rtnl/constants.rs
+++ b/src/rtnl/constants.rs
@@ -398,8 +398,8 @@ pub const IFLA_INFO_UNSPEC: u16 = 0;
 pub const IFLA_INFO_KIND: u16 = 1;
 pub const IFLA_INFO_DATA: u16 = 2;
 pub const IFLA_INFO_XSTATS: u16 = 3;
-pub const IFLA_INFO_SLAVE_KIND: u16 = 4;
-pub const IFLA_INFO_SLAVE_DATA: u16 = 5;
+pub const IFLA_INFO_PORT_KIND: u16 = 4;
+pub const IFLA_INFO_PORT_DATA: u16 = 5;
 // Bridge flags
 pub const IFLA_BRIDGE_FLAGS: u16 = 0;
 pub const BRIDGE_FLAGS_MASTER: u16 = 1; /* Bridge command to/from master */
@@ -663,8 +663,6 @@ pub const IFF_NOARP: u32 = libc::IFF_NOARP as u32;
 pub const IFF_PROMISC: u32 = libc::IFF_PROMISC as u32;
 /// Master of a load balancer (bonding)
 pub const IFF_MASTER: u32 = libc::IFF_MASTER as u32;
-/// Slave of a load balancer
-pub const IFF_SLAVE: u32 = libc::IFF_SLAVE as u32;
 /// Link selects port automatically (only used by ARM ethernet)
 pub const IFF_PORTSEL: u32 = libc::IFF_PORTSEL as u32;
 /// Driver supports setting media type (only used by ARM ethernet)
@@ -994,7 +992,7 @@ pub const __IFLA_VXLAN_MAX: u16 = 30;
 
 pub const IFLA_BOND_UNSPEC: u16 = 0;
 pub const IFLA_BOND_MODE: u16 = 1;
-pub const IFLA_BOND_ACTIVE_SLAVE: u16 = 2;
+pub const IFLA_BOND_ACTIVE_PORT: u16 = 2;
 pub const IFLA_BOND_MIIMON: u16 = 3;
 pub const IFLA_BOND_UPDELAY: u16 = 4;
 pub const IFLA_BOND_DOWNDELAY: u16 = 5;
@@ -1009,10 +1007,10 @@ pub const IFLA_BOND_FAIL_OVER_MAC: u16 = 13;
 pub const IFLA_BOND_XMIT_HASH_POLICY: u16 = 14;
 pub const IFLA_BOND_RESEND_IGMP: u16 = 15;
 pub const IFLA_BOND_NUM_PEER_NOTIF: u16 = 16;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: u16 = 17;
+pub const IFLA_BOND_ALL_PORTS_ACTIVE: u16 = 17;
 pub const IFLA_BOND_MIN_LINKS: u16 = 18;
 pub const IFLA_BOND_LP_INTERVAL: u16 = 19;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: u16 = 20;
+pub const IFLA_BOND_PACKETS_PER_PORT: u16 = 20;
 pub const IFLA_BOND_AD_LACP_RATE: u16 = 21;
 pub const IFLA_BOND_AD_SELECT: u16 = 22;
 pub const IFLA_BOND_AD_INFO: u16 = 23;
@@ -1032,24 +1030,24 @@ pub const IFLA_BOND_AD_INFO_ACTOR_KEY: u16 = 3;
 pub const IFLA_BOND_AD_INFO_PARTNER_KEY: u16 = 4;
 pub const IFLA_BOND_AD_INFO_PARTNER_MAC: u16 = 5;
 
-pub const IFLA_BOND_SLAVE_UNSPEC: u16 = 0;
-pub const IFLA_BOND_SLAVE_STATE: u16 = 1;
-pub const IFLA_BOND_SLAVE_MII_STATUS: u16 = 2;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: u16 = 3;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: u16 = 4;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: u16 = 5;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: u16 = 6;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: u16 = 7;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: u16 = 8;
-pub const IFLA_BOND_SLAVE_PRIO: u16 = 9;
+pub const IFLA_BOND_PORT_UNSPEC: u16 = 0;
+pub const IFLA_BOND_PORT_STATE: u16 = 1;
+pub const IFLA_BOND_PORT_MII_STATUS: u16 = 2;
+pub const IFLA_BOND_PORT_LINK_FAILURE_COUNT: u16 = 3;
+pub const IFLA_BOND_PORT_PERM_HWADDR: u16 = 4;
+pub const IFLA_BOND_PORT_QUEUE_ID: u16 = 5;
+pub const IFLA_BOND_PORT_AD_AGGREGATOR_ID: u16 = 6;
+pub const IFLA_BOND_PORT_AD_ACTOR_OPER_PORT_STATE: u16 = 7;
+pub const IFLA_BOND_PORT_AD_PARTNER_OPER_PORT_STATE: u16 = 8;
+pub const IFLA_BOND_PORT_PRIO: u16 = 9;
 
-pub const IFLA_BOND_SLAVE_STATE_ACTIVE: u8 = 0;
-pub const IFLA_BOND_SLAVE_STATE_BACKUP: u8 = 1;
+pub const IFLA_BOND_PORT_STATE_ACTIVE: u8 = 0;
+pub const IFLA_BOND_PORT_STATE_BACKUP: u8 = 1;
 
-pub const IFLA_BOND_SLAVE_MII_STATUS_UP: u8 = 0;
-pub const IFLA_BOND_SLAVE_MII_STATUS_GOING_DOWN: u8 = 1;
-pub const IFLA_BOND_SLAVE_MII_STATUS_DOWN: u8 = 2;
-pub const IFLA_BOND_SLAVE_MII_STATUS_GOING_BACK: u8 = 3;
+pub const IFLA_BOND_PORT_MII_STATUS_UP: u8 = 0;
+pub const IFLA_BOND_PORT_MII_STATUS_GOING_DOWN: u8 = 1;
+pub const IFLA_BOND_PORT_MII_STATUS_DOWN: u8 = 2;
+pub const IFLA_BOND_PORT_MII_STATUS_GOING_BACK: u8 = 3;
 
 // pub const IFLA_VF_INFO_UNSPEC: int = 0;
 // pub const IFLA_VF_INFO: int = 1;
@@ -1161,8 +1159,8 @@ pub const RTNLGRP_IPV6_MROUTE_R: u32 = 31;
 // pub const IPOIB_MODE_CONNECTED: int = 1;
 //
 // pub const IFLA_HSR_UNSPEC: int = 0;
-// pub const IFLA_HSR_SLAVE1: int = 1;
-// pub const IFLA_HSR_SLAVE2: int = 2;
+// pub const IFLA_HSR_PORT1: int = 1;
+// pub const IFLA_HSR_PORT2: int = 2;
 // pub const IFLA_HSR_MULTICAST_SPEC: int = 3;
 // pub const IFLA_HSR_SUPERVISION_ADDR: int = 4;
 // pub const IFLA_HSR_SEQ_NR: int = 5;
@@ -1171,7 +1169,7 @@ pub const RTNLGRP_IPV6_MROUTE_R: u32 = 31;
 // pub const IFLA_STATS_UNSPEC: int = 0;
 // pub const IFLA_STATS_LINK_64: int = 1;
 // pub const IFLA_STATS_LINK_XSTATS: int = 2;
-// pub const IFLA_STATS_LINK_XSTATS_SLAVE: int = 3;
+// pub const IFLA_STATS_LINK_XSTATS_PORT: int = 3;
 // pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: int = 4;
 // pub const IFLA_STATS_AF_SPEC: int = 5;
 //

--- a/src/rtnl/link/nlas/bond.rs
+++ b/src/rtnl/link/nlas/bond.rs
@@ -157,7 +157,7 @@ impl Nla for BondIpAddrNla {
 #[non_exhaustive]
 pub enum InfoBond {
     Mode(u8),
-    ActiveSlave(u32),
+    ActivePort(u32),
     MiiMon(u32),
     UpDelay(u32),
     DownDelay(u32),
@@ -172,10 +172,10 @@ pub enum InfoBond {
     XmitHashPolicy(u8),
     ResendIgmp(u32),
     NumPeerNotif(u8),
-    AllSlavesActive(u8),
+    AllPortsActive(u8),
     MinLinks(u32),
     LpInterval(u32),
-    PacketsPerSlave(u32),
+    PacketsPerPort(u32),
     AdLacpRate(u8),
     AdSelect(u8),
     AdInfo(Vec<BondAdInfo>),
@@ -200,7 +200,7 @@ impl Nla for InfoBond {
                 | FailOverMac(_)
                 | XmitHashPolicy(_)
                 | NumPeerNotif(_)
-                | AllSlavesActive(_)
+                | AllPortsActive(_)
                 | AdLacpActive(_)
                 | AdLacpRate(_)
                 | AdSelect(_)
@@ -210,7 +210,7 @@ impl Nla for InfoBond {
             AdActorSysPrio(_)
                 | AdUserPortKey(_)
             => 2,
-            ActiveSlave(_)
+            ActivePort(_)
                 | MiiMon(_)
                 | UpDelay(_)
                 | DownDelay(_)
@@ -221,7 +221,7 @@ impl Nla for InfoBond {
                 | ResendIgmp(_)
                 | MinLinks(_)
                 | LpInterval(_)
-                | PacketsPerSlave(_)
+                | PacketsPerPort(_)
                 | PeerNotifDelay(_)
                 => 4,
             ArpIpTarget(ref addrs)
@@ -248,7 +248,7 @@ impl Nla for InfoBond {
                 | FailOverMac(value)
                 | XmitHashPolicy(value)
                 | NumPeerNotif(value)
-                | AllSlavesActive(value)
+                | AllPortsActive(value)
                 | AdLacpActive(value)
                 | AdLacpRate(value)
                 | AdSelect(value)
@@ -258,7 +258,7 @@ impl Nla for InfoBond {
             AdActorSysPrio(value)
                 | AdUserPortKey(value)
             => NativeEndian::write_u16(buffer, *value),
-            ActiveSlave(value)
+            ActivePort(value)
                 | MiiMon(value)
                 | UpDelay(value)
                 | DownDelay(value)
@@ -269,7 +269,7 @@ impl Nla for InfoBond {
                 | ResendIgmp(value)
                 | MinLinks(value)
                 | LpInterval(value)
-                | PacketsPerSlave(value)
+                | PacketsPerPort(value)
                 | PeerNotifDelay(value)
              => NativeEndian::write_u32(buffer, *value),
             AdActorSystem(bytes) => buffer.copy_from_slice(bytes),
@@ -288,7 +288,7 @@ impl Nla for InfoBond {
 
         match self {
             Mode(_) => IFLA_BOND_MODE,
-            ActiveSlave(_) => IFLA_BOND_ACTIVE_SLAVE,
+            ActivePort(_) => IFLA_BOND_ACTIVE_PORT,
             MiiMon(_) => IFLA_BOND_MIIMON,
             UpDelay(_) => IFLA_BOND_UPDELAY,
             DownDelay(_) => IFLA_BOND_DOWNDELAY,
@@ -303,10 +303,10 @@ impl Nla for InfoBond {
             XmitHashPolicy(_) => IFLA_BOND_XMIT_HASH_POLICY,
             ResendIgmp(_) => IFLA_BOND_RESEND_IGMP,
             NumPeerNotif(_) => IFLA_BOND_NUM_PEER_NOTIF,
-            AllSlavesActive(_) => IFLA_BOND_ALL_SLAVES_ACTIVE,
+            AllPortsActive(_) => IFLA_BOND_ALL_PORTS_ACTIVE,
             MinLinks(_) => IFLA_BOND_MIN_LINKS,
             LpInterval(_) => IFLA_BOND_LP_INTERVAL,
-            PacketsPerSlave(_) => IFLA_BOND_PACKETS_PER_SLAVE,
+            PacketsPerPort(_) => IFLA_BOND_PACKETS_PER_PORT,
             AdLacpRate(_) => IFLA_BOND_AD_LACP_RATE,
             AdSelect(_) => IFLA_BOND_AD_SELECT,
             AdInfo(_) => IFLA_BOND_AD_INFO,
@@ -330,9 +330,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoBond {
             IFLA_BOND_MODE => Mode(
                 parse_u8(payload).context("invalid IFLA_BOND_MODE value")?,
             ),
-            IFLA_BOND_ACTIVE_SLAVE => ActiveSlave(
+            IFLA_BOND_ACTIVE_PORT => ActivePort(
                 parse_u32(payload)
-                    .context("invalid IFLA_BOND_ACTIVE_SLAVE value")?,
+                    .context("invalid IFLA_BOND_ACTIVE_PORT value")?,
             ),
             IFLA_BOND_MIIMON => MiiMon(
                 parse_u32(payload).context("invalid IFLA_BOND_MIIMON value")?,
@@ -396,9 +396,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoBond {
                 parse_u8(payload)
                     .context("invalid IFLA_BOND_NUM_PEER_NOTIF value")?,
             ),
-            IFLA_BOND_ALL_SLAVES_ACTIVE => AllSlavesActive(
+            IFLA_BOND_ALL_PORTS_ACTIVE => AllPortsActive(
                 parse_u8(payload)
-                    .context("invalid IFLA_BOND_ALL_SLAVES_ACTIVE value")?,
+                    .context("invalid IFLA_BOND_ALL_PORTS_ACTIVE value")?,
             ),
             IFLA_BOND_MIN_LINKS => MinLinks(
                 parse_u32(payload)
@@ -408,9 +408,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoBond {
                 parse_u32(payload)
                     .context("invalid IFLA_BOND_LP_INTERVAL value")?,
             ),
-            IFLA_BOND_PACKETS_PER_SLAVE => PacketsPerSlave(
+            IFLA_BOND_PACKETS_PER_PORT => PacketsPerPort(
                 parse_u32(payload)
-                    .context("invalid IFLA_BOND_PACKETS_PER_SLAVE value")?,
+                    .context("invalid IFLA_BOND_PACKETS_PER_PORT value")?,
             ),
             IFLA_BOND_AD_LACP_RATE => AdLacpRate(
                 parse_u8(payload)

--- a/src/rtnl/link/nlas/bond_port.rs
+++ b/src/rtnl/link/nlas/bond_port.rs
@@ -12,29 +12,29 @@ use crate::constants::*;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 #[non_exhaustive]
-pub enum SlaveState {
+pub enum BondPortState {
     Active,
     Backup,
     Other(u8),
 }
 
-impl From<u8> for SlaveState {
+impl From<u8> for BondPortState {
     fn from(value: u8) -> Self {
-        use self::SlaveState::*;
+        use self::BondPortState::*;
         match value {
-            IFLA_BOND_SLAVE_STATE_ACTIVE => Active,
-            IFLA_BOND_SLAVE_STATE_BACKUP => Backup,
+            IFLA_BOND_PORT_STATE_ACTIVE => Active,
+            IFLA_BOND_PORT_STATE_BACKUP => Backup,
             _ => Other(value),
         }
     }
 }
 
-impl From<SlaveState> for u8 {
-    fn from(value: SlaveState) -> Self {
-        use self::SlaveState::*;
+impl From<BondPortState> for u8 {
+    fn from(value: BondPortState) -> Self {
+        use self::BondPortState::*;
         match value {
-            Active => IFLA_BOND_SLAVE_STATE_ACTIVE,
-            Backup => IFLA_BOND_SLAVE_STATE_BACKUP,
+            Active => IFLA_BOND_PORT_STATE_ACTIVE,
+            Backup => IFLA_BOND_PORT_STATE_BACKUP,
             Other(other) => other,
         }
     }
@@ -54,10 +54,10 @@ impl From<u8> for MiiStatus {
     fn from(value: u8) -> Self {
         use self::MiiStatus::*;
         match value {
-            IFLA_BOND_SLAVE_MII_STATUS_UP => Up,
-            IFLA_BOND_SLAVE_MII_STATUS_GOING_DOWN => GoingDown,
-            IFLA_BOND_SLAVE_MII_STATUS_DOWN => Down,
-            IFLA_BOND_SLAVE_MII_STATUS_GOING_BACK => GoingBack,
+            IFLA_BOND_PORT_MII_STATUS_UP => Up,
+            IFLA_BOND_PORT_MII_STATUS_GOING_DOWN => GoingDown,
+            IFLA_BOND_PORT_MII_STATUS_DOWN => Down,
+            IFLA_BOND_PORT_MII_STATUS_GOING_BACK => GoingBack,
             _ => Other(value),
         }
     }
@@ -67,10 +67,10 @@ impl From<MiiStatus> for u8 {
     fn from(value: MiiStatus) -> Self {
         use self::MiiStatus::*;
         match value {
-            Up => IFLA_BOND_SLAVE_MII_STATUS_UP,
-            GoingDown => IFLA_BOND_SLAVE_MII_STATUS_GOING_DOWN,
-            Down => IFLA_BOND_SLAVE_MII_STATUS_DOWN,
-            GoingBack => IFLA_BOND_SLAVE_MII_STATUS_GOING_BACK,
+            Up => IFLA_BOND_PORT_MII_STATUS_UP,
+            GoingDown => IFLA_BOND_PORT_MII_STATUS_GOING_DOWN,
+            Down => IFLA_BOND_PORT_MII_STATUS_DOWN,
+            GoingBack => IFLA_BOND_PORT_MII_STATUS_GOING_BACK,
             Other(other) => other,
         }
     }
@@ -84,7 +84,7 @@ pub enum InfoBondPort {
     PermHwaddr(Vec<u8>),
     Prio(i32),
     QueueId(u16),
-    SlaveState(SlaveState),
+    BondPortState(BondPortState),
     Other(DefaultNla),
 }
 
@@ -101,7 +101,7 @@ impl Nla for InfoBondPort {
             PermHwaddr(ref bytes)
             => bytes.len(),
             MiiStatus(_) => 1,
-            SlaveState(_) => 1,
+            BondPortState(_) => 1,
             Other(nla)
                 => nla.value_len(),
         }
@@ -120,7 +120,7 @@ impl Nla for InfoBondPort {
             LinkFailureCount(value)
              => NativeEndian::write_u32(buffer, *value),
             MiiStatus(state) => buffer[0] = (*state).into(),
-            SlaveState(state) => buffer[0] = (*state).into(),
+            BondPortState(state) => buffer[0] = (*state).into(),
             Other(nla)
              => nla.emit_value(buffer),
         }
@@ -130,12 +130,12 @@ impl Nla for InfoBondPort {
         use self::InfoBondPort::*;
 
         match self {
-            LinkFailureCount(_) => IFLA_BOND_SLAVE_LINK_FAILURE_COUNT,
-            MiiStatus(_) => IFLA_BOND_SLAVE_MII_STATUS,
-            PermHwaddr(_) => IFLA_BOND_SLAVE_PERM_HWADDR,
-            Prio(_) => IFLA_BOND_SLAVE_PRIO,
-            QueueId(_) => IFLA_BOND_SLAVE_QUEUE_ID,
-            SlaveState(_) => IFLA_BOND_SLAVE_STATE,
+            LinkFailureCount(_) => IFLA_BOND_PORT_LINK_FAILURE_COUNT,
+            MiiStatus(_) => IFLA_BOND_PORT_MII_STATUS,
+            PermHwaddr(_) => IFLA_BOND_PORT_PERM_HWADDR,
+            Prio(_) => IFLA_BOND_PORT_PRIO,
+            QueueId(_) => IFLA_BOND_PORT_QUEUE_ID,
+            BondPortState(_) => IFLA_BOND_PORT_STATE,
             Other(nla) => nla.kind(),
         }
     }
@@ -146,28 +146,28 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoBondPort {
         use self::InfoBondPort::*;
         let payload = buf.value();
         Ok(match buf.kind() {
-            IFLA_BOND_SLAVE_LINK_FAILURE_COUNT => {
+            IFLA_BOND_PORT_LINK_FAILURE_COUNT => {
                 LinkFailureCount(parse_u32(payload).context(
-                    "invalid IFLA_BOND_SLAVE_LINK_FAILURE_COUNT value",
+                    "invalid IFLA_BOND_PORT_LINK_FAILURE_COUNT value",
                 )?)
             }
-            IFLA_BOND_SLAVE_MII_STATUS => MiiStatus(
+            IFLA_BOND_PORT_MII_STATUS => MiiStatus(
                 parse_u8(payload)
-                    .context("invalid IFLA_BOND_SLAVE_MII_STATUS value")?
+                    .context("invalid IFLA_BOND_PORT_MII_STATUS value")?
                     .into(),
             ),
-            IFLA_BOND_SLAVE_PERM_HWADDR => PermHwaddr(payload.to_vec()),
-            IFLA_BOND_SLAVE_PRIO => Prio(
+            IFLA_BOND_PORT_PERM_HWADDR => PermHwaddr(payload.to_vec()),
+            IFLA_BOND_PORT_PRIO => Prio(
                 parse_i32(payload)
-                    .context("invalid IFLA_BOND_SLAVE_PRIO value")?,
+                    .context("invalid IFLA_BOND_PORT_PRIO value")?,
             ),
-            IFLA_BOND_SLAVE_QUEUE_ID => QueueId(
+            IFLA_BOND_PORT_QUEUE_ID => QueueId(
                 parse_u16(payload)
-                    .context("invalid IFLA_BOND_SLAVE_QUEUE_ID value")?,
+                    .context("invalid IFLA_BOND_PORT_QUEUE_ID value")?,
             ),
-            IFLA_BOND_SLAVE_STATE => SlaveState(
+            IFLA_BOND_PORT_STATE => BondPortState(
                 parse_u8(payload)
-                    .context("invalid IFLA_BOND_SLAVE_STATE value")?
+                    .context("invalid IFLA_BOND_PORT_STATE value")?
                     .into(),
             ),
             kind => Other(


### PR DESCRIPTION
Replaced all `slave` to `port`:

 * `InfoBond::ActiveSlave` -> `InfoBond::ActivePort`
 * `InfoBond::AllSlavesActive` -> `InfoBond::AllPortsActive`
 * `InfoBond::PacketsPerSlave` -> `InfoBond::PacketsPerPort`
 * `SlaveState` -> `BondPortState`
 * `link_info::Info::SlaveKind` -> `link_info::Info::PortKind`
 * `link_info::Info::SlaveData` -> `link_info::Info::PortData`
 * `link_info::InfoSlaveData` -> `link_info::InfoPortData`