### PR TITLE
Make RouteAddress::parse public

### DIFF
--- a/src/route/address.rs
+++ b/src/route/address.rs
@@ -32,7 +32,7 @@ impl From<IpAddr> for RouteAddress {
 }
 
 impl RouteAddress {
-    pub(crate) fn parse(
+    pub fn parse(
         address_family: AddressFamily,
         payload: &[u8],
     ) -> Result<Self, DecodeError> {


### PR DESCRIPTION
This is needed as we want to parse it from a byte array and family.