### PR TITLE
New release 0.19.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,17 @@
 # Changelog
+## [0.19.0] - 2024-01-31
+### Breaking changes
+
+ - `InfoBridge::RootId` and `InfoBridge::BridgeId` changed. (fb497b3)
+
+### New features
+ - Support bridge bond port information. (faffa52)
+ - Support RTM_NEWPREFIX. (2a43e1c)
+ - Add `Default` derive to `TcFqCodelQdStats` and etc. (e21122e)
+
+### Bug fixes
+ - N/A
+
 ## [0.18.1] - 2023-12-05
 ### Breaking changes
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-packet-route"
-version = "0.18.1"
+version = "0.19.0"
 edition = "2021"
 
 homepage = "https://github.com/rust-netlink/netlink-packet-route"


### PR DESCRIPTION
=== Breaking changes

 - `InfoBridge::RootId` and `InfoBridge::BridgeId` changed. (fb497b3)

=== New features
 - Support bridge bond port information. (faffa52)
 - Support RTM_NEWPREFIX. (2a43e1c)
 - Add `Default` derive to `TcFqCodelQdStats` and etc. (e21122e)

=== Bug fixes
 - N/A