### PR TITLE
New release 0.18.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,18 @@
 # Changelog
+## [0.18.0] - 2023-12-04
+### Breaking changes
+
+ - MASSIVE changes to API in order to 1.0 preparation. Please check
+   document or code for detail. Sorry for the inconvenience.
+
+### New features
+ - Support HSR interface. (37f9c5c)
+
+### Bug fixes
+ - vxlan: Do not fail on unknown option. (2457bdf)
+ - bond: Do not fail on unknown option. (acac109)
+ - vlan: Do not fail on unknown option. (1617948)
+
 ## [0.17.1] - 2023-08-30
 ### Breaking changes
  - N/A

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-packet-route"
-version = "0.17.1"
+version = "0.18.0"
 edition = "2018"
 
 homepage = "https://github.com/rust-netlink/netlink-packet-route"

--- a/README.md
+++ b/README.md
@@ -40,16 +40,21 @@ crate directly.
    changed netlink attribute. To capture the netlink raw bytes, you may use
    tcpdump/wireshark again the `nlmon` interface. For example:
 
- * The integration test(play with linux kernel netlink interface) should be
-   placed into `rtnetlink` crate. Current(netlink-packet-route) crate should
-   only unit test case only.
-
 ```bash
 modprobe nlmon
 ip link add nl0 type nlmon
 ip link set nl0 up
 tcpdump -i nl0 -w netlink_capture_file.cap
+# Then use wireshark to open this `netlink_capture_file.cap`
+# Find out the packet you are interested,
+# right click -> "Copy" -> "...as Hex Dump".
+# You may use https://github.com/cathay4t/hex_to_rust to convert this
+# hexdump to rust u8 array
 ```
+ * The integration test(play with linux kernel netlink interface) should be
+   placed into `rtnetlink` crate. Current(netlink-packet-route) crate should
+   only unit test case only.
+
 
  * For certain netlink message which cannot captured by nlmon, please use
    Rust Debug and explain every bits in comment.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,4 @@
+ * Only tc has unparsed `Vec<u8>` left.
+ * Still has many flags not converted into `Vec<enum>`.
+ * Many place holders in `link::InfoData`.
+ * Missing unit test cases.

--- a/src/link/header.rs
+++ b/src/link/header.rs
@@ -59,7 +59,7 @@ pub struct LinkHeader {
     /// Link index.
     pub index: u32,
     /// Link type. It should be set to one of the `ARPHRD_*`
-    /// constants. The most common value is [ALinkLayerType::ETHER] for
+    /// constants. The most common value is [LinkLayerType::Ether] for
     /// Ethernet.
     /// The LinkLayerType has `From<u16>` and `From<LinkLayerType> for u16`
     /// implemented.

--- a/src/route/flags.rs
+++ b/src/route/flags.rs
@@ -15,8 +15,6 @@ const RTM_F_OFFLOAD: u32 = 0x4000;
 const RTM_F_TRAP: u32 = 0x8000;
 const RTM_F_OFFLOAD_FAILED: u32 = 0x20000000;
 
-/// Flags that can be set in a `RTM_GETROUTE`
-/// ([`RouteNetlinkMessage::GetRoute`]) message.
 #[derive(Clone, Eq, PartialEq, Debug, Copy)]
 #[non_exhaustive]
 pub enum RouteFlag {

--- a/src/route/header.rs
+++ b/src/route/header.rs
@@ -35,8 +35,8 @@ impl<'a, T: AsRef<[u8]> + ?Sized> RouteMessageBuffer<&'a T> {
 /// messages headers.
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub struct RouteHeader {
-    /// Address family of the route: either [AddressFamily::Ipv4] for IPv4,
-    /// or [AddressFamily::Ipv6] for IPv6.
+    /// Address family of the route: either [AddressFamily::Inet] for IPv4,
+    /// or [AddressFamily::Inet6] for IPv6.
     pub address_family: AddressFamily,
     /// Prefix length of the destination subnet.
     pub destination_prefix_length: u8,

--- a/src/rule/attribute.rs
+++ b/src/rule/attribute.rs
@@ -50,7 +50,7 @@ pub enum RuleAttribute {
     Source(IpAddr),
     /// input interface name
     Iifname(String),
-    /// The priority number of another rule for [RuleAction::Goto]
+    /// The priority number of another rule for [super::RuleAction::Goto]
     Goto(u32),
     Priority(u32),
     FwMark(u32),

--- a/src/rule/flags.rs
+++ b/src/rule/flags.rs
@@ -7,8 +7,6 @@ const FIB_RULE_IIF_DETACHED: u32 = 0x00000008;
 const FIB_RULE_DEV_DETACHED: u32 = FIB_RULE_IIF_DETACHED;
 const FIB_RULE_OIF_DETACHED: u32 = 0x00000010;
 
-/// Flags that can be set in a `RTM_GETROUTE`
-/// ([`RuleNetlinkMessage::GetRule`]) message.
 #[derive(Clone, Eq, PartialEq, Debug, Copy)]
 #[non_exhaustive]
 pub enum RuleFlag {


### PR DESCRIPTION
=== Breaking changes

 - MASSIVE changes to API in order to 1.0 preparation. Please check
   document or code for detail. Sorry for the inconvenience.

=== New features
 - Support HSR interface. (37f9c5c)

=== Bug fixes
 - vxlan: Do not fail on unknown option. (2457bdf)
 - bond: Do not fail on unknown option. (acac109)
 - vlan: Do not fail on unknown option. (1617948)