### PR TITLE
[api_break] ipv6: parse IPv6 address flags

### DIFF
--- a/examples/new_rule.rs
+++ b/examples/new_rule.rs
@@ -15,10 +15,12 @@ fn main() {
     let _port_number = socket.bind_auto().unwrap().port_number();
     socket.connect(&SocketAddr::new(0, 0)).unwrap();
 
-    let mut rule_msg_hdr = RuleHeader::default();
-    rule_msg_hdr.family = AF_INET as u8;
-    rule_msg_hdr.table = RT_TABLE_DEFAULT;
-    rule_msg_hdr.action = FR_ACT_TO_TBL;
+    let rule_msg_hdr = RuleHeader {
+        family: AF_INET as u8,
+        table: RT_TABLE_DEFAULT,
+        action: FR_ACT_TO_TBL,
+        ..Default::default()
+    };
 
     let mut rule_msg = RuleMessage::default();
     rule_msg.header = rule_msg_hdr;

--- a/src/rtnl/address/nlas/mod.rs
+++ b/src/rtnl/address/nlas/mod.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 
 mod cache_info;
+#[cfg(test)]
+mod test;
+
 pub use self::cache_info::*;
 
 use std::mem::size_of;
@@ -27,7 +30,7 @@ pub enum Nla {
     Anycast(Vec<u8>),
     CacheInfo(Vec<u8>),
     Multicast(Vec<u8>),
-    Flags(u32),
+    Flags(Inet6AddrFlags),
     Other(DefaultNla),
 }
 
@@ -78,7 +81,7 @@ impl nla::Nla for Nla {
             }
 
             // u32
-            Flags(ref value) => NativeEndian::write_u32(buffer, *value),
+            Flags(ref value) => NativeEndian::write_u32(buffer, value.into()),
 
 
             // Default
@@ -118,13 +121,91 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nla {
             IFA_ANYCAST => Anycast(payload.to_vec()),
             IFA_CACHEINFO => CacheInfo(payload.to_vec()),
             IFA_MULTICAST => Multicast(payload.to_vec()),
-            IFA_FLAGS => {
-                Flags(parse_u32(payload).context("invalid IFA_FLAGS value")?)
-            }
+            IFA_FLAGS => Flags(
+                parse_u32(payload)
+                    .context("invalid IFA_FLAGS value")?
+                    .into(),
+            ),
             kind => Other(
                 DefaultNla::parse(buf)
                     .context(format!("unknown NLA type {kind}"))?,
             ),
         })
+    }
+}
+
+const IFA_F_SECONDARY: u32 = 0x01;
+const IFA_F_NODAD: u32 = 0x02;
+const IFA_F_OPTIMISTIC: u32 = 0x04;
+const IFA_F_DADFAILED: u32 = 0x08;
+const IFA_F_HOMEADDRESS: u32 = 0x10;
+const IFA_F_DEPRECATED: u32 = 0x20;
+const IFA_F_TENTATIVE: u32 = 0x40;
+const IFA_F_PERMANENT: u32 = 0x80;
+const IFA_F_MANAGETEMPADDR: u32 = 0x100;
+const IFA_F_NOPREFIXROUTE: u32 = 0x200;
+const IFA_F_MCAUTOJOIN: u32 = 0x400;
+const IFA_F_STABLE_PRIVACY: u32 = 0x800;
+
+#[derive(Clone, Eq, PartialEq, Debug, Copy)]
+#[non_exhaustive]
+#[repr(u32)]
+pub enum Inet6AddrFlag {
+    Secondary = IFA_F_SECONDARY,
+    Nodad = IFA_F_NODAD,
+    Optimistic = IFA_F_OPTIMISTIC,
+    Dadfailed = IFA_F_DADFAILED,
+    Homeaddress = IFA_F_HOMEADDRESS,
+    Deprecated = IFA_F_DEPRECATED,
+    Tentative = IFA_F_TENTATIVE,
+    Permanent = IFA_F_PERMANENT,
+    Managetempaddr = IFA_F_MANAGETEMPADDR,
+    Noprefixroute = IFA_F_NOPREFIXROUTE,
+    Mcautojoin = IFA_F_MCAUTOJOIN,
+    StablePrivacy = IFA_F_STABLE_PRIVACY,
+}
+
+const ALL_INET6_FLAGS: [Inet6AddrFlag; 12] = [
+    Inet6AddrFlag::Secondary,
+    Inet6AddrFlag::Nodad,
+    Inet6AddrFlag::Optimistic,
+    Inet6AddrFlag::Dadfailed,
+    Inet6AddrFlag::Homeaddress,
+    Inet6AddrFlag::Deprecated,
+    Inet6AddrFlag::Tentative,
+    Inet6AddrFlag::Permanent,
+    Inet6AddrFlag::Managetempaddr,
+    Inet6AddrFlag::Noprefixroute,
+    Inet6AddrFlag::Mcautojoin,
+    Inet6AddrFlag::StablePrivacy,
+];
+
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub struct Inet6AddrFlags(Vec<Inet6AddrFlag>);
+
+impl From<u32> for Inet6AddrFlags {
+    fn from(d: u32) -> Self {
+        let mut got: u32 = 0;
+        let mut ret = Vec::new();
+        for flag in ALL_INET6_FLAGS {
+            if (d & (flag as u32)) > 0 {
+                ret.push(flag);
+                got += flag as u32;
+            }
+        }
+        if got != d {
+            eprintln!("Discarded unsupported IFA_FLAGS: {}", d - got);
+        }
+        Self(ret)
+    }
+}
+
+impl From<&Inet6AddrFlags> for u32 {
+    fn from(v: &Inet6AddrFlags) -> u32 {
+        let mut d: u32 = 0;
+        for flag in &v.0 {
+            d += *flag as u32;
+        }
+        d
     }
 }

--- a/src/rtnl/address/nlas/test.rs
+++ b/src/rtnl/address/nlas/test.rs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+
+use crate::rtnl::address::nlas::{Inet6AddrFlag, Inet6AddrFlags, Nla};
+use netlink_packet_utils::{nla::NlaBuffer, Emitable, Parseable};
+
+#[test]
+fn test_ipv6_addr_flags() {
+    let nla = Nla::Flags(Inet6AddrFlags(vec![
+        Inet6AddrFlag::Permanent,
+        Inet6AddrFlag::StablePrivacy,
+    ]));
+
+    let raw: [u8; 8] = [
+        0x08, 0x00, // length 8
+        0x08, 0x00, // IFA_FLAGS
+        0x80, 0x08, 0x00, 0x00, // IFA_F_PERMANENT | IFA_F_STABLE_PRIVACY
+    ];
+
+    let nla_buffer = NlaBuffer::new_checked(&raw).unwrap();
+    let parsed = Nla::parse(&nla_buffer).unwrap();
+    assert_eq!(parsed, nla);
+
+    assert_eq!(nla.buffer_len(), 8);
+
+    let mut buffer: [u8; 8] = [0; 8];
+    nla.emit(&mut buffer);
+    assert_eq!(buffer, raw);
+}


### PR DESCRIPTION
Changed `rtnl::address::nlas:Nla::Flags(u32)` to `Flags(Inet6AddrFlags)`,
so user of rust-netlink does not need to read kernel code for these flags.

Unit test case included.