### PR TITLE
tc: Fix DecodeError on sfq scheduler

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,5 +29,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           fail_ci_if_error: true

--- a/src/rtnl/tc/nlas/mod.rs
+++ b/src/rtnl/tc/nlas/mod.rs
@@ -10,6 +10,7 @@ mod stats_basic;
 pub use self::stats_basic::*;
 
 mod options;
+pub(crate) use self::options::VecTcOpt;
 pub use self::options::*;
 
 mod qdisc;

--- a/src/rtnl/tc/test.rs
+++ b/src/rtnl/tc/test.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     constants::*,
-    tc::{ingress, Nla, Stats, Stats2, StatsBuffer, TC_HEADER_LEN},
+    tc::{ingress, Nla, Stats, Stats2, StatsBuffer, TcOpt, TC_HEADER_LEN},
     TcHeader, TcMessage, TcMessageBuffer,
 };
 
@@ -167,7 +167,7 @@ fn tc_qdisc_ingress_read() {
     assert_eq!(nla, &Nla::Kind(String::from(ingress::KIND)));
 
     let nla = iter.next().unwrap();
-    assert_eq!(nla, &Nla::Options(vec![]));
+    assert_eq!(nla, &Nla::Options(vec![TcOpt::Ingress]));
 
     let nla = iter.next().unwrap();
     assert_eq!(nla, &Nla::HwOffload(0));


### PR DESCRIPTION
When running `GetQueueDiscipline` against `sfq` scheduler, we will get
DecodeError.

This is because different scheduler has different layout of
`TCA_OPTIONS`.

For `fq_codel`, it is a list of netlink attribute. For kernel code,
`fq_codel_dump()` has `nla_nest_start_noflag(skb, TCA_OPTIONS)`
For `sfq`, it is a single netlink attribute, trying to decode it as
`NlasIterator` will generate DecodeError as expected. For kernel code:
`sfq_dump()` only has `nla_put(skb, TCA_OPTIONS, sizeof(opt), &opt)`.

This patch created `pub(crate) struct VecTcOpt` to handle this
difference correctly.