### PR TITLE
fix clippy warnings

### DIFF
--- a/src/link/af_spec/bridge.rs
+++ b/src/link/af_spec/bridge.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-use std::convert::TryFrom;
-
 use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
 use netlink_packet_utils::{

--- a/src/link/xdp.rs
+++ b/src/link/xdp.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use std::{convert::TryFrom, mem::size_of, os::fd::RawFd};
+use std::{mem::size_of, os::fd::RawFd};
 
 use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};


### PR DESCRIPTION
```
   --> src/link/xdp.rs:3:11
    |
3   | use std::{convert::TryFrom, mem::size_of, os::fd::RawFd};
    |           ^^^^^^^^^^^^^^^^
    |
   ::: /home/me/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/prelude/mod.rs:129:13
    |
129 |     pub use core::prelude::rust_2021::*;
    |             ------------------------ the item `TryFrom` is already defined here
```