### PR TITLE
Add back hash/Ord support

### DIFF
--- a/src/address_family_linux.rs
+++ b/src/address_family_linux.rs
@@ -6,7 +6,7 @@ const AF_SMC: u8 = 43;
 const AF_XDP: u8 = 44;
 const AF_MCTP: u8 = 45;
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Default, Hash)]
 #[non_exhaustive]
 pub enum AddressFamily {
     #[default]

--- a/src/address_family_linux.rs
+++ b/src/address_family_linux.rs
@@ -6,7 +6,7 @@ const AF_SMC: u8 = 43;
 const AF_XDP: u8 = 44;
 const AF_MCTP: u8 = 45;
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Default, Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Default, Hash, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum AddressFamily {
     #[default]

--- a/src/route/flags.rs
+++ b/src/route/flags.rs
@@ -16,7 +16,7 @@ const RTM_F_TRAP: u32 = 0x8000;
 const RTM_F_OFFLOAD_FAILED: u32 = 0x20000000;
 
 bitflags! {
-    #[derive(Clone, Eq, PartialEq, Debug, Copy, Default)]
+    #[derive(Clone, Eq, PartialEq, Debug, Copy, Default, Hash)]
     #[non_exhaustive]
     pub struct RouteFlags: u32 {
         const Dead = RTNH_F_DEAD as u32;

--- a/src/route/header.rs
+++ b/src/route/header.rs
@@ -33,7 +33,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> RouteMessageBuffer<&'a T> {
 
 /// High level representation of `RTM_GETROUTE`, `RTM_ADDROUTE`, `RTM_DELROUTE`
 /// messages headers.
-#[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[derive(Debug, PartialEq, Eq, Clone, Default, Hash)]
 pub struct RouteHeader {
     /// Address family of the route: either [AddressFamily::Inet] for IPv4,
     /// or [AddressFamily::Inet6] for IPv6.
@@ -98,7 +98,7 @@ impl Emitable for RouteHeader {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 #[non_exhaustive]
 pub enum RouteProtocol {
     Unspec,
@@ -274,7 +274,7 @@ const RT_SCOPE_LINK: u8 = 253;
 const RT_SCOPE_HOST: u8 = 254;
 const RT_SCOPE_NOWHERE: u8 = 255;
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 #[non_exhaustive]
 pub enum RouteScope {
     Universe,
@@ -330,7 +330,7 @@ impl std::fmt::Display for RouteScope {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 #[non_exhaustive]
 pub enum RouteType {
     /// Unknown


### PR DESCRIPTION
Hash derives were previously removed from these structs. Add it back.