### PR TITLE
New release 0.16.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,15 @@
 # Changelog
-### [0.16.0] - 2023-06-25
+## [0.16.1] - 2023-07-10
+### Breaking changes
+ - N/A
+
+### New features
+ - N/A
+
+### Bug fixes
+ - Use latest rust-netlink crates. (2eda618)
+
+## [0.16.0] - 2023-06-25
 ### Breaking changes
  - Replaced all `slave` to `port`. (bfa1ec3)
     * `InfoBond::ActiveSlave` -> `InfoBond::ActivePort`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-packet-route"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2018"
 
 homepage = "https://github.com/rust-netlink/netlink-packet-route"


### PR DESCRIPTION
=== Breaking changes
 - N/A

=== New features
 - N/A

=== Bug fixes
 - Use latest rust-netlink crates. (2eda618)