### PR TITLE
prefix: add support for RTM_NEWPREFIX

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod link;
 pub mod neighbour;
 pub mod neighbour_table;
 pub mod nsid;
+pub mod prefix;
 pub mod route;
 pub mod rule;
 pub mod tc;

--- a/src/prefix/attribute.rs
+++ b/src/prefix/attribute.rs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+
+use std::net::Ipv6Addr;
+
+use anyhow::Context;
+use netlink_packet_utils::{
+    nla::{self, DefaultNla, NlaBuffer},
+    traits::Parseable,
+    DecodeError, Emitable,
+};
+
+use super::cache_info::{CacheInfo, CacheInfoBuffer};
+
+const PREFIX_ADDRESS: u16 = 1;
+const PREFIX_CACHEINFO: u16 = 2;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum PrefixAttribute {
+    Address(Ipv6Addr),
+    CacheInfo(CacheInfo),
+    Other(DefaultNla),
+}
+
+impl nla::Nla for PrefixAttribute {
+    fn value_len(&self) -> usize {
+        match *self {
+            Self::Address(_) => 16,
+            Self::CacheInfo(ref cache_info) => cache_info.buffer_len(),
+            Self::Other(ref attr) => attr.value_len(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match *self {
+            Self::Address(ref addr) => buffer.copy_from_slice(&addr.octets()),
+            Self::CacheInfo(ref cache_info) => cache_info.emit(buffer),
+            Self::Other(ref attr) => attr.emit_value(buffer),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match *self {
+            Self::Address(_) => PREFIX_ADDRESS,
+            Self::CacheInfo(_) => PREFIX_CACHEINFO,
+            Self::Other(ref nla) => nla.kind(),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
+    for PrefixAttribute
+{
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let payload = buf.value();
+        match buf.kind() {
+            PREFIX_ADDRESS => {
+                if let Ok(payload) = TryInto::<[u8; 16]>::try_into(payload) {
+                    Ok(Self::Address(Ipv6Addr::from(payload)))
+                } else {
+                    Err(DecodeError::from(format!("Invalid PREFIX_ADDRESS, unexpected payload length: {:?}", payload)))
+                }
+            }
+            PREFIX_CACHEINFO => Ok(Self::CacheInfo(
+                CacheInfo::parse(&CacheInfoBuffer::new(payload)).context(
+                    format!("Invalid PREFIX_CACHEINFO: {:?}", payload),
+                )?,
+            )),
+            _ => Ok(Self::Other(DefaultNla::parse(buf)?)),
+        }
+    }
+}

--- a/src/prefix/cache_info.rs
+++ b/src/prefix/cache_info.rs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+
+use netlink_packet_utils::{traits::Parseable, DecodeError, Emitable};
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+#[non_exhaustive]
+pub struct CacheInfo {
+    pub preferred_time: u32,
+    pub valid_time: u32,
+}
+
+const CACHE_INFO_LEN: usize = 8;
+
+buffer!(CacheInfoBuffer(CACHE_INFO_LEN) {
+    preferred_time: (u32, 0..4),
+    valid_time: (u32, 4..8),
+});
+
+impl<T: AsRef<[u8]>> Parseable<CacheInfoBuffer<T>> for CacheInfo {
+    fn parse(buf: &CacheInfoBuffer<T>) -> Result<Self, DecodeError> {
+        Ok(CacheInfo {
+            preferred_time: buf.preferred_time(),
+            valid_time: buf.valid_time(),
+        })
+    }
+}
+
+impl Emitable for CacheInfo {
+    fn buffer_len(&self) -> usize {
+        CACHE_INFO_LEN
+    }
+
+    fn emit(&self, buffer: &mut [u8]) {
+        let mut buffer = CacheInfoBuffer::new(buffer);
+        buffer.set_preferred_time(self.preferred_time);
+        buffer.set_valid_time(self.valid_time);
+    }
+}

--- a/src/prefix/header.rs
+++ b/src/prefix/header.rs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+
+use netlink_packet_utils::{
+    nla::{NlaBuffer, NlasIterator},
+    DecodeError, Emitable,
+};
+
+const PREFIX_HEADER_LEN: usize = 12;
+
+buffer!(PrefixMessageBuffer(PREFIX_HEADER_LEN) {
+    prefix_family: (u8, 0),
+    pad1: (u8, 1),
+    pad2: (u16, 2..4),
+    ifindex: (i32, 4..8),
+    prefix_type: (u8, 8),
+    prefix_len: (u8, 9),
+    flags: (u8, 10),
+    pad3: (u8, 11),
+    payload: (slice, PREFIX_HEADER_LEN..),
+});
+
+impl<'a, T: AsRef<[u8]> + ?Sized> PrefixMessageBuffer<&'a T> {
+    pub fn nlas(
+        &self,
+    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
+        NlasIterator::new(self.payload())
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
+pub struct PrefixHeader {
+    pub prefix_family: u8,
+    pub ifindex: i32,
+    pub prefix_type: u8,
+    pub prefix_len: u8,
+    pub flags: u8,
+}
+
+impl Emitable for PrefixHeader {
+    fn buffer_len(&self) -> usize {
+        PREFIX_HEADER_LEN
+    }
+
+    fn emit(&self, buffer: &mut [u8]) {
+        let mut packet = PrefixMessageBuffer::new(buffer);
+        packet.set_prefix_family(self.prefix_family);
+        packet.set_ifindex(self.ifindex);
+        packet.set_prefix_type(self.prefix_type);
+        packet.set_prefix_len(self.prefix_len);
+        packet.set_flags(self.flags);
+    }
+}

--- a/src/prefix/message.rs
+++ b/src/prefix/message.rs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+
+use anyhow::Context;
+
+use netlink_packet_utils::{
+    traits::{Emitable, Parseable},
+    DecodeError,
+};
+
+use super::{
+    attribute::PrefixAttribute,
+    header::{PrefixHeader, PrefixMessageBuffer},
+};
+
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
+pub struct PrefixMessage {
+    pub header: PrefixHeader,
+    pub attributes: Vec<PrefixAttribute>,
+}
+
+impl Emitable for PrefixMessage {
+    fn buffer_len(&self) -> usize {
+        self.header.buffer_len() + self.attributes.as_slice().buffer_len()
+    }
+
+    fn emit(&self, buffer: &mut [u8]) {
+        self.header.emit(buffer);
+        self.attributes
+            .as_slice()
+            .emit(&mut buffer[self.header.buffer_len()..]);
+    }
+}
+
+impl<T: AsRef<[u8]>> Parseable<PrefixMessageBuffer<T>> for PrefixHeader {
+    fn parse(buf: &PrefixMessageBuffer<T>) -> Result<Self, DecodeError> {
+        Ok(Self {
+            prefix_family: buf.prefix_family(),
+            ifindex: buf.ifindex(),
+            prefix_type: buf.prefix_type(),
+            prefix_len: buf.prefix_len(),
+            flags: buf.flags(),
+        })
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + 'a> Parseable<PrefixMessageBuffer<&'a T>>
+    for PrefixMessage
+{
+    fn parse(buf: &PrefixMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
+        Ok(Self {
+            header: PrefixHeader::parse(buf)
+                .context("failed to parse prefix message header")?,
+            attributes: Vec::<PrefixAttribute>::parse(buf)
+                .context("failed to parse prefix message attributes")?,
+        })
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + 'a> Parseable<PrefixMessageBuffer<&'a T>>
+    for Vec<PrefixAttribute>
+{
+    fn parse(buf: &PrefixMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let mut nlas = vec![];
+        for nla_buf in buf.nlas() {
+            nlas.push(PrefixAttribute::parse(&nla_buf?)?);
+        }
+        Ok(nlas)
+    }
+}

--- a/src/prefix/mod.rs
+++ b/src/prefix/mod.rs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+
+mod attribute;
+mod cache_info;
+mod header;
+mod message;
+#[cfg(test)]
+mod tests;
+
+pub use header::PrefixMessageBuffer;
+pub use message::PrefixMessage;

--- a/src/prefix/tests.rs
+++ b/src/prefix/tests.rs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+
+use std::{net::Ipv6Addr, str::FromStr};
+
+use netlink_packet_utils::{Emitable, Parseable};
+
+use crate::prefix::{
+    attribute::PrefixAttribute, cache_info::CacheInfo, header::PrefixHeader,
+    PrefixMessage, PrefixMessageBuffer,
+};
+
+#[test]
+fn test_new_prefix() {
+    #[rustfmt::skip]
+    let data = vec![
+        // prefixmsg
+        // AF_INET6 + padding
+        0x0a, 0x00, 0x00, 0x00,
+        // ifindex
+        0x02, 0x00, 0x00, 0x00,
+        // type, prefix length, flags, padding
+        0x03, 0x40, 0x01, 0x00,
+        // PREFIX_ADDRESS attribute
+        0x14, 0x00, 0x01, 0x00,
+        0xfc, 0x00, 0x0a, 0x0a, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+        // PREFIX_CACHEINFO attribute
+        0x0c, 0x00, 0x02, 0x00,
+        0xff, 0xff, 0xff, 0xfa,
+        0xff, 0xff, 0xff, 0xff,
+    ];
+    let actual = PrefixMessage::parse(&PrefixMessageBuffer::new(&data))
+        .expect("Generated PrefixMessage");
+
+    let expected = PrefixMessage {
+        header: PrefixHeader {
+            prefix_family: libc::AF_INET6 as u8,
+            ifindex: 2,
+            prefix_type: 3,
+            prefix_len: 64,
+            flags: 1,
+        },
+        attributes: vec![
+            PrefixAttribute::Address(
+                Ipv6Addr::from_str("fc00:a0a::1").expect("Ipv6Addr"),
+            ),
+            PrefixAttribute::CacheInfo(CacheInfo {
+                preferred_time: 0xfaffffff,
+                valid_time: 0xffffffff,
+            }),
+        ],
+    };
+
+    assert_eq!(expected, actual);
+
+    let mut buf = vec![0; 44];
+    expected.emit(&mut buf);
+    assert_eq!(data, buf);
+}


### PR DESCRIPTION
I implemented this against an older version of netlink-packet-route (0.7.0) some time ago, and only recently got around to rebasing and upstreaming it. Hopefully the diffs are consistent with the intervening changes to the crate structure and patterns :-).

