### PR TITLE
Convert `InfoBond::Mode` into an enum.

### DIFF
--- a/src/link/link_info/mod.rs
+++ b/src/link/link_info/mod.rs
@@ -27,7 +27,7 @@ mod vxlan;
 mod xfrm;
 mod xstats;
 
-pub use self::bond::{BondAdInfo, InfoBond};
+pub use self::bond::{BondAdInfo, BondMode, InfoBond};
 pub use self::bond_port::{BondPortState, InfoBondPort, MiiStatus};
 pub use self::bridge::{
     BridgeId, BridgeIdBuffer, BridgeQuerierState, InfoBridge,

--- a/src/link/mod.rs
+++ b/src/link/mod.rs
@@ -38,7 +38,7 @@ pub use self::ext_mask::LinkExtentMask;
 pub use self::header::{LinkHeader, LinkMessageBuffer};
 pub use self::link_flag::LinkFlags;
 pub use self::link_info::{
-    BondAdInfo, BondPortState, BridgeId, BridgeIdBuffer,
+    BondAdInfo, BondMode, BondPortState, BridgeId, BridgeIdBuffer,
     BridgePortMulticastRouter, BridgePortState, BridgeQuerierState,
     HsrProtocol, InfoBond, InfoBondPort, InfoBridge, InfoBridgePort, InfoData,
     InfoGreTap, InfoGreTap6, InfoGreTun, InfoGreTun6, InfoGtp, InfoHsr,

--- a/src/link/tests/bond.rs
+++ b/src/link/tests/bond.rs
@@ -4,9 +4,9 @@ use netlink_packet_utils::{Emitable, Parseable};
 
 use crate::link::link_flag::LinkFlags;
 use crate::link::{
-    BondPortState, InfoBond, InfoBondPort, InfoData, InfoKind, InfoPortData,
-    InfoPortKind, LinkAttribute, LinkHeader, LinkInfo, LinkLayerType,
-    LinkMessage, LinkMessageBuffer, MiiStatus,
+    BondMode, BondPortState, InfoBond, InfoBondPort, InfoData, InfoKind,
+    InfoPortData, InfoPortKind, LinkAttribute, LinkHeader, LinkInfo,
+    LinkLayerType, LinkMessage, LinkMessageBuffer, MiiStatus,
 };
 use crate::AddressFamily;
 
@@ -56,7 +56,7 @@ fn test_bond_link_info() {
         attributes: vec![LinkAttribute::LinkInfo(vec![
             LinkInfo::Kind(InfoKind::Bond),
             LinkInfo::Data(InfoData::Bond(vec![
-                InfoBond::Mode(0),
+                InfoBond::Mode(BondMode::BalanceRr),
                 InfoBond::MiiMon(0),
                 InfoBond::UpDelay(0),
                 InfoBond::DownDelay(0),


### PR DESCRIPTION
Closes #78

---

@cathay4t Is there an explicit  design decision regarding adding `Other(...)` variants to this kind of enum for forward compatibility?
Saw this behaviour in other enums, such as `AddressScope`, but it also has user-defined values.