### PR TITLE
[API break] link: Remove unused LinkAttribute

### DIFF
--- a/src/link/attribute.rs
+++ b/src/link/attribute.rs
@@ -65,7 +65,7 @@ const IFLA_PHYS_PORT_NAME: u16 = 38;
 const IFLA_PROTO_DOWN: u16 = 39;
 const IFLA_GSO_MAX_SEGS: u16 = 40;
 const IFLA_GSO_MAX_SIZE: u16 = 41;
-const IFLA_PAD: u16 = 42;
+// const IFLA_PAD: u16 = 42;
 const IFLA_XDP: u16 = 43;
 const IFLA_EVENT: u16 = 44;
 const IFLA_NEW_NETNSID: u16 = 45;
@@ -97,7 +97,6 @@ pub enum LinkAttribute {
     PortSelf(Vec<u8>),
     PhysPortId(Vec<u8>),
     PhysSwitchId(Vec<u8>),
-    Pad(Vec<u8>),
     Xdp(Vec<Xdp>),
     Event(Vec<u8>),
     NewNetnsId(Vec<u8>),
@@ -162,7 +161,6 @@ impl Nla for LinkAttribute {
             | Self::PortSelf(bytes)
             | Self::PhysPortId(bytes)
             | Self::PhysSwitchId(bytes)
-            | Self::Pad(bytes)
             | Self::Event(bytes)
             | Self::NewNetnsId(bytes)
             | Self::IfNetnsId(bytes)
@@ -225,7 +223,6 @@ impl Nla for LinkAttribute {
             | Self::PhysSwitchId(bytes)
             | Self::Wireless(bytes)
             | Self::ProtoInfo(bytes)
-            | Self::Pad(bytes)
             | Self::Event(bytes)
             | Self::NewNetnsId(bytes)
             | Self::IfNetnsId(bytes)
@@ -295,7 +292,6 @@ impl Nla for LinkAttribute {
             Self::LinkInfo(_) => IFLA_LINKINFO,
             Self::Wireless(_) => IFLA_WIRELESS,
             Self::ProtoInfo(_) => IFLA_PROTINFO,
-            Self::Pad(_) => IFLA_PAD,
             Self::Xdp(_) => IFLA_XDP,
             Self::Event(_) => IFLA_EVENT,
             Self::NewNetnsId(_) => IFLA_NEW_NETNSID,
@@ -361,7 +357,6 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
             IFLA_PHYS_SWITCH_ID => Self::PhysSwitchId(payload.to_vec()),
             IFLA_WIRELESS => Self::Wireless(payload.to_vec()),
             IFLA_PROTINFO => Self::ProtoInfo(payload.to_vec()),
-            IFLA_PAD => Self::Pad(payload.to_vec()),
             IFLA_EVENT => Self::Event(payload.to_vec()),
             IFLA_NEW_NETNSID => Self::NewNetnsId(payload.to_vec()),
             IFLA_IF_NETNSID => Self::IfNetnsId(payload.to_vec()),

--- a/src/link/attribute.rs
+++ b/src/link/attribute.rs
@@ -28,16 +28,17 @@ const IFLA_MTU: u16 = 4;
 const IFLA_LINK: u16 = 5;
 const IFLA_QDISC: u16 = 6;
 const IFLA_STATS: u16 = 7;
-// No kernel is using IFLA_COST
+// No kernel code is using IFLA_COST
 // const IFLA_COST: u16 = 8;
-// No kernel is using IFLA_PRIORITY
+// No kernel code is using IFLA_PRIORITY
 // const IFLA_PRIORITY: u16 = 9;
 const IFLA_MASTER: u16 = 10;
 const IFLA_WIRELESS: u16 = 11;
 const IFLA_PROTINFO: u16 = 12;
 const IFLA_TXQLEN: u16 = 13;
 const IFLA_MAP: u16 = 14;
-const IFLA_WEIGHT: u16 = 15;
+// No kernel code is using IFLA_WEIGHT
+// const IFLA_WEIGHT: u16 = 15;
 const IFLA_OPERSTATE: u16 = 16;
 const IFLA_LINKMODE: u16 = 17;
 const IFLA_LINKINFO: u16 = 18;
@@ -91,7 +92,6 @@ const IFLA_DEVLINK_PORT: u16 = 62;
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[non_exhaustive]
 pub enum LinkAttribute {
-    Weight(Vec<u8>),
     VfInfoList(Vec<u8>),
     VfPorts(Vec<u8>),
     PortSelf(Vec<u8>),
@@ -157,8 +157,7 @@ pub enum LinkAttribute {
 impl Nla for LinkAttribute {
     fn value_len(&self) -> usize {
         match self {
-            Self::Weight(bytes)
-            | Self::VfInfoList(bytes)
+            Self::VfInfoList(bytes)
             | Self::VfPorts(bytes)
             | Self::PortSelf(bytes)
             | Self::PhysPortId(bytes)
@@ -219,8 +218,7 @@ impl Nla for LinkAttribute {
 
     fn emit_value(&self, buffer: &mut [u8]) {
         match self {
-            Self::Weight(bytes)
-            | Self::VfInfoList(bytes)
+            Self::VfInfoList(bytes)
             | Self::VfPorts(bytes)
             | Self::PortSelf(bytes)
             | Self::PhysPortId(bytes)
@@ -289,7 +287,6 @@ impl Nla for LinkAttribute {
 
     fn kind(&self) -> u16 {
         match self {
-            Self::Weight(_) => IFLA_WEIGHT,
             Self::VfInfoList(_) => IFLA_VFINFO_LIST,
             Self::VfPorts(_) => IFLA_VF_PORTS,
             Self::PortSelf(_) => IFLA_PORT_SELF,
@@ -357,7 +354,6 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
     ) -> Result<Self, DecodeError> {
         let payload = buf.value();
         Ok(match buf.kind() {
-            IFLA_WEIGHT => Self::Weight(payload.to_vec()),
             IFLA_VFINFO_LIST => Self::VfInfoList(payload.to_vec()),
             IFLA_VF_PORTS => Self::VfPorts(payload.to_vec()),
             IFLA_PORT_SELF => Self::PortSelf(payload.to_vec()),

--- a/src/link/attribute.rs
+++ b/src/link/attribute.rs
@@ -30,7 +30,8 @@ const IFLA_QDISC: u16 = 6;
 const IFLA_STATS: u16 = 7;
 // No kernel is using IFLA_COST
 // const IFLA_COST: u16 = 8;
-const IFLA_PRIORITY: u16 = 9;
+// No kernel is using IFLA_PRIORITY
+// const IFLA_PRIORITY: u16 = 9;
 const IFLA_MASTER: u16 = 10;
 const IFLA_WIRELESS: u16 = 11;
 const IFLA_PROTINFO: u16 = 12;
@@ -90,7 +91,6 @@ const IFLA_DEVLINK_PORT: u16 = 62;
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[non_exhaustive]
 pub enum LinkAttribute {
-    Priority(Vec<u8>),
     Weight(Vec<u8>),
     VfInfoList(Vec<u8>),
     VfPorts(Vec<u8>),
@@ -157,8 +157,7 @@ pub enum LinkAttribute {
 impl Nla for LinkAttribute {
     fn value_len(&self) -> usize {
         match self {
-            Self::Priority(bytes)
-            | Self::Weight(bytes)
+            Self::Weight(bytes)
             | Self::VfInfoList(bytes)
             | Self::VfPorts(bytes)
             | Self::PortSelf(bytes)
@@ -220,8 +219,7 @@ impl Nla for LinkAttribute {
 
     fn emit_value(&self, buffer: &mut [u8]) {
         match self {
-            Self::Priority(bytes)
-            | Self::Weight(bytes)
+            Self::Weight(bytes)
             | Self::VfInfoList(bytes)
             | Self::VfPorts(bytes)
             | Self::PortSelf(bytes)
@@ -291,7 +289,6 @@ impl Nla for LinkAttribute {
 
     fn kind(&self) -> u16 {
         match self {
-            Self::Priority(_) => IFLA_PRIORITY,
             Self::Weight(_) => IFLA_WEIGHT,
             Self::VfInfoList(_) => IFLA_VFINFO_LIST,
             Self::VfPorts(_) => IFLA_VF_PORTS,
@@ -360,7 +357,6 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
     ) -> Result<Self, DecodeError> {
         let payload = buf.value();
         Ok(match buf.kind() {
-            IFLA_PRIORITY => Self::Priority(payload.to_vec()),
             IFLA_WEIGHT => Self::Weight(payload.to_vec()),
             IFLA_VFINFO_LIST => Self::VfInfoList(payload.to_vec()),
             IFLA_VF_PORTS => Self::VfPorts(payload.to_vec()),


### PR DESCRIPTION
Removed these entries of `LinkAttribute` as they are not used by linux Kernel
6.5.8:

 * `LinkAttribute::Pad`
 * `LinkAttribute::Weight`
 * `LinkAttribute::Priority`