### PR TITLE
Use bitflags crate for addr value

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rich_nlas = []
 
 [dependencies]
 anyhow = "1.0.31"
-bitflags = "1.2.1"
+bitflags = "2.4.1"
 byteorder = "1.3.2"
 libc = "0.2.66"
 log = { version = "0.4.20", features = ["std"] }
@@ -27,6 +27,6 @@ netlink-packet-utils = { version = "0.5.2" }
 name = "dump_packet_links"
 
 [dev-dependencies]
-pcap-file = "1.1.1"
+pcap-file = "2.0.0"
 netlink-sys = { version = "0.8.5" }
-pretty_assertions = "0.7.2"
+pretty_assertions = "1.4.0"

--- a/src/address/addr_flags.rs
+++ b/src/address/addr_flags.rs
@@ -13,195 +13,46 @@ const IFA_F_NOPREFIXROUTE: u32 = 0x200;
 const IFA_F_MCAUTOJOIN: u32 = 0x400;
 const IFA_F_STABLE_PRIVACY: u32 = 0x800;
 
-#[derive(Clone, Eq, PartialEq, Debug, Copy)]
-#[non_exhaustive]
-pub enum AddressFlag {
-    Secondary,
-    Nodad,
-    Optimistic,
-    Dadfailed,
-    Homeaddress,
-    Deprecated,
-    Tentative,
-    Permanent,
-    Managetempaddr,
-    Noprefixroute,
-    Mcautojoin,
-    StablePrivacy,
-    Other(u32),
-}
-
-impl From<u32> for AddressFlag {
-    fn from(d: u32) -> Self {
-        match d {
-            IFA_F_SECONDARY => Self::Secondary,
-            IFA_F_NODAD => Self::Nodad,
-            IFA_F_OPTIMISTIC => Self::Optimistic,
-            IFA_F_DADFAILED => Self::Dadfailed,
-            IFA_F_HOMEADDRESS => Self::Homeaddress,
-            IFA_F_DEPRECATED => Self::Deprecated,
-            IFA_F_TENTATIVE => Self::Tentative,
-            IFA_F_PERMANENT => Self::Permanent,
-            IFA_F_MANAGETEMPADDR => Self::Managetempaddr,
-            IFA_F_NOPREFIXROUTE => Self::Noprefixroute,
-            IFA_F_MCAUTOJOIN => Self::Mcautojoin,
-            IFA_F_STABLE_PRIVACY => Self::StablePrivacy,
-            _ => Self::Other(d),
-        }
+bitflags! {
+    #[non_exhaustive]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct AddressFlags : u32 {
+        const Secondary = IFA_F_SECONDARY;
+        const Nodad = IFA_F_NODAD;
+        const Optimistic = IFA_F_OPTIMISTIC;
+        const Dadfailed = IFA_F_DADFAILED;
+        const Homeaddress = IFA_F_HOMEADDRESS;
+        const Deprecated = IFA_F_DEPRECATED;
+        const Tentative = IFA_F_TENTATIVE;
+        const Permanent = IFA_F_PERMANENT;
+        const Managetempaddr = IFA_F_MANAGETEMPADDR;
+        const Noprefixroute = IFA_F_NOPREFIXROUTE;
+        const Mcautojoin = IFA_F_MCAUTOJOIN;
+        const StablePrivacy = IFA_F_STABLE_PRIVACY;
+        const _ = !0;
     }
 }
 
-impl From<AddressFlag> for u32 {
-    fn from(v: AddressFlag) -> u32 {
-        match v {
-            AddressFlag::Secondary => IFA_F_SECONDARY,
-            AddressFlag::Nodad => IFA_F_NODAD,
-            AddressFlag::Optimistic => IFA_F_OPTIMISTIC,
-            AddressFlag::Dadfailed => IFA_F_DADFAILED,
-            AddressFlag::Homeaddress => IFA_F_HOMEADDRESS,
-            AddressFlag::Deprecated => IFA_F_DEPRECATED,
-            AddressFlag::Tentative => IFA_F_TENTATIVE,
-            AddressFlag::Permanent => IFA_F_PERMANENT,
-            AddressFlag::Managetempaddr => IFA_F_MANAGETEMPADDR,
-            AddressFlag::Noprefixroute => IFA_F_NOPREFIXROUTE,
-            AddressFlag::Mcautojoin => IFA_F_MCAUTOJOIN,
-            AddressFlag::StablePrivacy => IFA_F_STABLE_PRIVACY,
-            AddressFlag::Other(d) => d,
-        }
+bitflags! {
+    #[non_exhaustive]
+    #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+    /// [AddressHeaderFlag] is only used for [super::AddressHeader] and holding
+    /// subset(first byte) of [AddressFlag].
+    pub struct AddressHeaderFlags : u8 {
+        const Secondary = IFA_F_SECONDARY as u8;
+        const Nodad = IFA_F_NODAD as u8;
+        const Optimistic = IFA_F_OPTIMISTIC as u8;
+        const Dadfailed = IFA_F_DADFAILED as u8;
+        const Homeaddress = IFA_F_HOMEADDRESS as u8;
+        const Deprecated = IFA_F_DEPRECATED as u8;
+        const Tentative = IFA_F_TENTATIVE as u8;
+        const Permanent = IFA_F_PERMANENT as u8;
+        const _ = !0;
     }
 }
 
-const ALL_ADDR_FLAGS: [AddressFlag; 12] = [
-    AddressFlag::Secondary,
-    AddressFlag::Nodad,
-    AddressFlag::Optimistic,
-    AddressFlag::Dadfailed,
-    AddressFlag::Homeaddress,
-    AddressFlag::Deprecated,
-    AddressFlag::Tentative,
-    AddressFlag::Permanent,
-    AddressFlag::Managetempaddr,
-    AddressFlag::Noprefixroute,
-    AddressFlag::Mcautojoin,
-    AddressFlag::StablePrivacy,
-];
-
-#[derive(Clone, Eq, PartialEq, Debug)]
-pub struct AddressFlags(pub(crate) Vec<AddressFlag>);
-
-impl From<u32> for AddressFlags {
-    fn from(d: u32) -> Self {
-        let mut got: u32 = 0;
-        let mut ret = Vec::new();
-        for flag in ALL_ADDR_FLAGS {
-            if (d & u32::from(flag)) > 0 {
-                ret.push(flag);
-                got += u32::from(flag);
-            }
-        }
-        if got != d {
-            log::warn!("Discarded unsupported IFA_F_: {}", d - got);
-        }
-        Self(ret)
-    }
-}
-
-impl From<&AddressFlags> for u32 {
-    fn from(v: &AddressFlags) -> u32 {
-        let mut d: u32 = 0;
-        for flag in &v.0 {
-            d += u32::from(*flag);
-        }
-        d
-    }
-}
-
-#[derive(Clone, Eq, PartialEq, Debug, Copy)]
-#[non_exhaustive]
-#[repr(u8)]
-/// [AddressHeaderFlag] is only used for [super::AddressHeader] and holding
-/// subset(first byte) of [AddressFlag].
-pub enum AddressHeaderFlag {
-    Secondary,
-    Nodad,
-    Optimistic,
-    Dadfailed,
-    Homeaddress,
-    Deprecated,
-    Tentative,
-    Permanent,
-    Other(u8),
-}
-
-impl From<u8> for AddressHeaderFlag {
-    fn from(d: u8) -> Self {
-        match d {
-            d if d == IFA_F_SECONDARY as u8 => Self::Secondary,
-            d if d == IFA_F_NODAD as u8 => Self::Nodad,
-            d if d == IFA_F_OPTIMISTIC as u8 => Self::Optimistic,
-            d if d == IFA_F_DADFAILED as u8 => Self::Dadfailed,
-            d if d == IFA_F_HOMEADDRESS as u8 => Self::Homeaddress,
-            d if d == IFA_F_DEPRECATED as u8 => Self::Deprecated,
-            d if d == IFA_F_TENTATIVE as u8 => Self::Tentative,
-            d if d == IFA_F_PERMANENT as u8 => Self::Permanent,
-            _ => Self::Other(d),
-        }
-    }
-}
-
-impl From<AddressHeaderFlag> for u8 {
-    fn from(v: AddressHeaderFlag) -> u8 {
-        match v {
-            AddressHeaderFlag::Secondary => IFA_F_SECONDARY as u8,
-            AddressHeaderFlag::Nodad => IFA_F_NODAD as u8,
-            AddressHeaderFlag::Optimistic => IFA_F_OPTIMISTIC as u8,
-            AddressHeaderFlag::Dadfailed => IFA_F_DADFAILED as u8,
-            AddressHeaderFlag::Homeaddress => IFA_F_HOMEADDRESS as u8,
-            AddressHeaderFlag::Deprecated => IFA_F_DEPRECATED as u8,
-            AddressHeaderFlag::Tentative => IFA_F_TENTATIVE as u8,
-            AddressHeaderFlag::Permanent => IFA_F_PERMANENT as u8,
-            AddressHeaderFlag::Other(d) => d,
-        }
-    }
-}
-
-const ALL_HDR_ADDR_FLAGS: [AddressHeaderFlag; 8] = [
-    AddressHeaderFlag::Secondary,
-    AddressHeaderFlag::Nodad,
-    AddressHeaderFlag::Optimistic,
-    AddressHeaderFlag::Dadfailed,
-    AddressHeaderFlag::Homeaddress,
-    AddressHeaderFlag::Deprecated,
-    AddressHeaderFlag::Tentative,
-    AddressHeaderFlag::Permanent,
-];
-
-#[derive(Clone, Eq, PartialEq, Debug)]
-pub struct AddressHeaderFlags(pub(crate) Vec<AddressHeaderFlag>);
-
-impl From<u8> for AddressHeaderFlags {
-    fn from(d: u8) -> Self {
-        let mut got: u8 = 0;
-        let mut ret = Vec::new();
-        for flag in ALL_HDR_ADDR_FLAGS {
-            if (d & u8::from(flag)) > 0 {
-                ret.push(flag);
-                got += u8::from(flag);
-            }
-        }
-        if got != d {
-            log::warn!("Discarded unsupported IFA_F_: {}", d - got);
-        }
-        Self(ret)
-    }
-}
-
-impl From<&AddressHeaderFlags> for u8 {
-    fn from(v: &AddressHeaderFlags) -> u8 {
-        let mut d: u8 = 0;
-        for flag in &v.0 {
-            d += u8::from(*flag);
-        }
-        d
+impl Default for AddressHeaderFlags {
+    fn default() -> Self {
+        Self::empty()
     }
 }

--- a/src/address/message.rs
+++ b/src/address/message.rs
@@ -8,9 +8,7 @@ use netlink_packet_utils::{
 };
 
 use crate::{
-    address::{
-        AddressAttribute, AddressHeaderFlag, AddressHeaderFlags, AddressScope,
-    },
+    address::{AddressAttribute, AddressHeaderFlags, AddressScope},
     AddressFamily,
 };
 
@@ -44,7 +42,7 @@ pub struct AddressMessage {
 pub struct AddressHeader {
     pub family: AddressFamily,
     pub prefix_len: u8,
-    pub flags: Vec<AddressHeaderFlag>,
+    pub flags: AddressHeaderFlags,
     pub scope: AddressScope,
     pub index: u32,
 }
@@ -58,7 +56,7 @@ impl Emitable for AddressHeader {
         let mut packet = AddressMessageBuffer::new(buffer);
         packet.set_family(self.family.into());
         packet.set_prefix_len(self.prefix_len);
-        packet.set_flags(u8::from(&AddressHeaderFlags(self.flags.to_vec())));
+        packet.set_flags(self.flags.bits());
         packet.set_scope(self.scope.into());
         packet.set_index(self.index);
     }
@@ -82,7 +80,7 @@ impl<T: AsRef<[u8]>> Parseable<AddressMessageBuffer<T>> for AddressHeader {
         Ok(Self {
             family: buf.family().into(),
             prefix_len: buf.prefix_len(),
-            flags: AddressHeaderFlags::from(buf.flags()).0,
+            flags: AddressHeaderFlags::from_bits_retain(buf.flags()),
             scope: buf.scope().into(),
             index: buf.index(),
         })

--- a/src/address/mod.rs
+++ b/src/address/mod.rs
@@ -9,9 +9,7 @@ mod message;
 #[cfg(test)]
 mod tests;
 
-pub use self::addr_flags::{
-    AddressFlag, AddressFlags, AddressHeaderFlag, AddressHeaderFlags,
-};
+pub use self::addr_flags::{AddressFlags, AddressHeaderFlags};
 pub use self::addr_scope::AddressScope;
 pub use self::attribute::AddressAttribute;
 pub use self::cache_info::{CacheInfo, CacheInfoBuffer};

--- a/src/address/tests/ipv4.rs
+++ b/src/address/tests/ipv4.rs
@@ -5,7 +5,7 @@ use std::net::{IpAddr, Ipv4Addr};
 use netlink_packet_utils::{Emitable, Parseable};
 
 use crate::address::{
-    AddressAttribute, AddressFlag, AddressHeader, AddressHeaderFlag,
+    AddressAttribute, AddressFlags, AddressHeader, AddressHeaderFlags,
     AddressMessage, AddressMessageBuffer, AddressScope, CacheInfo,
 };
 use crate::AddressFamily;
@@ -26,7 +26,7 @@ fn test_ipv4_get_loopback_address() {
         header: AddressHeader {
             family: AddressFamily::Inet,
             prefix_len: 8,
-            flags: vec![AddressHeaderFlag::Permanent],
+            flags: AddressHeaderFlags::Permanent,
             scope: AddressScope::Host,
             index: 1,
         },
@@ -34,7 +34,7 @@ fn test_ipv4_get_loopback_address() {
             AddressAttribute::Address(IpAddr::V4(Ipv4Addr::LOCALHOST)),
             AddressAttribute::Local(IpAddr::V4(Ipv4Addr::LOCALHOST)),
             AddressAttribute::Label("lo".to_string()),
-            AddressAttribute::Flags(vec![AddressFlag::Permanent]),
+            AddressAttribute::Flags(AddressFlags::Permanent),
             AddressAttribute::CacheInfo(CacheInfo {
                 ifa_preferred: u32::MAX,
                 ifa_valid: u32::MAX,

--- a/src/address/tests/ipv6.rs
+++ b/src/address/tests/ipv6.rs
@@ -5,7 +5,7 @@ use std::net::{IpAddr, Ipv6Addr};
 use netlink_packet_utils::{nla::NlaBuffer, Emitable, Parseable};
 
 use crate::address::{
-    AddressAttribute, AddressFlag, AddressHeader, AddressHeaderFlag,
+    AddressAttribute, AddressFlags, AddressHeader, AddressHeaderFlags,
     AddressMessage, AddressMessageBuffer, AddressScope, CacheInfo,
 };
 use crate::AddressFamily;
@@ -14,10 +14,9 @@ use crate::AddressFamily;
 
 #[test]
 fn test_addr_flag_stable_privacy() {
-    let nla = AddressAttribute::Flags(vec![
-        AddressFlag::Permanent,
-        AddressFlag::StablePrivacy,
-    ]);
+    let nla = AddressAttribute::Flags(
+        AddressFlags::Permanent | AddressFlags::StablePrivacy,
+    );
 
     let raw: [u8; 8] = [
         0x08, 0x00, // length 8
@@ -50,7 +49,7 @@ fn test_get_loopback_ipv6_addr() {
         header: AddressHeader {
             family: AddressFamily::Inet6,
             prefix_len: 128,
-            flags: vec![AddressHeaderFlag::Permanent],
+            flags: AddressHeaderFlags::Permanent,
             scope: AddressScope::Host,
             index: 1,
         },
@@ -62,10 +61,9 @@ fn test_get_loopback_ipv6_addr() {
                 cstamp: 142,
                 tstamp: 142,
             }),
-            AddressAttribute::Flags(vec![
-                AddressFlag::Permanent,
-                AddressFlag::Noprefixroute,
-            ]),
+            AddressAttribute::Flags(
+                AddressFlags::Permanent | AddressFlags::Noprefixroute,
+            ),
         ],
     };
 

--- a/src/rtnl/route/header.rs
+++ b/src/rtnl/route/header.rs
@@ -10,7 +10,8 @@ use crate::{constants::*, RouteMessageBuffer, ROUTE_HEADER_LEN};
 bitflags! {
     /// Flags that can be set in a `RTM_GETROUTE` ([`RtnlMessage::GetRoute`]) message.
     #[non_exhaustive]
-pub struct RouteFlags: u32 {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct RouteFlags: u32 {
         /// If the route changes, notify the user via rtnetlink
         const RTM_F_NOTIFY = RTM_F_NOTIFY;
         /// This route is cloned. Cloned routes are routes coming from the cache instead of the

--- a/src/rtnl/route/nlas/next_hops.rs
+++ b/src/rtnl/route/nlas/next_hops.rs
@@ -14,7 +14,8 @@ use netlink_packet_utils::{
 
 bitflags! {
     #[non_exhaustive]
-pub struct NextHopFlags: u8 {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct NextHopFlags: u8 {
         const RTNH_F_DEAD = constants::RTNH_F_DEAD;
         const RTNH_F_PERVASIVE = constants::RTNH_F_PERVASIVE;
         const RTNH_F_ONLINK = constants::RTNH_F_ONLINK;


### PR DESCRIPTION
@cathay4t did a very good first refactoring of all the flags and values and I'm very grateful for that.
This PR is the next step (?) and it uses the bitflags crate (which is already used in the route path and is now used in the addr path as well.

Let me know if there is any reason not to use the bitflags create here.
I think it's better than to manually search through a vec for a specific enum value.