### PR TITLE
rtnl: removes non_exhaustive from NextHop structs. fixes #25

### DIFF
--- a/src/rtnl/route/nlas/next_hops.rs
+++ b/src/rtnl/route/nlas/next_hops.rs
@@ -13,7 +13,6 @@ use netlink_packet_utils::{
 };
 
 bitflags! {
-    #[non_exhaustive]
 pub struct NextHopFlags: u8 {
         const RTNH_F_DEAD = constants::RTNH_F_DEAD;
         const RTNH_F_PERVASIVE = constants::RTNH_F_PERVASIVE;
@@ -72,7 +71,6 @@ impl<'a, T: AsRef<[u8]> + ?Sized> NextHopBuffer<&'a T> {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
-#[non_exhaustive]
 pub struct NextHop {
     /// Next-hop flags (see [`NextHopFlags`])
     pub flags: NextHopFlags,


### PR DESCRIPTION
Having these structs marked as non_exhaustive makes it impossible to construct a NextHop object. Constructing this object is useful for creating [MultiPath](https://github.com/rust-netlink/netlink-packet-route/blob/main/src/rtnl/route/nlas/mod.rs#L50C1-L50C1) routes which have multiple hops.

fixes #25 