### PR TITLE
New release 0.17.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,16 @@
 # Changelog
+## [0.17.1] - 2023-08-30
+### Breaking changes
+ - N/A
+
+### New features
+ - Add support of MACsec interface. (050fd64)
+
+### Bug fixes
+ - vxlan: fix port-range attribute marshalling. (55de269)
+ - vxlan: fix port-range attribute endianness. (ce406b2)
+ - vxlan: fix port attribute endianness. (927bdd7)
+
 ## [0.17.0] - 2023-07-10
 ### Breaking changes
  - `InfoVlan::EgressQos(Vec<u8>)` changed to

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-packet-route"
-version = "0.17.0"
+version = "0.17.1"
 edition = "2018"
 
 homepage = "https://github.com/rust-netlink/netlink-packet-route"


### PR DESCRIPTION
=== Breaking changes
 - N/A

=== New features
 - Add support of MACsec interface. (050fd64)

=== Bug fixes
 - vxlan: fix port-range attribute marshalling. (55de269)
 - vxlan: fix port-range attribute endianness. (ce406b2)
 - vxlan: fix port attribute endianness. (927bdd7)