### PR TITLE
Fix vxlan port range

### DIFF
--- a/src/rtnl/link/nlas/link_infos.rs
+++ b/src/rtnl/link/nlas/link_infos.rs
@@ -781,8 +781,8 @@ impl Nla for InfoVxlan {
             => buffer.copy_from_slice(value.as_slice()),
             Port(ref value) => BigEndian::write_u16(buffer, *value),
             PortRange(ref range) => {
-                NativeEndian::write_u16(buffer, range.0);
-                NativeEndian::write_u16(buffer, range.1)
+                BigEndian::write_u16(buffer, range.0);
+                BigEndian::write_u16(buffer, range.1)
             }
         }
     }
@@ -885,8 +885,8 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoVxlan {
                 if payload.len() != 4 {
                     return Err(err.into());
                 }
-                let low = parse_u16(&payload[0..2]).context(err)?;
-                let high = parse_u16(&payload[2..]).context(err)?;
+                let low = parse_u16_be(&payload[0..2]).context(err)?;
+                let high = parse_u16_be(&payload[2..]).context(err)?;
                 PortRange((low, high))
             }
             IFLA_VXLAN_PORT => Port(


### PR DESCRIPTION
Two things were wrong when attempting to create a vxlan link specifying its src port range:
- we were using native endianness (instead of big endian) to encode the port min / max ranges
- we were not updating the buffer pointer to where we were encoding the min/max values, and thus the "max" was overwriting the "min" value, causing an invalid netlink message.


Unit tests are added.

Fixes: #43 
Depends-on: #42 