### PR TITLE
rule: Fix crash on RuleFlag of `attempt to subtract with overflow`

### DIFF
--- a/src/rule/flags.rs
+++ b/src/rule/flags.rs
@@ -19,12 +19,11 @@ pub enum RuleFlag {
     Other(u32),
 }
 
-const ALL_RULE_FLAGS: [RuleFlag; 6] = [
+const ALL_RULE_FLAGS: [RuleFlag; 5] = [
     RuleFlag::Permanent,
     RuleFlag::Invert,
     RuleFlag::Unresolved,
     RuleFlag::IifDetached,
-    RuleFlag::DevDetached,
     RuleFlag::OifDetached,
 ];
 


### PR DESCRIPTION
The `RuleFlag::DevDetached` is equal to `RuleFlag::IifDetached`, hence
only one of them should be listed in search list of flags.