### PR TITLE
Add `Default` macro for non-exhaustive types

### DIFF
--- a/src/tc/qdiscs/fq_codel.rs
+++ b/src/tc/qdiscs/fq_codel.rs
@@ -90,7 +90,7 @@ impl Emitable for TcFqCodelXstats {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
 #[non_exhaustive]
 pub struct TcFqCodelQdStats {
     pub maxpacket: u32,
@@ -151,7 +151,7 @@ impl Emitable for TcFqCodelQdStats {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
 #[non_exhaustive]
 pub struct TcFqCodelClStats {
     deficit: i32,

--- a/src/tc/stats/basic.rs
+++ b/src/tc/stats/basic.rs
@@ -6,7 +6,7 @@ use netlink_packet_utils::{
 };
 
 /// Byte/Packet throughput statistics
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
 #[non_exhaustive]
 pub struct TcStatsBasic {
     /// number of seen bytes

--- a/src/tc/stats/compat.rs
+++ b/src/tc/stats/compat.rs
@@ -6,7 +6,7 @@ use netlink_packet_utils::{
 };
 
 /// Generic queue statistics
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
 #[non_exhaustive]
 pub struct TcStats {
     /// Number of enqueued bytes

--- a/src/tc/stats/queue.rs
+++ b/src/tc/stats/queue.rs
@@ -6,7 +6,7 @@ use netlink_packet_utils::{
 };
 
 /// Queuing statistics
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
 #[non_exhaustive]
 pub struct TcStatsQueue {
     /// queue length


### PR DESCRIPTION
Adding `Default` macros for a subset of the `non_exhaustive` structs.

Need this in order to write unit tests when using this library. Without `Default` macro, creating this struct is extremely tedious. We cannot use `struct` expression to create them as it results in the below error:
> error[E0639]: cannot create non-exhaustive struct using struct expression

It might be worthwhile to consider if the lib should drop `#[non_exhaustive]` macro altogether because I do not know if the macro is a right choice for a public facing library <sup>[1] [2]</sup>.

[1]: https://doc.rust-lang.org/reference/attributes/type_system.html
[2]: https://github.com/rust-lang/lang-team/issues/143