### PR TITLE
link: Check buffer length when parsing NLAs

### DIFF
--- a/src/link/link_info/vlan.rs
+++ b/src/link/link_info/vlan.rs
@@ -113,10 +113,17 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
         use VlanQosMapping::*;
         let payload = buf.value();
         Ok(match buf.kind() {
-            IFLA_VLAN_QOS_MAPPING => Mapping(
-                parse_u32(&payload[..4]).context("expected u32 from value")?,
-                parse_u32(&payload[4..]).context("expected u32 to value")?,
-            ),
+            IFLA_VLAN_QOS_MAPPING => {
+                if payload.len() != 8 {
+                    return Err("invalid IFLA_VLAN_QOS_MAPPING value".into());
+                }
+                Mapping(
+                    parse_u32(&payload[..4])
+                        .context("expected u32 from value")?,
+                    parse_u32(&payload[4..])
+                        .context("expected u32 to value")?,
+                )
+            }
             kind => Other(DefaultNla::parse(buf).context(format!(
                 "unknown NLA type {kind} for VLAN QoS mapping"
             ))?),


### PR DESCRIPTION
Verify the NlaBuffer has the expected size when parsing the `IFLA_XDP_ATTACHED` and `IFLA_VLAN_QOS_MAPPING` interface NLAs. This prevents a panic opportunity when attempting to parse malformed interface NLAs.