### PR TITLE
Use thiserror for error types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ byteorder = "1.3.2"
 libc = "0.2.66"
 log = { version = "0.4.20", features = ["std"] }
 netlink-packet-core = { version = "0.7.0" }
-netlink-packet-utils = { version = "0.5.2" }
+netlink-packet-utils = { path = "../netlink-packet-utils" }
+thiserror = "1.0.58"
 
 [[example]]
 name = "dump_packet_links"

--- a/src/address/attribute.rs
+++ b/src/address/attribute.rs
@@ -110,6 +110,8 @@ impl Nla for AddressAttribute {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for AddressAttribute
 {
+    type Error = DecodeError;
+
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();
         Ok(match buf.kind() {

--- a/src/address/cache_info.rs
+++ b/src/address/cache_info.rs
@@ -24,6 +24,8 @@ buffer!(CacheInfoBuffer(ADDRESSS_CACHE_INFO_LEN) {
 });
 
 impl<T: AsRef<[u8]>> Parseable<CacheInfoBuffer<T>> for CacheInfo {
+    type Error = DecodeError;
+
     fn parse(buf: &CacheInfoBuffer<T>) -> Result<Self, DecodeError> {
         Ok(CacheInfo {
             ifa_preferred: buf.ifa_preferred(),

--- a/src/address/error.rs
+++ b/src/address/error.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+
+use netlink_packet_utils::{nla::NlaError, DecodeError};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum AddressError {
+    #[error(
+        "Invalid {kind}, got unexpected length of payload: {payload_length}"
+    )]
+    ParseAttributeInvalidPayload {
+        kind: &'static str,
+        payload_length: usize,
+    },
+
+    #[error("Invalid {kind} value")]
+    ParseAttribute {
+        kind: &'static str,
+        err: DecodeError,
+    },
+
+    #[error("unknown NLA {kind}")]
+    ParseUnknownNLA { kind: u16, err: DecodeError },
+
+    #[error(transparent)]
+    NlaAttribute(#[from] NlaError),
+
+    #[error("Faield to parse address buffer: {0:?}")]
+    FailedBufferInit(DecodeError),
+}

--- a/src/address/message.rs
+++ b/src/address/message.rs
@@ -76,6 +76,7 @@ impl Emitable for AddressMessage {
 }
 
 impl<T: AsRef<[u8]>> Parseable<AddressMessageBuffer<T>> for AddressHeader {
+    type Error = DecodeError;
     fn parse(buf: &AddressMessageBuffer<T>) -> Result<Self, DecodeError> {
         Ok(Self {
             family: buf.family().into(),
@@ -90,6 +91,7 @@ impl<T: AsRef<[u8]>> Parseable<AddressMessageBuffer<T>> for AddressHeader {
 impl<'a, T: AsRef<[u8]> + 'a> Parseable<AddressMessageBuffer<&'a T>>
     for AddressMessage
 {
+    type Error = DecodeError;
     fn parse(buf: &AddressMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
         Ok(AddressMessage {
             header: AddressHeader::parse(buf)
@@ -103,6 +105,7 @@ impl<'a, T: AsRef<[u8]> + 'a> Parseable<AddressMessageBuffer<&'a T>>
 impl<'a, T: AsRef<[u8]> + 'a> Parseable<AddressMessageBuffer<&'a T>>
     for Vec<AddressAttribute>
 {
+    type Error = DecodeError;
     fn parse(buf: &AddressMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
         let mut attributes = vec![];
         for nla_buf in buf.attributes() {

--- a/src/address/message.rs
+++ b/src/address/message.rs
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
+use crate::{
+    address::{
+        AddressAttribute, AddressError, AddressHeaderFlags, AddressScope,
+    },
+    AddressFamily,
+};
 use netlink_packet_utils::{
-    nla::{NlaBuffer, NlasIterator},
+    nla::{NlaBuffer, NlaError, NlasIterator},
     traits::{Emitable, Parseable},
     DecodeError,
-};
-
-use crate::{
-    address::{AddressAttribute, AddressHeaderFlags, AddressScope},
-    AddressFamily,
 };
 
 const ADDRESS_HEADER_LEN: usize = 8;
@@ -26,7 +26,7 @@ buffer!(AddressMessageBuffer(ADDRESS_HEADER_LEN) {
 impl<'a, T: AsRef<[u8]> + ?Sized> AddressMessageBuffer<&'a T> {
     pub fn attributes(
         &self,
-    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
+    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, NlaError>> {
         NlasIterator::new(self.payload())
     }
 }
@@ -76,8 +76,8 @@ impl Emitable for AddressMessage {
 }
 
 impl<T: AsRef<[u8]>> Parseable<AddressMessageBuffer<T>> for AddressHeader {
-    type Error = DecodeError;
-    fn parse(buf: &AddressMessageBuffer<T>) -> Result<Self, DecodeError> {
+    type Error = ();
+    fn parse(buf: &AddressMessageBuffer<T>) -> Result<Self, ()> {
         Ok(Self {
             family: buf.family().into(),
             prefix_len: buf.prefix_len(),
@@ -91,13 +91,12 @@ impl<T: AsRef<[u8]>> Parseable<AddressMessageBuffer<T>> for AddressHeader {
 impl<'a, T: AsRef<[u8]> + 'a> Parseable<AddressMessageBuffer<&'a T>>
     for AddressMessage
 {
-    type Error = DecodeError;
-    fn parse(buf: &AddressMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
+    type Error = AddressError;
+    fn parse(buf: &AddressMessageBuffer<&'a T>) -> Result<Self, AddressError> {
         Ok(AddressMessage {
-            header: AddressHeader::parse(buf)
-                .context("failed to parse address message header")?,
-            attributes: Vec::<AddressAttribute>::parse(buf)
-                .context("failed to parse address message NLAs")?,
+            // ok to unwrap, we never fail parsing the header.
+            header: AddressHeader::parse(buf).unwrap(),
+            attributes: Vec::<AddressAttribute>::parse(buf)?,
         })
     }
 }
@@ -105,8 +104,8 @@ impl<'a, T: AsRef<[u8]> + 'a> Parseable<AddressMessageBuffer<&'a T>>
 impl<'a, T: AsRef<[u8]> + 'a> Parseable<AddressMessageBuffer<&'a T>>
     for Vec<AddressAttribute>
 {
-    type Error = DecodeError;
-    fn parse(buf: &AddressMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
+    type Error = AddressError;
+    fn parse(buf: &AddressMessageBuffer<&'a T>) -> Result<Self, AddressError> {
         let mut attributes = vec![];
         for nla_buf in buf.attributes() {
             attributes.push(AddressAttribute::parse(&nla_buf?)?);

--- a/src/address/mod.rs
+++ b/src/address/mod.rs
@@ -4,6 +4,7 @@ mod addr_flags;
 mod addr_scope;
 mod attribute;
 mod cache_info;
+mod error;
 mod message;
 
 #[cfg(test)]
@@ -13,4 +14,5 @@ pub use self::addr_flags::{AddressFlags, AddressHeaderFlags};
 pub use self::addr_scope::AddressScope;
 pub use self::attribute::AddressAttribute;
 pub use self::cache_info::{CacheInfo, CacheInfoBuffer};
+pub use self::error::AddressError;
 pub use self::message::{AddressHeader, AddressMessage, AddressMessageBuffer};

--- a/src/link/af_spec/bridge.rs
+++ b/src/link/af_spec/bridge.rs
@@ -52,6 +52,7 @@ impl nla::Nla for AfSpecBridge {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for AfSpecBridge {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         use self::AfSpecBridge::*;
 
@@ -80,6 +81,7 @@ pub(crate) struct VecAfSpecBridge(pub(crate) Vec<AfSpecBridge>);
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for VecAfSpecBridge
 {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let mut nlas = vec![];
         let err = "Invalid AF_INET NLA for IFLA_AF_SPEC(AF_BRIDGE)";

--- a/src/link/af_spec/inet.rs
+++ b/src/link/af_spec/inet.rs
@@ -27,6 +27,7 @@ pub(crate) struct VecAfSpecInet(pub(crate) Vec<AfSpecInet>);
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for VecAfSpecInet
 {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let mut nlas = vec![];
         let err = "Invalid AF_INET NLA for IFLA_AF_SPEC(AF_UNSPEC)";
@@ -65,6 +66,7 @@ impl nla::Nla for AfSpecInet {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for AfSpecInet {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         use self::AfSpecInet::*;
 
@@ -162,6 +164,7 @@ pub struct InetDevConf {
 }
 
 impl<T: AsRef<[u8]>> Parseable<InetDevConfBuffer<T>> for InetDevConf {
+    type Error = DecodeError;
     fn parse(buf: &InetDevConfBuffer<T>) -> Result<Self, DecodeError> {
         Ok(Self {
             forwarding: buf.forwarding(),

--- a/src/link/af_spec/inet6.rs
+++ b/src/link/af_spec/inet6.rs
@@ -53,6 +53,7 @@ pub(crate) struct VecAfSpecInet6(pub(crate) Vec<AfSpecInet6>);
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for VecAfSpecInet6
 {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let mut nlas = vec![];
         let err = "Invalid AF_INET6 NLA for IFLA_AF_SPEC(AF_UNSPEC)";
@@ -111,6 +112,7 @@ impl Nla for AfSpecInet6 {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for AfSpecInet6 {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         use self::AfSpecInet6::*;
 

--- a/src/link/af_spec/inet6_cache.rs
+++ b/src/link/af_spec/inet6_cache.rs
@@ -24,6 +24,7 @@ buffer!(Inet6CacheInfoBuffer(LINK_INET6_CACHE_INFO_LEN) {
 });
 
 impl<T: AsRef<[u8]>> Parseable<Inet6CacheInfoBuffer<T>> for Inet6CacheInfo {
+    type Error = DecodeError;
     fn parse(buf: &Inet6CacheInfoBuffer<T>) -> Result<Self, DecodeError> {
         Ok(Self {
             max_reasm_len: buf.max_reasm_len(),

--- a/src/link/af_spec/inet6_devconf.rs
+++ b/src/link/af_spec/inet6_devconf.rs
@@ -72,6 +72,7 @@ buffer!(Inet6DevConfBuffer(LINK_INET6_DEV_CONF_LEN) {
 });
 
 impl<T: AsRef<[u8]>> Parseable<Inet6DevConfBuffer<T>> for Inet6DevConf {
+    type Error = DecodeError;
     fn parse(buf: &Inet6DevConfBuffer<T>) -> Result<Self, DecodeError> {
         Ok(Self {
             forwarding: buf.forwarding(),

--- a/src/link/af_spec/inet6_icmp.rs
+++ b/src/link/af_spec/inet6_icmp.rs
@@ -28,6 +28,7 @@ buffer!(Icmp6StatsBuffer(ICMP6_STATS_LEN) {
 });
 
 impl<T: AsRef<[u8]>> Parseable<Icmp6StatsBuffer<T>> for Icmp6Stats {
+    type Error = DecodeError;
     fn parse(buf: &Icmp6StatsBuffer<T>) -> Result<Self, DecodeError> {
         Ok(Self {
             num: buf.num(),

--- a/src/link/af_spec/inet6_stats.rs
+++ b/src/link/af_spec/inet6_stats.rs
@@ -88,6 +88,7 @@ pub struct Inet6Stats {
 }
 
 impl<T: AsRef<[u8]>> Parseable<Inet6StatsBuffer<T>> for Inet6Stats {
+    type Error = DecodeError;
     fn parse(buf: &Inet6StatsBuffer<T>) -> Result<Self, DecodeError> {
         Ok(Self {
             num: buf.num(),

--- a/src/link/af_spec/unspec.rs
+++ b/src/link/af_spec/unspec.rs
@@ -48,6 +48,7 @@ pub(crate) struct VecAfSpecUnspec(pub(crate) Vec<AfSpecUnspec>);
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for VecAfSpecUnspec
 {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let mut nlas = vec![];
         let err = "Invalid NLA for IFLA_AF_SPEC(AF_UNSPEC)";

--- a/src/link/attribute.rs
+++ b/src/link/attribute.rs
@@ -14,7 +14,7 @@ use netlink_packet_utils::{
 #[cfg(any(target_os = "linux", target_os = "fuchsia",))]
 use super::af_spec::VecAfSpecBridge;
 #[cfg(any(target_os = "linux", target_os = "fuchsia",))]
-use super::proto_info::VecLinkProtoInfoBridge;
+use super::proto_info::VecanhowLinkProtoInfoBridge;
 use super::{
     af_spec::VecAfSpecUnspec,
     buffer_tool::expand_buffer_if_small,
@@ -367,6 +367,7 @@ impl Nla for LinkAttribute {
 impl<'a, T: AsRef<[u8]> + ?Sized>
     ParseableParametrized<NlaBuffer<&'a T>, AddressFamily> for LinkAttribute
 {
+    type Error = DecodeError;
     fn parse_with_param(
         buf: &NlaBuffer<&'a T>,
         interface_family: AddressFamily,

--- a/src/link/down_reason.rs
+++ b/src/link/down_reason.rs
@@ -22,6 +22,7 @@ pub enum LinkProtocolDownReason {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for LinkProtocolDownReason
 {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();
         Ok(match buf.kind() {

--- a/src/link/event.rs
+++ b/src/link/event.rs
@@ -59,6 +59,7 @@ impl From<LinkEvent> for u32 {
 }
 
 impl<T: AsRef<[u8]> + ?Sized> Parseable<T> for LinkEvent {
+    type Error = DecodeError;
     fn parse(buf: &T) -> Result<Self, DecodeError> {
         Ok(LinkEvent::from(
             parse_u32(buf.as_ref()).context("invalid IFLA_EVENT value")?,

--- a/src/link/header.rs
+++ b/src/link/header.rs
@@ -86,6 +86,7 @@ impl Emitable for LinkHeader {
 }
 
 impl<T: AsRef<[u8]>> Parseable<LinkMessageBuffer<T>> for LinkHeader {
+    type Error = DecodeError;
     fn parse(buf: &LinkMessageBuffer<T>) -> Result<Self, DecodeError> {
         Ok(Self {
             interface_family: buf.interface_family().into(),

--- a/src/link/header.rs
+++ b/src/link/header.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 use netlink_packet_utils::{
-    nla::{NlaBuffer, NlasIterator},
+    nla::{NlaBuffer, NlaError, NlasIterator},
     traits::{Emitable, Parseable},
     DecodeError,
 };
@@ -25,7 +25,7 @@ buffer!(LinkMessageBuffer(LINK_HEADER_LEN) {
 impl<'a, T: AsRef<[u8]> + ?Sized> LinkMessageBuffer<&'a T> {
     pub fn attributes(
         &self,
-    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
+    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, NlaError>> {
         NlasIterator::new(self.payload())
     }
 }

--- a/src/link/link_info/bond.rs
+++ b/src/link/link_info/bond.rs
@@ -107,6 +107,7 @@ impl Nla for BondAdInfo {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for BondAdInfo {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();
         Ok(match buf.kind() {
@@ -426,6 +427,7 @@ impl Nla for InfoBond {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoBond {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();
         Ok(match buf.kind() {

--- a/src/link/link_info/bond_port.rs
+++ b/src/link/link_info/bond_port.rs
@@ -158,6 +158,7 @@ impl Nla for InfoBondPort {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoBondPort {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         use self::InfoBondPort::*;
         let payload = buf.value();

--- a/src/link/link_info/bridge.rs
+++ b/src/link/link_info/bridge.rs
@@ -305,6 +305,7 @@ impl Nla for InfoBridge {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoBridge {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();
         Ok(match buf.kind() {
@@ -530,6 +531,7 @@ buffer!(BridgeIdBuffer(BRIDGE_ID_LEN) {
 });
 
 impl<T: AsRef<[u8]> + ?Sized> Parseable<BridgeIdBuffer<&T>> for BridgeId {
+    type Error = DecodeError;
     fn parse(buf: &BridgeIdBuffer<&T>) -> Result<Self, DecodeError> {
         // Priority is encoded in big endian. From kernel's
         // net/bridge/br_netlink.c br_fill_info():
@@ -616,6 +618,7 @@ impl Nla for BridgeQuerierState {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for BridgeQuerierState
 {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         use self::BridgeQuerierState::*;
         let payload = buf.value();

--- a/src/link/link_info/bridge_port.rs
+++ b/src/link/link_info/bridge_port.rs
@@ -274,6 +274,7 @@ impl Nla for InfoBridgePort {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for InfoBridgePort
 {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();
 

--- a/src/link/link_info/gre.rs
+++ b/src/link/link_info/gre.rs
@@ -33,6 +33,7 @@ impl Nla for InfoGreTun {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoGreTun {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         #[allow(clippy::match_single_binding)]
         Ok(match buf.kind() {

--- a/src/link/link_info/gre6.rs
+++ b/src/link/link_info/gre6.rs
@@ -33,6 +33,7 @@ impl Nla for InfoGreTun6 {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoGreTun6 {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         #[allow(clippy::match_single_binding)]
         Ok(match buf.kind() {

--- a/src/link/link_info/gre_tap.rs
+++ b/src/link/link_info/gre_tap.rs
@@ -33,6 +33,7 @@ impl Nla for InfoGreTap {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoGreTap {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         #[allow(clippy::match_single_binding)]
         Ok(match buf.kind() {

--- a/src/link/link_info/gre_tap6.rs
+++ b/src/link/link_info/gre_tap6.rs
@@ -33,6 +33,8 @@ impl Nla for InfoGreTap6 {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoGreTap6 {
+    type Error = DecodeError;
+
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         #[allow(clippy::match_single_binding)]
         Ok(match buf.kind() {

--- a/src/link/link_info/gtp.rs
+++ b/src/link/link_info/gtp.rs
@@ -33,6 +33,7 @@ impl Nla for InfoGtp {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoGtp {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         #[allow(clippy::match_single_binding)]
         Ok(match buf.kind() {

--- a/src/link/link_info/hsr.rs
+++ b/src/link/link_info/hsr.rs
@@ -74,6 +74,7 @@ impl Nla for InfoHsr {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoHsr {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         use self::InfoHsr::*;
         let payload = buf.value();

--- a/src/link/link_info/info_port.rs
+++ b/src/link/link_info/info_port.rs
@@ -63,6 +63,7 @@ impl Nla for InfoPortKind {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoPortKind {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<InfoPortKind, DecodeError> {
         if buf.kind() != IFLA_INFO_PORT_KIND {
             return Err(format!(

--- a/src/link/link_info/info_port.rs
+++ b/src/link/link_info/info_port.rs
@@ -119,11 +119,17 @@ impl InfoPortData {
     ) -> Result<InfoPortData, DecodeError> {
         let port_data = match kind {
             InfoPortKind::Bond => NlasIterator::new(payload)
-                .map(|nla| nla.and_then(|nla| InfoBondPort::parse(&nla)))
+                .map(|nla| {
+                    let nla = nla?;
+                    InfoBondPort::parse(&nla)
+                })
                 .collect::<Result<Vec<_>, _>>()
                 .map(InfoPortData::BondPort),
             InfoPortKind::Bridge => NlasIterator::new(payload)
-                .map(|nla| nla.and_then(|nla| InfoBridgePort::parse(&nla)))
+                .map(|nla| {
+                    let nla = nla?;
+                    InfoBridgePort::parse(&nla)
+                })
                 .collect::<Result<Vec<_>, _>>()
                 .map(InfoPortData::BridgePort),
             InfoPortKind::Other(_) => Ok(InfoPortData::Other(payload.to_vec())),

--- a/src/link/link_info/infos.rs
+++ b/src/link/link_info/infos.rs
@@ -103,6 +103,7 @@ pub(crate) struct VecLinkInfo(pub(crate) Vec<LinkInfo>);
 // The downside is that this impl will not be exposed.
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for VecLinkInfo {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let mut nlas = Vec::new();
         let mut link_info_kind: Option<InfoKind> = None;
@@ -290,6 +291,7 @@ impl Nla for InfoKind {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoKind {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<InfoKind, DecodeError> {
         if buf.kind() != IFLA_INFO_KIND {
             return Err(format!(

--- a/src/link/link_info/ipoib.rs
+++ b/src/link/link_info/ipoib.rs
@@ -53,6 +53,7 @@ impl Nla for InfoIpoib {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoIpoib {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         use self::InfoIpoib::*;
         let payload = buf.value();

--- a/src/link/link_info/ipvlan.rs
+++ b/src/link/link_info/ipvlan.rs
@@ -49,6 +49,7 @@ impl Nla for InfoIpVlan {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoIpVlan {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         use self::InfoIpVlan::*;
         let payload = buf.value();
@@ -106,6 +107,7 @@ impl Nla for InfoIpVtap {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoIpVtap {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         use self::InfoIpVtap::*;
         let payload = buf.value();

--- a/src/link/link_info/mac_vlan.rs
+++ b/src/link/link_info/mac_vlan.rs
@@ -90,6 +90,7 @@ impl Nla for InfoMacVlan {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoMacVlan {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         use self::InfoMacVlan::*;
         let payload = buf.value();
@@ -210,6 +211,7 @@ impl Nla for InfoMacVtap {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoMacVtap {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         use self::InfoMacVtap::*;
         let payload = buf.value();

--- a/src/link/link_info/macsec.rs
+++ b/src/link/link_info/macsec.rs
@@ -213,6 +213,7 @@ impl Nla for InfoMacSec {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoMacSec {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         use self::InfoMacSec::*;
         let payload = buf.value();

--- a/src/link/link_info/sit.rs
+++ b/src/link/link_info/sit.rs
@@ -33,6 +33,7 @@ impl Nla for InfoSitTun {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoSitTun {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         #[allow(clippy::match_single_binding)]
         Ok(match buf.kind() {

--- a/src/link/link_info/tun.rs
+++ b/src/link/link_info/tun.rs
@@ -33,6 +33,7 @@ impl Nla for InfoTun {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoTun {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         #[allow(clippy::match_single_binding)]
         Ok(match buf.kind() {

--- a/src/link/link_info/veth.rs
+++ b/src/link/link_info/veth.rs
@@ -48,6 +48,7 @@ impl Nla for InfoVeth {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoVeth {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         use self::InfoVeth::*;
         let payload = buf.value();

--- a/src/link/link_info/vlan.rs
+++ b/src/link/link_info/vlan.rs
@@ -109,6 +109,7 @@ impl Nla for VlanQosMapping {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for VlanQosMapping
 {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         use VlanQosMapping::*;
         let payload = buf.value();
@@ -142,6 +143,7 @@ fn parse_mappings(payload: &[u8]) -> Result<Vec<VlanQosMapping>, DecodeError> {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoVlan {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         use self::InfoVlan::*;
         let payload = buf.value();

--- a/src/link/link_info/vrf.rs
+++ b/src/link/link_info/vrf.rs
@@ -45,6 +45,7 @@ impl Nla for InfoVrf {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoVrf {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         use self::InfoVrf::*;
         let payload = buf.value();

--- a/src/link/link_info/vti.rs
+++ b/src/link/link_info/vti.rs
@@ -33,6 +33,7 @@ impl Nla for InfoVti {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoVti {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         #[allow(clippy::match_single_binding)]
         Ok(match buf.kind() {

--- a/src/link/link_info/vxlan.rs
+++ b/src/link/link_info/vxlan.rs
@@ -193,6 +193,7 @@ impl Nla for InfoVxlan {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoVxlan {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();
         Ok(match buf.kind() {

--- a/src/link/link_info/xfrm.rs
+++ b/src/link/link_info/xfrm.rs
@@ -50,6 +50,7 @@ impl Nla for InfoXfrm {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoXfrm {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         use self::InfoXfrm::*;
         let payload = buf.value();

--- a/src/link/link_info/xstats.rs
+++ b/src/link/link_info/xstats.rs
@@ -31,6 +31,7 @@ impl Emitable for LinkXstats {
 impl<'a, T: AsRef<[u8]> + ?Sized>
     ParseableParametrized<NlaBuffer<&'a T>, &InfoKind> for LinkXstats
 {
+    type Error = DecodeError;
     fn parse_with_param(
         buf: &NlaBuffer<&'a T>,
         _kind: &InfoKind,

--- a/src/link/map.rs
+++ b/src/link/map.rs
@@ -28,6 +28,7 @@ pub struct Map {
 }
 
 impl<T: AsRef<[u8]>> Parseable<MapBuffer<T>> for Map {
+    type Error = DecodeError;
     fn parse(buf: &MapBuffer<T>) -> Result<Self, DecodeError> {
         Ok(Self {
             memory_start: buf.memory_start(),

--- a/src/link/message.rs
+++ b/src/link/message.rs
@@ -32,6 +32,7 @@ impl Emitable for LinkMessage {
 impl<'a, T: AsRef<[u8]> + 'a> Parseable<LinkMessageBuffer<&'a T>>
     for LinkMessage
 {
+    type Error = DecodeError;
     fn parse(buf: &LinkMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
         let header = LinkHeader::parse(buf)
             .context("failed to parse link message header")?;
@@ -47,6 +48,7 @@ impl<'a, T: AsRef<[u8]> + 'a>
     ParseableParametrized<LinkMessageBuffer<&'a T>, AddressFamily>
     for Vec<LinkAttribute>
 {
+    type Error = DecodeError;
     fn parse_with_param(
         buf: &LinkMessageBuffer<&'a T>,
         family: AddressFamily,

--- a/src/link/phys_id.rs
+++ b/src/link/phys_id.rs
@@ -15,6 +15,7 @@ pub struct LinkPhysId {
 }
 
 impl Parseable<[u8]> for LinkPhysId {
+    type Error = DecodeError;
     fn parse(buf: &[u8]) -> Result<Self, DecodeError> {
         let len = buf.len() % MAX_PHYS_ITEM_ID_LEN;
         let mut id = [0; MAX_PHYS_ITEM_ID_LEN];

--- a/src/link/prop_list.rs
+++ b/src/link/prop_list.rs
@@ -49,6 +49,7 @@ impl Nla for Prop {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Prop {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();
         Ok(match buf.kind() {

--- a/src/link/proto_info/bridge.rs
+++ b/src/link/proto_info/bridge.rs
@@ -18,6 +18,7 @@ pub(crate) struct VecLinkProtoInfoBridge(pub(crate) Vec<LinkProtoInfoBridge>);
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for VecLinkProtoInfoBridge
 {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let mut nlas = vec![];
         for nla in NlasIterator::new(buf.into_inner()) {
@@ -54,6 +55,7 @@ impl Nla for LinkProtoInfoBridge {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for LinkProtoInfoBridge
 {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         Ok(Self::Other(DefaultNla::parse(buf).context(format!(
             "invalid bridge IFLA_PROTINFO {:?}",

--- a/src/link/proto_info/inet6.rs
+++ b/src/link/proto_info/inet6.rs
@@ -18,6 +18,7 @@ pub(crate) struct VecLinkProtoInfoInet6(pub(crate) Vec<LinkProtoInfoInet6>);
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for VecLinkProtoInfoInet6
 {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let mut nlas = vec![];
         for nla in NlasIterator::new(buf.into_inner()) {
@@ -54,6 +55,7 @@ impl Nla for LinkProtoInfoInet6 {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for LinkProtoInfoInet6
 {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         Ok(Self::Other(DefaultNla::parse(buf).context(format!(
             "invalid inet6 IFLA_PROTINFO {:?}",

--- a/src/link/sriov/broadcast.rs
+++ b/src/link/sriov/broadcast.rs
@@ -29,6 +29,7 @@ buffer!(VfInfoBroadcastBuffer(VF_INFO_BROADCAST_LEN) {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<VfInfoBroadcastBuffer<&'a T>>
     for VfInfoBroadcast
 {
+    type Error = DecodeError;
     fn parse(buf: &VfInfoBroadcastBuffer<&T>) -> Result<Self, DecodeError> {
         Ok(Self::new(buf.addr()))
     }

--- a/src/link/sriov/guid.rs
+++ b/src/link/sriov/guid.rs
@@ -25,6 +25,7 @@ buffer!(VfInfoGuidBuffer(VF_INFO_GUID_LEN) {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<VfInfoGuidBuffer<&'a T>>
     for VfInfoGuid
 {
+    type Error = DecodeError;
     fn parse(buf: &VfInfoGuidBuffer<&T>) -> Result<Self, DecodeError> {
         Ok(Self::new(buf.vf_id(), buf.guid()))
     }

--- a/src/link/sriov/link_state.rs
+++ b/src/link/sriov/link_state.rs
@@ -25,6 +25,7 @@ buffer!(VfInfoLinkStateBuffer(VF_INFO_LINK_STATE_LEN) {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<VfInfoLinkStateBuffer<&'a T>>
     for VfInfoLinkState
 {
+    type Error = DecodeError;
     fn parse(buf: &VfInfoLinkStateBuffer<&T>) -> Result<Self, DecodeError> {
         Ok(Self::new(buf.vf_id(), buf.state().into()))
     }

--- a/src/link/sriov/mac.rs
+++ b/src/link/sriov/mac.rs
@@ -36,6 +36,7 @@ buffer!(VfInfoMacBuffer(VF_INFO_MAC_LEN) {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<VfInfoMacBuffer<&'a T>>
     for VfInfoMac
 {
+    type Error = DecodeError;
     fn parse(buf: &VfInfoMacBuffer<&T>) -> Result<Self, DecodeError> {
         Ok(Self::new(buf.vf_id(), buf.mac()))
     }

--- a/src/link/sriov/rate.rs
+++ b/src/link/sriov/rate.rs
@@ -31,6 +31,7 @@ buffer!(VfInfoRateBuffer(VF_INFO_RATE_LEN) {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<VfInfoRateBuffer<&'a T>>
     for VfInfoRate
 {
+    type Error = DecodeError;
     fn parse(buf: &VfInfoRateBuffer<&T>) -> Result<Self, DecodeError> {
         Ok(Self {
             vf_id: buf.vf_id(),

--- a/src/link/sriov/rss_query.rs
+++ b/src/link/sriov/rss_query.rs
@@ -25,6 +25,7 @@ buffer!(VfInfoRssQueryEnBuffer(VF_INFO_RSS_QUERY_EN_LEN) {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<VfInfoRssQueryEnBuffer<&'a T>>
     for VfInfoRssQueryEn
 {
+    type Error = DecodeError;
     fn parse(buf: &VfInfoRssQueryEnBuffer<&T>) -> Result<Self, DecodeError> {
         Ok(Self::new(
             buf.vf_id(),

--- a/src/link/sriov/spoofchk.rs
+++ b/src/link/sriov/spoofchk.rs
@@ -25,6 +25,7 @@ buffer!(VfInfoSpoofCheckBuffer(VF_INFO_SPOOFCHK_LEN) {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<VfInfoSpoofCheckBuffer<&'a T>>
     for VfInfoSpoofCheck
 {
+    type Error = DecodeError;
     fn parse(buf: &VfInfoSpoofCheckBuffer<&T>) -> Result<Self, DecodeError> {
         Ok(Self::new(
             buf.vf_id(),

--- a/src/link/sriov/stats.rs
+++ b/src/link/sriov/stats.rs
@@ -70,6 +70,7 @@ impl Nla for VfStats {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for VfStats {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();
         Ok(match buf.kind() {

--- a/src/link/sriov/trust.rs
+++ b/src/link/sriov/trust.rs
@@ -25,6 +25,7 @@ buffer!(VfInfoTrustBuffer(VF_INFO_TRUST_LEN) {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<VfInfoTrustBuffer<&'a T>>
     for VfInfoTrust
 {
+    type Error = DecodeError;
     fn parse(buf: &VfInfoTrustBuffer<&T>) -> Result<Self, DecodeError> {
         Ok(Self::new(
             buf.vf_id(),

--- a/src/link/sriov/tx_rate.rs
+++ b/src/link/sriov/tx_rate.rs
@@ -25,6 +25,7 @@ buffer!(VfInfoTxRateBuffer(VF_INFO_TX_RATE_LEN) {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<VfInfoTxRateBuffer<&'a T>>
     for VfInfoTxRate
 {
+    type Error = DecodeError;
     fn parse(buf: &VfInfoTxRateBuffer<&T>) -> Result<Self, DecodeError> {
         Ok(Self {
             vf_id: buf.vf_id(),

--- a/src/link/sriov/vf_list.rs
+++ b/src/link/sriov/vf_list.rs
@@ -23,6 +23,7 @@ pub(crate) struct VecLinkVfInfo(pub(crate) Vec<LinkVfInfo>);
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for VecLinkVfInfo
 {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let mut nlas = vec![];
         for nla in NlasIterator::new(buf.into_inner()) {
@@ -62,6 +63,7 @@ impl Nla for LinkVfInfo {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for LinkVfInfo {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let mut nlas = vec![];
         for nla in NlasIterator::new(buf.into_inner()) {
@@ -168,6 +170,7 @@ impl Nla for VfInfo {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for VfInfo {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();
         Ok(match buf.kind() {

--- a/src/link/sriov/vf_port.rs
+++ b/src/link/sriov/vf_port.rs
@@ -12,6 +12,7 @@ pub(crate) struct VecLinkVfPort(pub(crate) Vec<LinkVfPort>);
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for VecLinkVfPort
 {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let mut nlas = vec![];
         for nla in NlasIterator::new(buf.into_inner()) {
@@ -53,6 +54,7 @@ impl Nla for LinkVfPort {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for LinkVfPort {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let mut nlas = vec![];
         for nla in NlasIterator::new(buf.into_inner()) {
@@ -111,6 +113,7 @@ impl Nla for VfPort {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for VfPort {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();
         #[allow(clippy::match_single_binding)]

--- a/src/link/sriov/vf_vlan.rs
+++ b/src/link/sriov/vf_vlan.rs
@@ -41,6 +41,7 @@ impl Nla for VfVlan {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for VfVlan {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();
         Ok(match buf.kind() {
@@ -93,6 +94,7 @@ buffer!(VfVlanInfoBuffer(VF_VLAN_INFO_LEN) {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<VfVlanInfoBuffer<&'a T>>
     for VfVlanInfo
 {
+    type Error = DecodeError;
     fn parse(buf: &VfVlanInfoBuffer<&T>) -> Result<Self, DecodeError> {
         Ok(Self {
             vf_id: buf.vf_id(),

--- a/src/link/sriov/vlan.rs
+++ b/src/link/sriov/vlan.rs
@@ -31,6 +31,7 @@ buffer!(VfInfoVlanBuffer(VF_INFO_VLAN_LEN) {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<VfInfoVlanBuffer<&'a T>>
     for VfInfoVlan
 {
+    type Error = DecodeError;
     fn parse(buf: &VfInfoVlanBuffer<&T>) -> Result<Self, DecodeError> {
         Ok(Self {
             vf_id: buf.vf_id(),

--- a/src/link/stats.rs
+++ b/src/link/stats.rs
@@ -86,6 +86,7 @@ buffer!(StatsBuffer(LINK_STATS_LEN) {
 });
 
 impl<T: AsRef<[u8]>> Parseable<StatsBuffer<T>> for Stats {
+    type Error = DecodeError;
     fn parse(buf: &StatsBuffer<T>) -> Result<Self, DecodeError> {
         Ok(Self {
             rx_packets: buf.rx_packets(),

--- a/src/link/stats64.rs
+++ b/src/link/stats64.rs
@@ -89,6 +89,7 @@ pub struct Stats64 {
 }
 
 impl<T: AsRef<[u8]>> Parseable<Stats64Buffer<T>> for Stats64 {
+    type Error = DecodeError;
     fn parse(buf: &Stats64Buffer<T>) -> Result<Self, DecodeError> {
         Ok(Self {
             rx_packets: buf.rx_packets(),

--- a/src/link/wireless.rs
+++ b/src/link/wireless.rs
@@ -8,6 +8,7 @@ use netlink_packet_utils::{DecodeError, Emitable, Parseable};
 pub struct LinkWirelessEvent(Vec<u8>);
 
 impl<T: AsRef<[u8]> + ?Sized> Parseable<T> for LinkWirelessEvent {
+    type Error = DecodeError;
     fn parse(buf: &T) -> Result<Self, DecodeError> {
         Ok(LinkWirelessEvent(buf.as_ref().to_vec()))
     }

--- a/src/link/xdp.rs
+++ b/src/link/xdp.rs
@@ -92,6 +92,7 @@ impl Nla for LinkXdp {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for LinkXdp {
+    type Error = DecodeError;
     fn parse(nla: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = nla.value();
         Ok(match nla.kind() as u32 {
@@ -138,6 +139,7 @@ pub(crate) struct VecLinkXdp(pub(crate) Vec<LinkXdp>);
 //  nla->data[0].type   <- nla.kind()
 //  nla->data[0].len
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for VecLinkXdp {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let mut res = Vec::new();
         let nlas = NlasIterator::new(buf.into_inner());

--- a/src/neighbour/attribute.rs
+++ b/src/neighbour/attribute.rs
@@ -106,6 +106,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
     ParseableParametrized<NlaBuffer<&'a T>, AddressFamily>
     for NeighbourAttribute
 {
+    type Error = DecodeError;
     fn parse_with_param(
         buf: &NlaBuffer<&'a T>,
         address_family: AddressFamily,

--- a/src/neighbour/attribute.rs
+++ b/src/neighbour/attribute.rs
@@ -1,15 +1,16 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
+use super::{
+    NeighbourAddress, NeighbourCacheInfo, NeighbourCacheInfoBuffer,
+    NeighbourError,
+};
+use crate::{route::RouteProtocol, AddressFamily};
 use byteorder::{BigEndian, ByteOrder, NativeEndian};
 use netlink_packet_utils::{
     nla::{DefaultNla, Nla, NlaBuffer},
     parsers::{parse_u16, parse_u16_be, parse_u32},
-    DecodeError, Emitable, Parseable, ParseableParametrized,
+    Emitable, Parseable, ParseableParametrized,
 };
-
-use super::{NeighbourAddress, NeighbourCacheInfo, NeighbourCacheInfoBuffer};
-use crate::{route::RouteProtocol, AddressFamily};
 
 const NDA_DST: u16 = 1;
 const NDA_LLADDR: u16 = 2;
@@ -106,58 +107,93 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
     ParseableParametrized<NlaBuffer<&'a T>, AddressFamily>
     for NeighbourAttribute
 {
-    type Error = DecodeError;
+    type Error = NeighbourError;
     fn parse_with_param(
         buf: &NlaBuffer<&'a T>,
         address_family: AddressFamily,
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, Self::Error> {
         let payload = buf.value();
         Ok(match buf.kind() {
             NDA_DST => Self::Destination(
                 NeighbourAddress::parse_with_param(address_family, payload)
-                    .context(format!("invalid NDA_DST value {:?}", payload))?,
+                    .map_err(|error| NeighbourError::InvalidValue {
+                        kind: "NDA_DST",
+                        error,
+                    })?,
             ),
             NDA_LLADDR => Self::LinkLocalAddress(payload.to_vec()),
             NDA_CACHEINFO => Self::CacheInfo(
-                NeighbourCacheInfo::parse(
-                    &NeighbourCacheInfoBuffer::new_checked(payload).context(
-                        format!("invalid NDA_CACHEINFO value {:?}", payload),
-                    )?,
-                )
-                .context(format!(
-                    "invalid NDA_CACHEINFO value {:?}",
-                    payload
-                ))?,
+                NeighbourCacheInfoBuffer::new_checked(payload)
+                    .and_then(|buffer| NeighbourCacheInfo::parse(&buffer))
+                    .map_err(|error| NeighbourError::InvalidValue {
+                        kind: "NDA_CACHEINFO",
+                        error,
+                    })?,
             ),
             NDA_PROBES => {
-                Self::Probes(parse_u32(payload).context(format!(
-                    "invalid NDA_PROBES value {:?}",
-                    payload
-                ))?)
+                Self::Probes(parse_u32(payload).map_err(|error| {
+                    NeighbourError::InvalidValue {
+                        kind: "NDA_PROBES",
+                        error,
+                    }
+                })?)
             }
-            NDA_VLAN => Self::Vlan(parse_u16(payload)?),
-            NDA_PORT => Self::Port(
-                parse_u16_be(payload)
-                    .context(format!("invalid NDA_PORT value {payload:?}"))?,
-            ),
-            NDA_VNI => Self::Vni(parse_u32(payload)?),
-            NDA_IFINDEX => Self::IfIndex(parse_u32(payload)?),
-            NDA_CONTROLLER => Self::Controller(parse_u32(payload).context(
-                format!("invalid NDA_CONTROLLER value {payload:?}"),
-            )?),
-            NDA_LINK_NETNSID => Self::LinkNetNsId(parse_u32(payload).context(
-                format!("invalid NDA_LINK_NETNSID value {payload:?}"),
-            )?),
-            NDA_SRC_VNI => Self::SourceVni(parse_u32(payload)?),
-            NDA_PROTOCOL => {
-                Self::Protocol(RouteProtocol::parse(payload).context(
-                    format!("invalid NDA_PROTOCOL value {:?}", payload),
-                )?)
+            NDA_VLAN => Self::Vlan(parse_u16(payload).map_err(|error| {
+                NeighbourError::InvalidValue {
+                    kind: "NDA_VLAN",
+                    error,
+                }
+            })?),
+            NDA_PORT => Self::Port(parse_u16_be(payload).map_err(|error| {
+                NeighbourError::InvalidValue {
+                    kind: "NDA_PORT",
+                    error,
+                }
+            })?),
+            NDA_VNI => Self::Vni(parse_u32(payload).map_err(|error| {
+                NeighbourError::InvalidValue {
+                    kind: "NDA_VNI",
+                    error,
+                }
+            })?),
+            NDA_IFINDEX => {
+                Self::IfIndex(parse_u32(payload).map_err(|error| {
+                    NeighbourError::InvalidValue {
+                        kind: "NDA_IFINDEX",
+                        error,
+                    }
+                })?)
             }
-            _ => Self::Other(
-                DefaultNla::parse(buf)
-                    .context("invalid link NLA value (unknown type)")?,
-            ),
+            NDA_CONTROLLER => {
+                Self::Controller(parse_u32(payload).map_err(|error| {
+                    NeighbourError::InvalidValue {
+                        kind: "NDA_CONTROLLER",
+                        error,
+                    }
+                })?)
+            }
+            NDA_LINK_NETNSID => {
+                Self::LinkNetNsId(parse_u32(payload).map_err(|error| {
+                    NeighbourError::InvalidValue {
+                        kind: "NDA_LINK_NETNSID",
+                        error,
+                    }
+                })?)
+            }
+            NDA_SRC_VNI => {
+                Self::SourceVni(parse_u32(payload).map_err(|error| {
+                    NeighbourError::InvalidValue {
+                        kind: "NDA_SRC_VNI",
+                        error,
+                    }
+                })?)
+            }
+            NDA_PROTOCOL => Self::Protocol(RouteProtocol::parse(payload)?),
+            kind => {
+                Self::Other(DefaultNla::parse(buf).map_err(|error| {
+                    NeighbourError::UnknownNLA { kind, error }
+                })?)
+            }
         })
     }
 }

--- a/src/neighbour/cache_info.rs
+++ b/src/neighbour/cache_info.rs
@@ -26,6 +26,7 @@ buffer!(NeighbourCacheInfoBuffer(NEIGHBOUR_CACHE_INFO_LEN) {
 impl<T: AsRef<[u8]>> Parseable<NeighbourCacheInfoBuffer<T>>
     for NeighbourCacheInfo
 {
+    type Error = DecodeError;
     fn parse(buf: &NeighbourCacheInfoBuffer<T>) -> Result<Self, DecodeError> {
         Ok(Self {
             confirmed: buf.confirmed(),

--- a/src/neighbour/error.rs
+++ b/src/neighbour/error.rs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+
+use crate::route::RouteError;
+use netlink_packet_utils::{nla::NlaError, DecodeError};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum NeighbourError {
+    #[error("Invalid {kind}")]
+    InvalidValue {
+        kind: &'static str,
+        error: DecodeError,
+    },
+
+    #[error("Unknown NLA type: {kind}")]
+    UnknownNLA { kind: u16, error: DecodeError },
+
+    #[error(transparent)]
+    ParseNdaProtocol(#[from] RouteError),
+
+    #[error(transparent)]
+    ParseNla(#[from] NlaError),
+}

--- a/src/neighbour/header.rs
+++ b/src/neighbour/header.rs
@@ -58,6 +58,7 @@ pub struct NeighbourHeader {
 }
 
 impl<T: AsRef<[u8]>> Parseable<NeighbourMessageBuffer<T>> for NeighbourHeader {
+    type Error = DecodeError;
     fn parse(buf: &NeighbourMessageBuffer<T>) -> Result<Self, DecodeError> {
         Ok(Self {
             family: buf.family().into(),

--- a/src/neighbour/header.rs
+++ b/src/neighbour/header.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 use netlink_packet_utils::{
-    nla::{NlaBuffer, NlasIterator},
+    nla::{NlaBuffer, NlaError, NlasIterator},
     traits::{Emitable, Parseable},
     DecodeError,
 };
@@ -23,7 +23,7 @@ buffer!(NeighbourMessageBuffer(NEIGHBOUR_HEADER_LEN) {
 impl<'a, T: AsRef<[u8]> + ?Sized> NeighbourMessageBuffer<&'a T> {
     pub fn attributes(
         &self,
-    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
+    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, NlaError>> {
         NlasIterator::new(self.payload())
     }
 }
@@ -58,8 +58,8 @@ pub struct NeighbourHeader {
 }
 
 impl<T: AsRef<[u8]>> Parseable<NeighbourMessageBuffer<T>> for NeighbourHeader {
-    type Error = DecodeError;
-    fn parse(buf: &NeighbourMessageBuffer<T>) -> Result<Self, DecodeError> {
+    type Error = ();
+    fn parse(buf: &NeighbourMessageBuffer<T>) -> Result<Self, ()> {
         Ok(Self {
             family: buf.family().into(),
             ifindex: buf.ifindex(),

--- a/src/neighbour/message.rs
+++ b/src/neighbour/message.rs
@@ -34,6 +34,7 @@ impl Emitable for NeighbourMessage {
 impl<'a, T: AsRef<[u8]> + 'a> Parseable<NeighbourMessageBuffer<&'a T>>
     for NeighbourMessage
 {
+    type Error = DecodeError;
     fn parse(buf: &NeighbourMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
         let header = NeighbourHeader::parse(buf)
             .context("failed to parse neighbour message header")?;
@@ -53,6 +54,7 @@ impl<'a, T: AsRef<[u8]> + 'a>
     ParseableParametrized<NeighbourMessageBuffer<&'a T>, AddressFamily>
     for Vec<NeighbourAttribute>
 {
+    type Error = DecodeError;
     fn parse_with_param(
         buf: &NeighbourMessageBuffer<&'a T>,
         address_family: AddressFamily,

--- a/src/neighbour/message.rs
+++ b/src/neighbour/message.rs
@@ -1,14 +1,11 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
-use netlink_packet_utils::{
-    traits::{Emitable, Parseable, ParseableParametrized},
-    DecodeError,
-};
-
 use super::{
-    super::AddressFamily, NeighbourAttribute, NeighbourHeader,
+    super::AddressFamily, NeighbourAttribute, NeighbourError, NeighbourHeader,
     NeighbourMessageBuffer,
+};
+use netlink_packet_utils::traits::{
+    Emitable, Parseable, ParseableParametrized,
 };
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
@@ -34,18 +31,19 @@ impl Emitable for NeighbourMessage {
 impl<'a, T: AsRef<[u8]> + 'a> Parseable<NeighbourMessageBuffer<&'a T>>
     for NeighbourMessage
 {
-    type Error = DecodeError;
-    fn parse(buf: &NeighbourMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
-        let header = NeighbourHeader::parse(buf)
-            .context("failed to parse neighbour message header")?;
+    type Error = NeighbourError;
+    fn parse(
+        buf: &NeighbourMessageBuffer<&'a T>,
+    ) -> Result<Self, NeighbourError> {
+        // unwrap: parsing the header is always ok.
+        let header = NeighbourHeader::parse(buf).unwrap();
         let address_family = header.family;
         Ok(NeighbourMessage {
             header,
             attributes: Vec::<NeighbourAttribute>::parse_with_param(
                 buf,
                 address_family,
-            )
-            .context("failed to parse neighbour message NLAs")?,
+            )?,
         })
     }
 }
@@ -54,11 +52,11 @@ impl<'a, T: AsRef<[u8]> + 'a>
     ParseableParametrized<NeighbourMessageBuffer<&'a T>, AddressFamily>
     for Vec<NeighbourAttribute>
 {
-    type Error = DecodeError;
+    type Error = NeighbourError;
     fn parse_with_param(
         buf: &NeighbourMessageBuffer<&'a T>,
         address_family: AddressFamily,
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, NeighbourError> {
         let mut attributes = vec![];
         for nla_buf in buf.attributes() {
             attributes.push(NeighbourAttribute::parse_with_param(

--- a/src/neighbour/mod.rs
+++ b/src/neighbour/mod.rs
@@ -3,6 +3,7 @@
 mod address;
 mod attribute;
 mod cache_info;
+mod error;
 mod flags;
 mod header;
 mod message;
@@ -14,6 +15,7 @@ mod tests;
 pub use self::address::NeighbourAddress;
 pub use self::attribute::NeighbourAttribute;
 pub use self::cache_info::{NeighbourCacheInfo, NeighbourCacheInfoBuffer};
+pub use self::error::NeighbourError;
 pub use self::flags::NeighbourFlags;
 pub use self::header::{NeighbourHeader, NeighbourMessageBuffer};
 pub use self::message::NeighbourMessage;

--- a/src/neighbour_table/attribute.rs
+++ b/src/neighbour_table/attribute.rs
@@ -90,6 +90,7 @@ impl Nla for NeighbourTableAttribute {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for NeighbourTableAttribute
 {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();
         Ok(match buf.kind() {

--- a/src/neighbour_table/attribute.rs
+++ b/src/neighbour_table/attribute.rs
@@ -1,17 +1,15 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
+use super::{
+    param::VecNeighbourTableParameter, NeighbourTableConfig,
+    NeighbourTableConfigBuffer, NeighbourTableError, NeighbourTableParameter,
+    NeighbourTableStats, NeighbourTableStatsBuffer,
+};
 use byteorder::{ByteOrder, NativeEndian};
 use netlink_packet_utils::{
     nla::{DefaultNla, Nla, NlaBuffer},
     parsers::{parse_string, parse_u32, parse_u64},
-    DecodeError, Emitable, Parseable,
-};
-
-use super::{
-    param::VecNeighbourTableParameter, NeighbourTableConfig,
-    NeighbourTableConfigBuffer, NeighbourTableParameter, NeighbourTableStats,
-    NeighbourTableStatsBuffer,
+    Emitable, Parseable,
 };
 
 const NDTA_NAME: u16 = 1;
@@ -90,48 +88,88 @@ impl Nla for NeighbourTableAttribute {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for NeighbourTableAttribute
 {
-    type Error = DecodeError;
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+    type Error = NeighbourTableError;
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, Self::Error> {
         let payload = buf.value();
         Ok(match buf.kind() {
-            NDTA_NAME => Self::Name(
-                parse_string(payload).context("invalid NDTA_NAME value")?,
-            ),
+            NDTA_NAME => {
+                Self::Name(parse_string(payload).map_err(|error| {
+                    NeighbourTableError::InvalidValue {
+                        kind: "NDTA_NAME",
+                        error,
+                    }
+                })?)
+            }
             NDTA_CONFIG => Self::Config(
                 NeighbourTableConfig::parse(
-                    &NeighbourTableConfigBuffer::new_checked(payload)
-                        .context(format!("invalid NDTA_CONFIG {payload:?}"))?,
+                    &NeighbourTableConfigBuffer::new_checked(payload).map_err(
+                        |error| NeighbourTableError::InvalidValue {
+                            kind: "NDTA_CONFIG",
+                            error,
+                        },
+                    )?,
                 )
-                .context(format!("invalid NDTA_CONFIG {payload:?}"))?,
+                .map_err(|error| {
+                    NeighbourTableError::InvalidValue {
+                        kind: "NDTA_CONFIG",
+                        error,
+                    }
+                })?,
             ),
             NDTA_STATS => Self::Stats(
                 NeighbourTableStats::parse(
-                    &NeighbourTableStatsBuffer::new_checked(payload)
-                        .context(format!("invalid NDTA_STATS {payload:?}"))?,
+                    &NeighbourTableStatsBuffer::new_checked(payload).map_err(
+                        |error| NeighbourTableError::InvalidValue {
+                            kind: "NDTA_STATS",
+                            error,
+                        },
+                    )?,
                 )
-                .context(format!("invalid NDTA_STATS {payload:?}"))?,
+                .map_err(|error| {
+                    NeighbourTableError::InvalidValue {
+                        kind: "NDTA_STATS",
+                        error,
+                    }
+                })?,
             ),
             NDTA_PARMS => Self::Parms(
-                VecNeighbourTableParameter::parse(&NlaBuffer::new(payload))
-                    .context(format!("invalid NDTA_PARMS {payload:?}"))?
-                    .0,
+                VecNeighbourTableParameter::parse(&NlaBuffer::new(payload))?.0,
             ),
-            NDTA_GC_INTERVAL => Self::GcInterval(
-                parse_u64(payload).context("invalid NDTA_GC_INTERVAL value")?,
-            ),
-            NDTA_THRESH1 => Self::Threshold1(
-                parse_u32(payload).context("invalid NDTA_THRESH1 value")?,
-            ),
-            NDTA_THRESH2 => Self::Threshold2(
-                parse_u32(payload).context("invalid NDTA_THRESH2 value")?,
-            ),
-            NDTA_THRESH3 => Self::Threshold3(
-                parse_u32(payload).context("invalid NDTA_THRESH3 value")?,
-            ),
-            kind => Self::Other(
-                DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {kind}"))?,
-            ),
+            NDTA_GC_INTERVAL => {
+                Self::GcInterval(parse_u64(payload).map_err(|error| {
+                    NeighbourTableError::InvalidValue {
+                        kind: "NDTA_GC_INTERVAL",
+                        error,
+                    }
+                })?)
+            }
+            NDTA_THRESH1 => {
+                Self::Threshold1(parse_u32(payload).map_err(|error| {
+                    NeighbourTableError::InvalidValue {
+                        kind: "NDTA_THRESH1",
+                        error,
+                    }
+                })?)
+            }
+            NDTA_THRESH2 => {
+                Self::Threshold2(parse_u32(payload).map_err(|error| {
+                    NeighbourTableError::InvalidValue {
+                        kind: "NDTA_THRESH2",
+                        error,
+                    }
+                })?)
+            }
+            NDTA_THRESH3 => {
+                Self::Threshold3(parse_u32(payload).map_err(|error| {
+                    NeighbourTableError::InvalidValue {
+                        kind: "NDTA_THRESH3",
+                        error,
+                    }
+                })?)
+            }
+            kind => Self::Other(DefaultNla::parse(buf).map_err(|error| {
+                NeighbourTableError::UnknownNla { kind, error }
+            })?),
         })
     }
 }

--- a/src/neighbour_table/config.rs
+++ b/src/neighbour_table/config.rs
@@ -36,6 +36,7 @@ buffer!(NeighbourTableConfigBuffer(CONFIG_LEN) {
 impl<T: AsRef<[u8]>> Parseable<NeighbourTableConfigBuffer<T>>
     for NeighbourTableConfig
 {
+    type Error = DecodeError;
     fn parse(buf: &NeighbourTableConfigBuffer<T>) -> Result<Self, DecodeError> {
         Ok(Self {
             key_len: buf.key_len(),

--- a/src/neighbour_table/error.rs
+++ b/src/neighbour_table/error.rs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+
+use netlink_packet_utils::{nla::NlaError, DecodeError};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum NeighbourTableError {
+    #[error("Invalid {kind}")]
+    InvalidValue {
+        kind: &'static str,
+        error: DecodeError,
+    },
+
+    #[error("Invalid {kind} value")]
+    InvalidParameter {
+        kind: &'static str,
+        error: DecodeError,
+    },
+
+    #[error("Unknown NLA type: {kind}")]
+    UnknownNla { kind: u16, error: DecodeError },
+
+    #[error(transparent)]
+    ParseNla(#[from] NlaError),
+}

--- a/src/neighbour_table/header.rs
+++ b/src/neighbour_table/header.rs
@@ -32,6 +32,7 @@ pub struct NeighbourTableHeader {
 impl<T: AsRef<[u8]>> Parseable<NeighbourTableMessageBuffer<T>>
     for NeighbourTableHeader
 {
+    type Error = DecodeError;
     fn parse(
         buf: &NeighbourTableMessageBuffer<T>,
     ) -> Result<Self, DecodeError> {

--- a/src/neighbour_table/header.rs
+++ b/src/neighbour_table/header.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 use netlink_packet_utils::{
-    nla::{NlaBuffer, NlasIterator},
+    nla::{NlaBuffer, NlaError, NlasIterator},
     traits::{Emitable, Parseable},
     DecodeError,
 };
@@ -18,7 +18,7 @@ buffer!(NeighbourTableMessageBuffer(NEIGHBOUR_TABLE_HEADER_LEN) {
 impl<'a, T: AsRef<[u8]> + ?Sized> NeighbourTableMessageBuffer<&'a T> {
     pub fn attributes(
         &self,
-    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
+    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, NlaError>> {
         NlasIterator::new(self.payload())
     }
 }
@@ -32,10 +32,8 @@ pub struct NeighbourTableHeader {
 impl<T: AsRef<[u8]>> Parseable<NeighbourTableMessageBuffer<T>>
     for NeighbourTableHeader
 {
-    type Error = DecodeError;
-    fn parse(
-        buf: &NeighbourTableMessageBuffer<T>,
-    ) -> Result<Self, DecodeError> {
+    type Error = ();
+    fn parse(buf: &NeighbourTableMessageBuffer<T>) -> Result<Self, ()> {
         Ok(Self {
             family: buf.family().into(),
         })

--- a/src/neighbour_table/message.rs
+++ b/src/neighbour_table/message.rs
@@ -33,6 +33,7 @@ impl Emitable for NeighbourTableMessage {
 impl<'a, T: AsRef<[u8]> + 'a> Parseable<NeighbourTableMessageBuffer<&'a T>>
     for NeighbourTableMessage
 {
+    type Error = DecodeError;
     fn parse(
         buf: &NeighbourTableMessageBuffer<&'a T>,
     ) -> Result<Self, DecodeError> {
@@ -48,6 +49,7 @@ impl<'a, T: AsRef<[u8]> + 'a> Parseable<NeighbourTableMessageBuffer<&'a T>>
 impl<'a, T: AsRef<[u8]> + 'a> Parseable<NeighbourTableMessageBuffer<&'a T>>
     for Vec<NeighbourTableAttribute>
 {
+    type Error = DecodeError;
     fn parse(
         buf: &NeighbourTableMessageBuffer<&'a T>,
     ) -> Result<Self, DecodeError> {

--- a/src/neighbour_table/message.rs
+++ b/src/neighbour_table/message.rs
@@ -1,14 +1,10 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
-use netlink_packet_utils::{
-    traits::{Emitable, Parseable},
-    DecodeError,
-};
-
 use super::{
-    NeighbourTableAttribute, NeighbourTableHeader, NeighbourTableMessageBuffer,
+    NeighbourTableAttribute, NeighbourTableError, NeighbourTableHeader,
+    NeighbourTableMessageBuffer,
 };
+use netlink_packet_utils::traits::{Emitable, Parseable};
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
@@ -33,15 +29,14 @@ impl Emitable for NeighbourTableMessage {
 impl<'a, T: AsRef<[u8]> + 'a> Parseable<NeighbourTableMessageBuffer<&'a T>>
     for NeighbourTableMessage
 {
-    type Error = DecodeError;
+    type Error = NeighbourTableError;
     fn parse(
         buf: &NeighbourTableMessageBuffer<&'a T>,
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, NeighbourTableError> {
         Ok(NeighbourTableMessage {
-            header: NeighbourTableHeader::parse(buf)
-                .context("failed to parse neighbour table message header")?,
-            attributes: Vec::<NeighbourTableAttribute>::parse(buf)
-                .context("failed to parse neighbour table message NLAs")?,
+            // unwrap: we always succeed at parsing the header
+            header: NeighbourTableHeader::parse(buf).unwrap(),
+            attributes: Vec::<NeighbourTableAttribute>::parse(buf)?,
         })
     }
 }
@@ -49,10 +44,10 @@ impl<'a, T: AsRef<[u8]> + 'a> Parseable<NeighbourTableMessageBuffer<&'a T>>
 impl<'a, T: AsRef<[u8]> + 'a> Parseable<NeighbourTableMessageBuffer<&'a T>>
     for Vec<NeighbourTableAttribute>
 {
-    type Error = DecodeError;
+    type Error = NeighbourTableError;
     fn parse(
         buf: &NeighbourTableMessageBuffer<&'a T>,
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, NeighbourTableError> {
         let mut attributes = vec![];
         for nla_buf in buf.attributes() {
             attributes.push(NeighbourTableAttribute::parse(&nla_buf?)?);

--- a/src/neighbour_table/mod.rs
+++ b/src/neighbour_table/mod.rs
@@ -2,6 +2,7 @@
 
 mod attribute;
 mod config;
+mod error;
 mod header;
 mod message;
 pub(crate) mod param;
@@ -11,6 +12,7 @@ mod tests;
 
 pub use self::attribute::NeighbourTableAttribute;
 pub use self::config::{NeighbourTableConfig, NeighbourTableConfigBuffer};
+pub use self::error::NeighbourTableError;
 pub use self::header::{NeighbourTableHeader, NeighbourTableMessageBuffer};
 pub use self::message::NeighbourTableMessage;
 pub use self::param::NeighbourTableParameter;

--- a/src/neighbour_table/param.rs
+++ b/src/neighbour_table/param.rs
@@ -135,6 +135,7 @@ impl Nla for NeighbourTableParameter {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for NeighbourTableParameter
 {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();
         Ok(match buf.kind() {
@@ -233,6 +234,7 @@ pub(crate) struct VecNeighbourTableParameter(
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for VecNeighbourTableParameter
 {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let mut nlas = vec![];
         let err = "invalid NDTA_PARMS attribute";

--- a/src/neighbour_table/param.rs
+++ b/src/neighbour_table/param.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
+use super::NeighbourTableError;
 use byteorder::{ByteOrder, NativeEndian};
 use netlink_packet_utils::{
     nla::{DefaultNla, Nla, NlaBuffer, NlasIterator},
@@ -135,93 +135,160 @@ impl Nla for NeighbourTableParameter {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for NeighbourTableParameter
 {
-    type Error = DecodeError;
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+    type Error = NeighbourTableError;
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, NeighbourTableError> {
         let payload = buf.value();
         Ok(match buf.kind() {
             NDTPA_IFINDEX => {
-                Self::Ifindex(parse_u32(payload).context(format!(
-                    "invalid NDTPA_IFINDEX value {payload:?}"
-                ))?)
+                Self::Ifindex(parse_u32(payload).map_err(|error| {
+                    NeighbourTableError::InvalidParameter {
+                        kind: "NDTPA_IFINDEX",
+                        error,
+                    }
+                })?)
             }
             NDTPA_REFCNT => {
-                Self::ReferenceCount(parse_u32(payload).context(format!(
-                    "invalid NDTPA_REFCNT value {payload:?}"
-                ))?)
+                Self::ReferenceCount(parse_u32(payload).map_err(|error| {
+                    NeighbourTableError::InvalidParameter {
+                        kind: "NDTPA_REFCNT",
+                        error,
+                    }
+                })?)
             }
             NDTPA_REACHABLE_TIME => {
-                Self::ReachableTime(parse_u64(payload).context(format!(
-                    "invalid NDTPA_REACHABLE_TIME value {payload:?}"
-                ))?)
+                Self::ReachableTime(parse_u64(payload).map_err(|error| {
+                    NeighbourTableError::InvalidParameter {
+                        kind: "NDTPA_REACHABLE_TIME",
+                        error,
+                    }
+                })?)
             }
             NDTPA_BASE_REACHABLE_TIME => {
-                Self::BaseReachableTime(parse_u64(payload).context(format!(
-                    "invalid NDTPA_BASE_REACHABLE_TIME value {payload:?}"
-                ))?)
+                Self::BaseReachableTime(parse_u64(payload).map_err(
+                    |error| NeighbourTableError::InvalidParameter {
+                        kind: "NDTPA_BASE_REACHABLE_TIME",
+                        error,
+                    },
+                )?)
             }
             NDTPA_RETRANS_TIME => {
-                Self::RetransTime(parse_u64(payload).context(format!(
-                    "invalid NDTPA_RETRANS_TIME value {payload:?}"
-                ))?)
+                Self::RetransTime(parse_u64(payload).map_err(|error| {
+                    NeighbourTableError::InvalidParameter {
+                        kind: "NDTPA_RETRANS_TIME",
+                        error,
+                    }
+                })?)
             }
             NDTPA_GC_STALETIME => {
-                Self::GcStaletime(parse_u64(payload).context(format!(
-                    "invalid NDTPA_GC_STALE_TIME value {payload:?}"
-                ))?)
+                Self::GcStaletime(parse_u64(payload).map_err(|error| {
+                    NeighbourTableError::InvalidParameter {
+                        kind: "NDTPA_GC_STALETIME",
+                        error,
+                    }
+                })?)
             }
             NDTPA_DELAY_PROBE_TIME => {
-                Self::DelayProbeTime(parse_u64(payload).context(format!(
-                    "invalid NDTPA_DELAY_PROBE_TIME value {payload:?}"
-                ))?)
+                Self::DelayProbeTime(parse_u64(payload).map_err(|error| {
+                    NeighbourTableError::InvalidParameter {
+                        kind: "NDTPA_DELAY_PROBE_TIME",
+                        error,
+                    }
+                })?)
             }
-            NDTPA_QUEUE_LEN => Self::QueueLen(parse_u32(payload).context(
-                format!("invalid NDTPA_QUEUE_LEN value {payload:?}"),
-            )?),
-            NDTPA_APP_PROBES => Self::AppProbes(parse_u32(payload).context(
-                format!("invalid NDTPA_APP_PROBES value {payload:?}"),
-            )?),
+            NDTPA_QUEUE_LEN => {
+                Self::QueueLen(parse_u32(payload).map_err(|error| {
+                    NeighbourTableError::InvalidParameter {
+                        kind: "NDTPA_QUEUE_LEN",
+                        error,
+                    }
+                })?)
+            }
+            NDTPA_APP_PROBES => {
+                Self::AppProbes(parse_u32(payload).map_err(|error| {
+                    NeighbourTableError::InvalidParameter {
+                        kind: "NDTPA_APP_PROBES",
+                        error,
+                    }
+                })?)
+            }
             NDTPA_UCAST_PROBES => {
-                Self::UcastProbes(parse_u32(payload).context(format!(
-                    "invalid NDTPA_UCAST_PROBES value {payload:?}"
-                ))?)
+                Self::UcastProbes(parse_u32(payload).map_err(|error| {
+                    NeighbourTableError::InvalidParameter {
+                        kind: "NDTPA_UCAST_PROBES",
+                        error,
+                    }
+                })?)
             }
             NDTPA_MCAST_PROBES => {
-                Self::McastProbes(parse_u32(payload).context(format!(
-                    "invalid NDTPA_MCAST_PROBES value {payload:?}"
-                ))?)
+                Self::McastProbes(parse_u32(payload).map_err(|error| {
+                    NeighbourTableError::InvalidParameter {
+                        kind: "NDTPA_MCAST_PROBES",
+                        error,
+                    }
+                })?)
             }
             NDTPA_ANYCAST_DELAY => {
-                Self::AnycastDelay(parse_u64(payload).context(format!(
-                    "invalid NDTPA_ANYCAST_DELAY value {payload:?}"
-                ))?)
+                Self::AnycastDelay(parse_u64(payload).map_err(|error| {
+                    NeighbourTableError::InvalidParameter {
+                        kind: "NDTPA_ANYCAST_DELAY",
+                        error,
+                    }
+                })?)
             }
-            NDTPA_PROXY_DELAY => Self::ProxyDelay(parse_u64(payload).context(
-                format!("invalid NDTPA_PROXY_DELAY value {payload:?}"),
-            )?),
-            NDTPA_PROXY_QLEN => Self::ProxyQlen(parse_u32(payload).context(
-                format!("invalid NDTPA_PROXY_QLEN value {payload:?}"),
-            )?),
-            NDTPA_LOCKTIME => Self::Locktime(parse_u64(payload).context(
-                format!("invalid NDTPA_LOCKTIME value {payload:?}"),
-            )?),
+            NDTPA_PROXY_DELAY => {
+                Self::ProxyDelay(parse_u64(payload).map_err(|error| {
+                    NeighbourTableError::InvalidParameter {
+                        kind: "NDTPA_PROXY_DELAY",
+                        error,
+                    }
+                })?)
+            }
+            NDTPA_PROXY_QLEN => {
+                Self::ProxyQlen(parse_u32(payload).map_err(|error| {
+                    NeighbourTableError::InvalidParameter {
+                        kind: "NDTPA_PROXY_QLEN",
+                        error,
+                    }
+                })?)
+            }
+            NDTPA_LOCKTIME => {
+                Self::Locktime(parse_u64(payload).map_err(|error| {
+                    NeighbourTableError::InvalidParameter {
+                        kind: "NDTPA_LOCKTIME",
+                        error,
+                    }
+                })?)
+            }
             NDTPA_QUEUE_LENBYTES => {
-                Self::QueueLenbytes(parse_u32(payload).context(format!(
-                    "invalid NDTPA_QUEUE_LENBYTES value {payload:?}"
-                ))?)
+                Self::QueueLenbytes(parse_u32(payload).map_err(|error| {
+                    NeighbourTableError::InvalidParameter {
+                        kind: "NDTPA_QUEUE_LENBYTES",
+                        error,
+                    }
+                })?)
             }
             NDTPA_MCAST_REPROBES => {
-                Self::McastReprobes(parse_u32(payload).context(format!(
-                    "invalid NDTPA_MCAST_PROBES value {payload:?}"
-                ))?)
+                Self::McastReprobes(parse_u32(payload).map_err(|error| {
+                    NeighbourTableError::InvalidParameter {
+                        kind: "NDTPA_MCAST_REPROBES",
+                        error,
+                    }
+                })?)
             }
-            NDTPA_INTERVAL_PROBE_TIME_MS => Self::IntervalProbeTimeMs(
-                parse_u64(payload).context(format!(
-                    "invalid NDTPA_INTERVAL_PROBE_TIME_MS value {payload:?}"
-                ))?,
-            ),
-            _ => Self::Other(DefaultNla::parse(buf).context(format!(
-                "invalid NDTA_PARMS attribute {payload:?}"
-            ))?),
+            NDTPA_INTERVAL_PROBE_TIME_MS => {
+                Self::IntervalProbeTimeMs(parse_u64(payload).map_err(
+                    |error| NeighbourTableError::InvalidParameter {
+                        kind: "NDTPA_INTERVAL_PROBE_TIME_MS",
+                        error,
+                    },
+                )?)
+            }
+            _ => Self::Other(DefaultNla::parse(buf).map_err(|error| {
+                NeighbourTableError::InvalidParameter {
+                    kind: "NDTA_PARMS",
+                    error,
+                }
+            })?),
         })
     }
 }
@@ -234,13 +301,12 @@ pub(crate) struct VecNeighbourTableParameter(
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for VecNeighbourTableParameter
 {
-    type Error = DecodeError;
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+    type Error = NeighbourTableError;
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, NeighbourTableError> {
         let mut nlas = vec![];
-        let err = "invalid NDTA_PARMS attribute";
         for nla in NlasIterator::new(buf.into_inner()) {
-            let nla = nla.context(err)?;
-            nlas.push(NeighbourTableParameter::parse(&nla).context(err)?);
+            let nla = nla?;
+            nlas.push(NeighbourTableParameter::parse(&nla)?);
         }
         Ok(Self(nlas))
     }

--- a/src/neighbour_table/stats.rs
+++ b/src/neighbour_table/stats.rs
@@ -39,6 +39,7 @@ buffer!(NeighbourTableStatsBuffer(STATS_LEN) {
 impl<T: AsRef<[u8]>> Parseable<NeighbourTableStatsBuffer<T>>
     for NeighbourTableStats
 {
+    type Error = DecodeError;
     fn parse(buf: &NeighbourTableStatsBuffer<T>) -> Result<Self, DecodeError> {
         Ok(Self {
             allocs: buf.allocs(),

--- a/src/nsid/attribute.rs
+++ b/src/nsid/attribute.rs
@@ -65,6 +65,7 @@ impl Nla for NsidAttribute {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for NsidAttribute
 {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();
         Ok(match buf.kind() {

--- a/src/nsid/attribute.rs
+++ b/src/nsid/attribute.rs
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
+use super::NsidError;
 use byteorder::{ByteOrder, NativeEndian};
-
 use netlink_packet_utils::{
     nla::{DefaultNla, Nla, NlaBuffer},
     parsers::{parse_i32, parse_u32},
     traits::Parseable,
-    DecodeError,
 };
 
 const NETNSA_NSID: u16 = 1;
@@ -65,28 +63,47 @@ impl Nla for NsidAttribute {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for NsidAttribute
 {
-    type Error = DecodeError;
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+    type Error = NsidError;
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, NsidError> {
         let payload = buf.value();
         Ok(match buf.kind() {
-            NETNSA_NSID => {
-                Self::Id(parse_i32(payload).context("invalid NETNSA_NSID")?)
+            NETNSA_NSID => Self::Id(parse_i32(payload).map_err(|error| {
+                NsidError::InvalidValue {
+                    kind: "NETNSA_NSID",
+                    error,
+                }
+            })?),
+            NETNSA_PID => Self::Pid(parse_u32(payload).map_err(|error| {
+                NsidError::InvalidValue {
+                    kind: "NETNSA_PID",
+                    error,
+                }
+            })?),
+            NETNSA_FD => Self::Fd(parse_u32(payload).map_err(|error| {
+                NsidError::InvalidValue {
+                    kind: "NETNSA_FD",
+                    error,
+                }
+            })?),
+            NETNSA_TARGET_NSID => {
+                Self::TargetNsid(parse_i32(payload).map_err(|error| {
+                    NsidError::InvalidValue {
+                        kind: "NETNSA_TARGET_NSID",
+                        error,
+                    }
+                })?)
             }
-            NETNSA_PID => {
-                Self::Pid(parse_u32(payload).context("invalid NETNSA_PID")?)
+            NETNSA_CURRENT_NSID => {
+                Self::CurrentNsid(parse_i32(payload).map_err(|error| {
+                    NsidError::InvalidValue {
+                        kind: "NETNSA_CURRENT_NSID",
+                        error,
+                    }
+                })?)
             }
-            NETNSA_FD => {
-                Self::Fd(parse_u32(payload).context("invalid NETNSA_FD")?)
-            }
-            NETNSA_TARGET_NSID => Self::TargetNsid(
-                parse_i32(payload).context("invalid NETNSA_TARGET_NSID")?,
-            ),
-            NETNSA_CURRENT_NSID => Self::CurrentNsid(
-                parse_i32(payload).context("invalid NETNSA_CURRENT_NSID")?,
-            ),
             kind => Self::Other(
                 DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {kind}"))?,
+                    .map_err(|error| NsidError::UnknownNLA { kind, error })?,
             ),
         })
     }

--- a/src/nsid/error.rs
+++ b/src/nsid/error.rs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+
+use netlink_packet_utils::{nla::NlaError, DecodeError};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum NsidError {
+    #[error("Invalid {kind}")]
+    InvalidValue {
+        kind: &'static str,
+        error: DecodeError,
+    },
+
+    #[error("Unknown NLA type: {kind}")]
+    UnknownNLA { kind: u16, error: DecodeError },
+
+    #[error(transparent)]
+    ParseNla(#[from] NlaError),
+}

--- a/src/nsid/header.rs
+++ b/src/nsid/header.rs
@@ -39,6 +39,7 @@ impl Emitable for NsidHeader {
 }
 
 impl<T: AsRef<[u8]>> Parseable<NsidMessageBuffer<T>> for NsidHeader {
+    type Error = DecodeError;
     fn parse(buf: &NsidMessageBuffer<T>) -> Result<Self, DecodeError> {
         Ok(NsidHeader {
             family: buf.family().into(),

--- a/src/nsid/header.rs
+++ b/src/nsid/header.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 use netlink_packet_utils::{
-    nla::{NlaBuffer, NlasIterator},
+    nla::{NlaBuffer, NlaError, NlasIterator},
     DecodeError, Emitable, Parseable,
 };
 
@@ -17,7 +17,7 @@ buffer!(NsidMessageBuffer(NSID_HEADER_LEN) {
 impl<'a, T: AsRef<[u8]> + ?Sized> NsidMessageBuffer<&'a T> {
     pub fn attributes(
         &self,
-    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
+    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, NlaError>> {
         NlasIterator::new(self.payload())
     }
 }
@@ -39,8 +39,8 @@ impl Emitable for NsidHeader {
 }
 
 impl<T: AsRef<[u8]>> Parseable<NsidMessageBuffer<T>> for NsidHeader {
-    type Error = DecodeError;
-    fn parse(buf: &NsidMessageBuffer<T>) -> Result<Self, DecodeError> {
+    type Error = ();
+    fn parse(buf: &NsidMessageBuffer<T>) -> Result<Self, ()> {
         Ok(NsidHeader {
             family: buf.family().into(),
         })

--- a/src/nsid/message.rs
+++ b/src/nsid/message.rs
@@ -18,6 +18,7 @@ pub struct NsidMessage {
 impl<'a, T: AsRef<[u8]> + 'a> Parseable<NsidMessageBuffer<&'a T>>
     for NsidMessage
 {
+    type Error = DecodeError;
     fn parse(buf: &NsidMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
         Ok(Self {
             header: NsidHeader::parse(buf)
@@ -31,6 +32,7 @@ impl<'a, T: AsRef<[u8]> + 'a> Parseable<NsidMessageBuffer<&'a T>>
 impl<'a, T: AsRef<[u8]> + 'a> Parseable<NsidMessageBuffer<&'a T>>
     for Vec<NsidAttribute>
 {
+    type Error = DecodeError;
     fn parse(buf: &NsidMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
         let mut attributes = vec![];
         for nla_buf in buf.attributes() {

--- a/src/nsid/message.rs
+++ b/src/nsid/message.rs
@@ -1,12 +1,7 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
-use netlink_packet_utils::{
-    traits::{Emitable, Parseable},
-    DecodeError,
-};
-
-use crate::nsid::{NsidAttribute, NsidHeader, NsidMessageBuffer};
+use crate::nsid::{NsidAttribute, NsidError, NsidHeader, NsidMessageBuffer};
+use netlink_packet_utils::traits::{Emitable, Parseable};
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
@@ -18,13 +13,12 @@ pub struct NsidMessage {
 impl<'a, T: AsRef<[u8]> + 'a> Parseable<NsidMessageBuffer<&'a T>>
     for NsidMessage
 {
-    type Error = DecodeError;
-    fn parse(buf: &NsidMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
+    type Error = NsidError;
+    fn parse(buf: &NsidMessageBuffer<&'a T>) -> Result<Self, NsidError> {
         Ok(Self {
-            header: NsidHeader::parse(buf)
-                .context("failed to parse nsid message header")?,
-            attributes: Vec::<NsidAttribute>::parse(buf)
-                .context("failed to parse nsid message NLAs")?,
+            // unwrap: parsing the header can't fail
+            header: NsidHeader::parse(buf).unwrap(),
+            attributes: Vec::<NsidAttribute>::parse(buf)?,
         })
     }
 }
@@ -32,8 +26,8 @@ impl<'a, T: AsRef<[u8]> + 'a> Parseable<NsidMessageBuffer<&'a T>>
 impl<'a, T: AsRef<[u8]> + 'a> Parseable<NsidMessageBuffer<&'a T>>
     for Vec<NsidAttribute>
 {
-    type Error = DecodeError;
-    fn parse(buf: &NsidMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
+    type Error = NsidError;
+    fn parse(buf: &NsidMessageBuffer<&'a T>) -> Result<Self, NsidError> {
         let mut attributes = vec![];
         for nla_buf in buf.attributes() {
             attributes.push(NsidAttribute::parse(&nla_buf?)?);

--- a/src/nsid/mod.rs
+++ b/src/nsid/mod.rs
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: MIT
 
 mod attribute;
+mod error;
 mod header;
 mod message;
 #[cfg(test)]
 mod tests;
 
 pub use self::attribute::NsidAttribute;
+pub use self::error::NsidError;
 pub use self::header::{NsidHeader, NsidMessageBuffer};
 pub use self::message::NsidMessage;

--- a/src/prefix/attribute.rs
+++ b/src/prefix/attribute.rs
@@ -50,6 +50,7 @@ impl nla::Nla for PrefixAttribute {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for PrefixAttribute
 {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();
         match buf.kind() {

--- a/src/prefix/attribute.rs
+++ b/src/prefix/attribute.rs
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: MIT
 
-use std::net::Ipv6Addr;
-
-use anyhow::Context;
+use super::{
+    cache_info::{CacheInfo, CacheInfoBuffer},
+    error::PrefixError,
+};
 use netlink_packet_utils::{
     nla::{self, DefaultNla, NlaBuffer},
     traits::Parseable,
-    DecodeError, Emitable,
+    Emitable,
 };
-
-use super::cache_info::{CacheInfo, CacheInfoBuffer};
+use std::net::Ipv6Addr;
 
 const PREFIX_ADDRESS: u16 = 1;
 const PREFIX_CACHEINFO: u16 = 2;
@@ -50,23 +50,26 @@ impl nla::Nla for PrefixAttribute {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for PrefixAttribute
 {
-    type Error = DecodeError;
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+    type Error = PrefixError;
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, PrefixError> {
         let payload = buf.value();
         match buf.kind() {
             PREFIX_ADDRESS => {
                 if let Ok(payload) = TryInto::<[u8; 16]>::try_into(payload) {
                     Ok(Self::Address(Ipv6Addr::from(payload)))
                 } else {
-                    Err(DecodeError::from(format!("Invalid PREFIX_ADDRESS, unexpected payload length: {:?}", payload)))
+                    Err(PrefixError::InvalidPrefixAddress {
+                        payload_length: payload.len(),
+                    })
                 }
             }
             PREFIX_CACHEINFO => Ok(Self::CacheInfo(
-                CacheInfo::parse(&CacheInfoBuffer::new(payload)).context(
-                    format!("Invalid PREFIX_CACHEINFO: {:?}", payload),
-                )?,
+                CacheInfo::parse(&CacheInfoBuffer::new(payload))
+                    .map_err(PrefixError::InvalidPrefixCacheInfo)?,
             )),
-            _ => Ok(Self::Other(DefaultNla::parse(buf)?)),
+            _ => Ok(Self::Other(
+                DefaultNla::parse(buf).map_err(PrefixError::Other)?,
+            )),
         }
     }
 }

--- a/src/prefix/cache_info.rs
+++ b/src/prefix/cache_info.rs
@@ -17,6 +17,7 @@ buffer!(CacheInfoBuffer(CACHE_INFO_LEN) {
 });
 
 impl<T: AsRef<[u8]>> Parseable<CacheInfoBuffer<T>> for CacheInfo {
+    type Error = DecodeError;
     fn parse(buf: &CacheInfoBuffer<T>) -> Result<Self, DecodeError> {
         Ok(CacheInfo {
             preferred_time: buf.preferred_time(),

--- a/src/prefix/error.rs
+++ b/src/prefix/error.rs
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+
+use netlink_packet_utils::{nla::NlaError, DecodeError};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum PrefixError {
+    #[error(
+        "Invalid PREFIX_ADDRESS, unexpected payload length: {payload_length}"
+    )]
+    InvalidPrefixAddress { payload_length: usize },
+
+    #[error("Invalid PREFIX_CACHEINFO: {0:?}")]
+    InvalidPrefixCacheInfo(DecodeError),
+
+    #[error(transparent)]
+    ParseNla(#[from] NlaError),
+
+    #[error(transparent)]
+    Other(#[from] DecodeError),
+}

--- a/src/prefix/header.rs
+++ b/src/prefix/header.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 use netlink_packet_utils::{
-    nla::{NlaBuffer, NlasIterator},
+    nla::{NlaBuffer, NlaError, NlasIterator},
     DecodeError, Emitable,
 };
 
@@ -22,7 +22,7 @@ buffer!(PrefixMessageBuffer(PREFIX_HEADER_LEN) {
 impl<'a, T: AsRef<[u8]> + ?Sized> PrefixMessageBuffer<&'a T> {
     pub fn nlas(
         &self,
-    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
+    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, NlaError>> {
         NlasIterator::new(self.payload())
     }
 }

--- a/src/prefix/message.rs
+++ b/src/prefix/message.rs
@@ -32,6 +32,7 @@ impl Emitable for PrefixMessage {
 }
 
 impl<T: AsRef<[u8]>> Parseable<PrefixMessageBuffer<T>> for PrefixHeader {
+    type Error = DecodeError;
     fn parse(buf: &PrefixMessageBuffer<T>) -> Result<Self, DecodeError> {
         Ok(Self {
             prefix_family: buf.prefix_family(),
@@ -46,6 +47,7 @@ impl<T: AsRef<[u8]>> Parseable<PrefixMessageBuffer<T>> for PrefixHeader {
 impl<'a, T: AsRef<[u8]> + 'a> Parseable<PrefixMessageBuffer<&'a T>>
     for PrefixMessage
 {
+    type Error = DecodeError;
     fn parse(buf: &PrefixMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
         Ok(Self {
             header: PrefixHeader::parse(buf)
@@ -59,6 +61,7 @@ impl<'a, T: AsRef<[u8]> + 'a> Parseable<PrefixMessageBuffer<&'a T>>
 impl<'a, T: AsRef<[u8]> + 'a> Parseable<PrefixMessageBuffer<&'a T>>
     for Vec<PrefixAttribute>
 {
+    type Error = DecodeError;
     fn parse(buf: &PrefixMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
         let mut nlas = vec![];
         for nla_buf in buf.nlas() {

--- a/src/prefix/message.rs
+++ b/src/prefix/message.rs
@@ -1,16 +1,11 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
-
-use netlink_packet_utils::{
-    traits::{Emitable, Parseable},
-    DecodeError,
-};
-
 use super::{
     attribute::PrefixAttribute,
+    error::PrefixError,
     header::{PrefixHeader, PrefixMessageBuffer},
 };
+use netlink_packet_utils::traits::{Emitable, Parseable};
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub struct PrefixMessage {
@@ -32,8 +27,8 @@ impl Emitable for PrefixMessage {
 }
 
 impl<T: AsRef<[u8]>> Parseable<PrefixMessageBuffer<T>> for PrefixHeader {
-    type Error = DecodeError;
-    fn parse(buf: &PrefixMessageBuffer<T>) -> Result<Self, DecodeError> {
+    type Error = ();
+    fn parse(buf: &PrefixMessageBuffer<T>) -> Result<Self, ()> {
         Ok(Self {
             prefix_family: buf.prefix_family(),
             ifindex: buf.ifindex(),
@@ -47,13 +42,12 @@ impl<T: AsRef<[u8]>> Parseable<PrefixMessageBuffer<T>> for PrefixHeader {
 impl<'a, T: AsRef<[u8]> + 'a> Parseable<PrefixMessageBuffer<&'a T>>
     for PrefixMessage
 {
-    type Error = DecodeError;
-    fn parse(buf: &PrefixMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
+    type Error = PrefixError;
+    fn parse(buf: &PrefixMessageBuffer<&'a T>) -> Result<Self, PrefixError> {
         Ok(Self {
-            header: PrefixHeader::parse(buf)
-                .context("failed to parse prefix message header")?,
-            attributes: Vec::<PrefixAttribute>::parse(buf)
-                .context("failed to parse prefix message attributes")?,
+            // Unwrap: ok, we never return an error above.
+            header: PrefixHeader::parse(buf).unwrap(),
+            attributes: Vec::<PrefixAttribute>::parse(buf)?,
         })
     }
 }
@@ -61,8 +55,8 @@ impl<'a, T: AsRef<[u8]> + 'a> Parseable<PrefixMessageBuffer<&'a T>>
 impl<'a, T: AsRef<[u8]> + 'a> Parseable<PrefixMessageBuffer<&'a T>>
     for Vec<PrefixAttribute>
 {
-    type Error = DecodeError;
-    fn parse(buf: &PrefixMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
+    type Error = PrefixError;
+    fn parse(buf: &PrefixMessageBuffer<&'a T>) -> Result<Self, PrefixError> {
         let mut nlas = vec![];
         for nla_buf in buf.nlas() {
             nlas.push(PrefixAttribute::parse(&nla_buf?)?);

--- a/src/prefix/mod.rs
+++ b/src/prefix/mod.rs
@@ -2,10 +2,12 @@
 
 mod attribute;
 mod cache_info;
+mod error;
 mod header;
 mod message;
 #[cfg(test)]
 mod tests;
 
+pub use error::PrefixError;
 pub use header::PrefixMessageBuffer;
 pub use message::PrefixMessage;

--- a/src/route/attribute.rs
+++ b/src/route/attribute.rs
@@ -194,6 +194,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
         (AddressFamily, RouteType, RouteLwEnCapType),
     > for RouteAttribute
 {
+    type Error = DecodeError;
     fn parse_with_param(
         buf: &NlaBuffer<&'a T>,
         (address_family, route_type, encap_type): (

--- a/src/route/attribute.rs
+++ b/src/route/attribute.rs
@@ -1,21 +1,18 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
+use super::{
+    super::AddressFamily, lwtunnel::VecRouteLwTunnelEncap,
+    metrics::VecRouteMetric, mpls::VecMplsLabel, MplsLabel, RouteAddress,
+    RouteCacheInfo, RouteCacheInfoBuffer, RouteError, RouteLwEnCapType,
+    RouteLwTunnelEncap, RouteMetric, RouteMfcStats, RouteMfcStatsBuffer,
+    RouteMplsTtlPropagation, RouteNextHop, RouteNextHopBuffer, RoutePreference,
+    RouteRealm, RouteType, RouteVia, RouteViaBuffer,
+};
 use byteorder::{ByteOrder, NativeEndian};
 use netlink_packet_utils::{
     nla::{DefaultNla, Nla, NlaBuffer},
     parsers::{parse_u16, parse_u32, parse_u64, parse_u8},
     traits::{Emitable, Parseable, ParseableParametrized},
-    DecodeError,
-};
-
-use super::{
-    super::AddressFamily, lwtunnel::VecRouteLwTunnelEncap,
-    metrics::VecRouteMetric, mpls::VecMplsLabel, MplsLabel, RouteAddress,
-    RouteCacheInfo, RouteCacheInfoBuffer, RouteLwEnCapType, RouteLwTunnelEncap,
-    RouteMetric, RouteMfcStats, RouteMfcStatsBuffer, RouteMplsTtlPropagation,
-    RouteNextHop, RouteNextHopBuffer, RoutePreference, RouteRealm, RouteType,
-    RouteVia, RouteViaBuffer,
 };
 
 const RTA_DST: u16 = 1;
@@ -194,7 +191,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
         (AddressFamily, RouteType, RouteLwEnCapType),
     > for RouteAttribute
 {
-    type Error = DecodeError;
+    type Error = RouteError;
     fn parse_with_param(
         buf: &NlaBuffer<&'a T>,
         (address_family, route_type, encap_type): (
@@ -202,117 +199,184 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
             RouteType,
             RouteLwEnCapType,
         ),
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, RouteError> {
         let payload = buf.value();
         Ok(match buf.kind() {
-            RTA_DST => {
-                Self::Destination(RouteAddress::parse(address_family, payload)?)
-            }
-            RTA_SRC => {
-                Self::Source(RouteAddress::parse(address_family, payload)?)
-            }
-            RTA_GATEWAY => {
-                Self::Gateway(RouteAddress::parse(address_family, payload)?)
-            }
-            RTA_PREFSRC => {
-                Self::PrefSource(RouteAddress::parse(address_family, payload)?)
-            }
+            RTA_DST => Self::Destination(
+                RouteAddress::parse(address_family, payload).map_err(
+                    |error| RouteError::InvalidValue {
+                        kind: "RTA_DST",
+                        error,
+                    },
+                )?,
+            ),
+            RTA_SRC => Self::Source(
+                RouteAddress::parse(address_family, payload).map_err(
+                    |error| RouteError::InvalidValue {
+                        kind: "RTA_SRC",
+                        error,
+                    },
+                )?,
+            ),
+            RTA_GATEWAY => Self::Gateway(
+                RouteAddress::parse(address_family, payload).map_err(
+                    |error| RouteError::InvalidValue {
+                        kind: "RTA_GATEWAY",
+                        error,
+                    },
+                )?,
+            ),
+            RTA_PREFSRC => Self::PrefSource(
+                RouteAddress::parse(address_family, payload).map_err(
+                    |error| RouteError::InvalidValue {
+                        kind: "RTA_PREFSRC",
+                        error,
+                    },
+                )?,
+            ),
             RTA_VIA => Self::Via(
                 RouteVia::parse(
-                    &RouteViaBuffer::new_checked(payload).context(format!(
-                        "Invalid RTA_VIA value {:?}",
-                        payload
-                    ))?,
+                    &RouteViaBuffer::new_checked(payload).map_err(|error| {
+                        RouteError::InvalidValue {
+                            kind: "RTA_VIA",
+                            error,
+                        }
+                    })?,
                 )
-                .context(format!("Invalid RTA_VIA value {:?}", payload))?,
+                .map_err(|error| RouteError::InvalidValue {
+                    kind: "RTA_VIA",
+                    error,
+                })?,
             ),
-            RTA_NEWDST => Self::NewDestination(
-                VecMplsLabel::parse(payload)
-                    .context(format!("Invalid RTA_NEWDST value {:?}", payload))?
-                    .0,
-            ),
+            RTA_NEWDST => Self::NewDestination(VecMplsLabel::parse(payload)?.0),
 
-            RTA_PREF => Self::Preference(parse_u8(payload)?.into()),
+            RTA_PREF => Self::Preference(
+                parse_u8(payload)
+                    .map_err(|error| RouteError::InvalidValue {
+                        kind: "RTA_PREF",
+                        error,
+                    })?
+                    .into(),
+            ),
             RTA_ENCAP => Self::Encap(
                 VecRouteLwTunnelEncap::parse_with_param(buf, encap_type)?.0,
             ),
             RTA_EXPIRES => {
                 if route_type == RouteType::Multicast {
-                    Self::MulticastExpires(parse_u64(payload).context(
-                        format!(
-                            "invalid RTA_EXPIRES (multicast) value {:?}",
-                            payload
-                        ),
+                    Self::MulticastExpires(parse_u64(payload).map_err(
+                        |error| RouteError::InvalidValue {
+                            kind: "RTA_EXPIRES (multicast)",
+                            error,
+                        },
                     )?)
                 } else {
-                    Self::Expires(parse_u32(payload).context(format!(
-                        "invalid RTA_EXPIRES value {:?}",
-                        payload
-                    ))?)
+                    Self::Expires(parse_u32(payload).map_err(|error| {
+                        RouteError::InvalidValue {
+                            kind: "RTA_EXPIRES",
+                            error,
+                        }
+                    })?)
                 }
             }
-            RTA_UID => Self::Uid(
-                parse_u32(payload)
-                    .context(format!("invalid RTA_UID value {:?}", payload))?,
-            ),
+            RTA_UID => Self::Uid(parse_u32(payload).map_err(|error| {
+                RouteError::InvalidValue {
+                    kind: "RTA_UID",
+                    error,
+                }
+            })?),
             RTA_TTL_PROPAGATE => Self::TtlPropagate(
-                RouteMplsTtlPropagation::from(parse_u8(payload).context(
-                    format!("invalid RTA_TTL_PROPAGATE {:?}", payload),
+                RouteMplsTtlPropagation::from(parse_u8(payload).map_err(
+                    |error| RouteError::InvalidValue {
+                        kind: "RTA_TTL_PROPAGATE",
+                        error,
+                    },
                 )?),
             ),
             RTA_ENCAP_TYPE => Self::EncapType(RouteLwEnCapType::from(
-                parse_u16(payload).context("invalid RTA_ENCAP_TYPE value")?,
+                parse_u16(payload).map_err(|error| {
+                    RouteError::InvalidValue {
+                        kind: "RTA_ENCAP_TYPE",
+                        error,
+                    }
+                })?,
             )),
-            RTA_IIF => {
-                Self::Iif(parse_u32(payload).context("invalid RTA_IIF value")?)
+            RTA_IIF => Self::Iif(parse_u32(payload).map_err(|error| {
+                RouteError::InvalidValue {
+                    kind: "RTA_IIF",
+                    error,
+                }
+            })?),
+            RTA_OIF => Self::Oif(parse_u32(payload).map_err(|error| {
+                RouteError::InvalidValue {
+                    kind: "RTA_OIF",
+                    error,
+                }
+            })?),
+            RTA_PRIORITY => {
+                Self::Priority(parse_u32(payload).map_err(|error| {
+                    RouteError::InvalidValue {
+                        kind: "RTA_PRIORITY",
+                        error,
+                    }
+                })?)
             }
-            RTA_OIF => {
-                Self::Oif(parse_u32(payload).context("invalid RTA_OIF value")?)
-            }
-            RTA_PRIORITY => Self::Priority(
-                parse_u32(payload).context("invalid RTA_PRIORITY value")?,
-            ),
-            RTA_FLOW => Self::Realm(
-                RouteRealm::parse(payload).context("invalid RTA_FLOW value")?,
-            ),
-            RTA_TABLE => Self::Table(
-                parse_u32(payload).context("invalid RTA_TABLE value")?,
-            ),
-            RTA_MARK => Self::Mark(
-                parse_u32(payload).context("invalid RTA_MARK value")?,
-            ),
+            RTA_FLOW => Self::Realm(RouteRealm::parse(payload)?),
+            RTA_TABLE => Self::Table(parse_u32(payload).map_err(|error| {
+                RouteError::InvalidValue {
+                    kind: "RTA_TABLE",
+                    error,
+                }
+            })?),
+            RTA_MARK => Self::Mark(parse_u32(payload).map_err(|error| {
+                RouteError::InvalidValue {
+                    kind: "RTA_MARK",
+                    error,
+                }
+            })?),
 
             RTA_CACHEINFO => Self::CacheInfo(
                 RouteCacheInfo::parse(
-                    &RouteCacheInfoBuffer::new_checked(payload)
-                        .context("invalid RTA_CACHEINFO value")?,
+                    &RouteCacheInfoBuffer::new_checked(payload).map_err(
+                        |error| RouteError::InvalidValue {
+                            kind: "RTA_CACHEINFO",
+                            error,
+                        },
+                    )?,
                 )
-                .context("invalid RTA_CACHEINFO value")?,
+                .map_err(|error| RouteError::InvalidValue {
+                    kind: "RTA_CACHEINFO",
+                    error,
+                })?,
             ),
             RTA_MFC_STATS => Self::MfcStats(
                 RouteMfcStats::parse(
-                    &RouteMfcStatsBuffer::new_checked(payload)
-                        .context("invalid RTA_MFC_STATS value")?,
+                    &RouteMfcStatsBuffer::new_checked(payload).map_err(
+                        |error| RouteError::InvalidValue {
+                            kind: "RTA_MFC_STATS",
+                            error,
+                        },
+                    )?,
                 )
-                .context("invalid RTA_MFC_STATS value")?,
+                .map_err(|error| RouteError::InvalidValue {
+                    kind: "RTA_MFC_STATS",
+                    error,
+                })?,
             ),
-            RTA_METRICS => Self::Metrics(
-                VecRouteMetric::parse(payload)
-                    .context("invalid RTA_METRICS value")?
-                    .0,
-            ),
+            RTA_METRICS => Self::Metrics(VecRouteMetric::parse(payload)?.0),
             RTA_MULTIPATH => {
                 let mut next_hops = vec![];
                 let mut buf = payload;
                 loop {
                     let nh_buf = RouteNextHopBuffer::new_checked(&buf)
-                        .context("invalid RTA_MULTIPATH value")?;
+                        .map_err(|error| RouteError::InvalidValue {
+                            kind: "RTA_MULTIPATH",
+                            error,
+                        })?;
                     let len = nh_buf.length() as usize;
                     let nh = RouteNextHop::parse_with_param(
                         &nh_buf,
                         (address_family, route_type, encap_type),
-                    )
-                    .context("invalid RTA_MULTIPATH value")?;
+                    )?;
                     next_hops.push(nh);
                     if buf.len() == len {
                         break;
@@ -321,9 +385,12 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
                 }
                 Self::MultiPath(next_hops)
             }
-            _ => Self::Other(
-                DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?,
-            ),
+            _ => Self::Other(DefaultNla::parse(buf).map_err(|error| {
+                RouteError::InvalidValue {
+                    kind: "NLA (uknown kind)",
+                    error,
+                }
+            })?),
         })
     }
 }

--- a/src/route/cache_info.rs
+++ b/src/route/cache_info.rs
@@ -32,6 +32,7 @@ buffer!(RouteCacheInfoBuffer(CACHE_INFO_LEN) {
 });
 
 impl<T: AsRef<[u8]>> Parseable<RouteCacheInfoBuffer<T>> for RouteCacheInfo {
+    type Error = DecodeError;
     fn parse(buf: &RouteCacheInfoBuffer<T>) -> Result<Self, DecodeError> {
         Ok(Self {
             clntref: buf.clntref(),

--- a/src/route/error.rs
+++ b/src/route/error.rs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+use super::RouteLwEnCapType;
+use netlink_packet_utils::{nla::NlaError, DecodeError};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum RouteError {
+    #[error("Invalid {kind} value")]
+    InvalidValue {
+        kind: &'static str,
+        #[source]
+        error: DecodeError,
+    },
+
+    #[error("cannot parse route attributes in next-hop")]
+    ParseNextHopAttributes(#[source] DecodeError),
+
+    #[error("Invalid RTA_ENCAP for kind: {kind}")]
+    InvalidRtaEncap {
+        kind: RouteLwEnCapType,
+        error: NlaError,
+    },
+
+    #[error("invalid MPLS_IPTUNNEL_DST value")]
+    InvalidMplsIpTunnelTtl(#[source] DecodeError),
+
+    #[error("Invalid {kind} value")]
+    InvalidRouteMetric {
+        kind: &'static str,
+        #[source]
+        error: DecodeError,
+    },
+
+    #[error("Invalid array length. Expected={expected}, got={got}")]
+    ParseMplsLabel { expected: usize, got: usize },
+
+    #[error("Expected single u8 for route protocol")]
+    ParseRouteProtocol,
+
+    #[error("Invalid rule port range data, expecting {expected} u8 array, but got {got}")]
+    InvalidRulePortRange { expected: usize, got: usize },
+
+    #[error(transparent)]
+    ParseNla(#[from] NlaError),
+
+    #[error(transparent)]
+    Other(#[from] DecodeError),
+}

--- a/src/route/header.rs
+++ b/src/route/header.rs
@@ -64,6 +64,7 @@ impl RouteHeader {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<RouteMessageBuffer<&'a T>>
     for RouteHeader
 {
+    type Error = DecodeError;
     fn parse(buf: &RouteMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
         Ok(RouteHeader {
             address_family: buf.address_family().into(),
@@ -246,6 +247,7 @@ impl Default for RouteProtocol {
 }
 
 impl Parseable<[u8]> for RouteProtocol {
+    type Error = DecodeError;
     fn parse(buf: &[u8]) -> Result<Self, DecodeError> {
         if buf.len() == 1 {
             Ok(Self::from(buf[0]))

--- a/src/route/header.rs
+++ b/src/route/header.rs
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: MIT
 
+use super::{super::AddressFamily, flags::RouteFlags, RouteError};
 use netlink_packet_utils::{
-    nla::{NlaBuffer, NlasIterator},
+    nla::{NlaBuffer, NlaError, NlasIterator},
     traits::{Emitable, Parseable},
     DecodeError,
 };
-
-use super::{super::AddressFamily, flags::RouteFlags};
 
 const ROUTE_HEADER_LEN: usize = 12;
 
@@ -26,7 +25,7 @@ buffer!(RouteMessageBuffer(ROUTE_HEADER_LEN) {
 impl<'a, T: AsRef<[u8]> + ?Sized> RouteMessageBuffer<&'a T> {
     pub fn attributes(
         &self,
-    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
+    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, NlaError>> {
         NlasIterator::new(self.payload())
     }
 }
@@ -64,8 +63,8 @@ impl RouteHeader {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<RouteMessageBuffer<&'a T>>
     for RouteHeader
 {
-    type Error = DecodeError;
-    fn parse(buf: &RouteMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
+    type Error = ();
+    fn parse(buf: &RouteMessageBuffer<&'a T>) -> Result<Self, ()> {
         Ok(RouteHeader {
             address_family: buf.address_family().into(),
             destination_prefix_length: buf.destination_prefix_length(),
@@ -247,15 +246,12 @@ impl Default for RouteProtocol {
 }
 
 impl Parseable<[u8]> for RouteProtocol {
-    type Error = DecodeError;
-    fn parse(buf: &[u8]) -> Result<Self, DecodeError> {
+    type Error = RouteError;
+    fn parse(buf: &[u8]) -> Result<Self, RouteError> {
         if buf.len() == 1 {
             Ok(Self::from(buf[0]))
         } else {
-            Err(DecodeError::from(format!(
-                "Expecting single u8 for route protocol, but got {:?}",
-                buf
-            )))
+            Err(RouteError::ParseRouteProtocol)
         }
     }
 }

--- a/src/route/lwtunnel.rs
+++ b/src/route/lwtunnel.rs
@@ -141,6 +141,7 @@ impl<'a, T> ParseableParametrized<NlaBuffer<&'a T>, RouteLwEnCapType>
 where
     T: AsRef<[u8]> + ?Sized,
 {
+    type Error = DecodeError;
     fn parse_with_param(
         buf: &NlaBuffer<&'a T>,
         kind: RouteLwEnCapType,
@@ -163,6 +164,7 @@ impl<'a, T> ParseableParametrized<NlaBuffer<&'a T>, RouteLwEnCapType>
 where
     T: AsRef<[u8]> + ?Sized,
 {
+    type Error = DecodeError;
     fn parse_with_param(
         buf: &NlaBuffer<&'a T>,
         kind: RouteLwEnCapType,

--- a/src/route/lwtunnel.rs
+++ b/src/route/lwtunnel.rs
@@ -1,13 +1,10 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
+use super::{RouteError, RouteMplsIpTunnel};
 use netlink_packet_utils::{
     nla::{DefaultNla, Nla, NlaBuffer, NlasIterator},
     traits::{Emitable, Parseable, ParseableParametrized},
-    DecodeError,
 };
-
-use super::RouteMplsIpTunnel;
 
 const LWTUNNEL_ENCAP_NONE: u16 = 0;
 const LWTUNNEL_ENCAP_MPLS: u16 = 1;
@@ -141,11 +138,11 @@ impl<'a, T> ParseableParametrized<NlaBuffer<&'a T>, RouteLwEnCapType>
 where
     T: AsRef<[u8]> + ?Sized,
 {
-    type Error = DecodeError;
+    type Error = RouteError;
     fn parse_with_param(
         buf: &NlaBuffer<&'a T>,
         kind: RouteLwEnCapType,
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, Self::Error> {
         Ok(match kind {
             RouteLwEnCapType::Mpls => {
                 Self::Mpls(RouteMplsIpTunnel::parse(buf)?)
@@ -164,18 +161,16 @@ impl<'a, T> ParseableParametrized<NlaBuffer<&'a T>, RouteLwEnCapType>
 where
     T: AsRef<[u8]> + ?Sized,
 {
-    type Error = DecodeError;
+    type Error = RouteError;
     fn parse_with_param(
         buf: &NlaBuffer<&'a T>,
         kind: RouteLwEnCapType,
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, RouteError> {
         let mut ret = Vec::new();
         for nla in NlasIterator::new(buf.value()) {
-            let nla =
-                nla.context(format!("Invalid RTA_ENCAP for kind: {kind}"))?;
-            ret.push(RouteLwTunnelEncap::parse_with_param(&nla, kind).context(
-                format!("Failed to parse RTA_ENCAP for kind: {kind}",),
-            )?)
+            let nla = nla
+                .map_err(|error| RouteError::InvalidRtaEncap { error, kind })?;
+            ret.push(RouteLwTunnelEncap::parse_with_param(&nla, kind)?);
         }
         Ok(Self(ret))
     }

--- a/src/route/message.rs
+++ b/src/route/message.rs
@@ -34,6 +34,7 @@ impl Emitable for RouteMessage {
 impl<'a, T: AsRef<[u8]> + 'a> Parseable<RouteMessageBuffer<&'a T>>
     for RouteMessage
 {
+    type Error = DecodeError;
     fn parse(buf: &RouteMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
         let header = RouteHeader::parse(buf)
             .context("failed to parse route message header")?;
@@ -54,6 +55,7 @@ impl<'a, T: AsRef<[u8]> + 'a>
     ParseableParametrized<RouteMessageBuffer<&'a T>, (AddressFamily, RouteType)>
     for Vec<RouteAttribute>
 {
+    type Error = DecodeError;
     fn parse_with_param(
         buf: &RouteMessageBuffer<&'a T>,
         (address_family, route_type): (AddressFamily, RouteType),

--- a/src/route/message.rs
+++ b/src/route/message.rs
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
-use netlink_packet_utils::{
-    traits::{Emitable, Parseable, ParseableParametrized},
-    DecodeError,
-};
-
 use super::{
-    super::AddressFamily, attribute::RTA_ENCAP_TYPE, RouteAttribute,
-    RouteHeader, RouteLwEnCapType, RouteMessageBuffer, RouteType,
+    super::AddressFamily, attribute::RTA_ENCAP_TYPE, error::RouteError,
+    RouteAttribute, RouteHeader, RouteLwEnCapType, RouteMessageBuffer,
+    RouteType,
+};
+use netlink_packet_utils::traits::{
+    Emitable, Parseable, ParseableParametrized,
 };
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
@@ -34,10 +32,10 @@ impl Emitable for RouteMessage {
 impl<'a, T: AsRef<[u8]> + 'a> Parseable<RouteMessageBuffer<&'a T>>
     for RouteMessage
 {
-    type Error = DecodeError;
-    fn parse(buf: &RouteMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
-        let header = RouteHeader::parse(buf)
-            .context("failed to parse route message header")?;
+    type Error = RouteError;
+    fn parse(buf: &RouteMessageBuffer<&'a T>) -> Result<Self, RouteError> {
+        // unwrap: RouteHeader can't fail.
+        let header = RouteHeader::parse(buf).unwrap();
         let address_family = header.address_family;
         let route_type = header.kind;
         Ok(RouteMessage {
@@ -45,8 +43,7 @@ impl<'a, T: AsRef<[u8]> + 'a> Parseable<RouteMessageBuffer<&'a T>>
             attributes: Vec::<RouteAttribute>::parse_with_param(
                 buf,
                 (address_family, route_type),
-            )
-            .context("failed to parse route message NLAs")?,
+            )?,
         })
     }
 }
@@ -55,11 +52,11 @@ impl<'a, T: AsRef<[u8]> + 'a>
     ParseableParametrized<RouteMessageBuffer<&'a T>, (AddressFamily, RouteType)>
     for Vec<RouteAttribute>
 {
-    type Error = DecodeError;
+    type Error = RouteError;
     fn parse_with_param(
         buf: &RouteMessageBuffer<&'a T>,
         (address_family, route_type): (AddressFamily, RouteType),
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, RouteError> {
         let mut attributes = vec![];
         let mut encap_type = RouteLwEnCapType::None;
         // The RTA_ENCAP_TYPE is provided __after__ RTA_ENCAP, we should find

--- a/src/route/metrics.rs
+++ b/src/route/metrics.rs
@@ -127,6 +127,7 @@ impl Nla for RouteMetric {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for RouteMetric {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();
         Ok(match buf.kind() {
@@ -193,6 +194,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for RouteMetric {
 pub(crate) struct VecRouteMetric(pub(crate) Vec<RouteMetric>);
 
 impl<T: AsRef<[u8]> + ?Sized> Parseable<T> for VecRouteMetric {
+    type Error = DecodeError;
     fn parse(payload: &T) -> Result<Self, DecodeError> {
         let mut nlas = vec![];
         for nla in NlasIterator::new(payload) {

--- a/src/route/metrics.rs
+++ b/src/route/metrics.rs
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
+use super::error::RouteError;
 use byteorder::{ByteOrder, NativeEndian};
-use std::mem::size_of;
-
 use netlink_packet_utils::{
     nla::{DefaultNla, Nla, NlaBuffer, NlasIterator},
     parsers::parse_u32,
     traits::Parseable,
-    DecodeError,
 };
+use std::mem::size_of;
 
 const RTAX_LOCK: u16 = 1;
 const RTAX_MTU: u16 = 2;
@@ -127,66 +125,144 @@ impl Nla for RouteMetric {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for RouteMetric {
-    type Error = DecodeError;
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+    type Error = RouteError;
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, RouteError> {
         let payload = buf.value();
         Ok(match buf.kind() {
-            RTAX_LOCK => Self::Lock(
-                parse_u32(payload).context("invalid RTAX_LOCK value")?,
-            ),
-            RTAX_MTU => {
-                Self::Mtu(parse_u32(payload).context("invalid RTAX_MTU value")?)
+            RTAX_LOCK => Self::Lock(parse_u32(payload).map_err(|error| {
+                RouteError::InvalidRouteMetric {
+                    kind: "RTAX_LOCK",
+                    error,
+                }
+            })?),
+            RTAX_MTU => Self::Mtu(parse_u32(payload).map_err(|error| {
+                RouteError::InvalidRouteMetric {
+                    kind: "RTAX_MTU",
+                    error,
+                }
+            })?),
+            RTAX_WINDOW => {
+                Self::Window(parse_u32(payload).map_err(|error| {
+                    RouteError::InvalidRouteMetric {
+                        kind: "RTAX_WINDOW",
+                        error,
+                    }
+                })?)
             }
-            RTAX_WINDOW => Self::Window(
-                parse_u32(payload).context("invalid RTAX_WINDOW value")?,
-            ),
-            RTAX_RTT => {
-                Self::Rtt(parse_u32(payload).context("invalid RTAX_RTT value")?)
+            RTAX_RTT => Self::Rtt(parse_u32(payload).map_err(|error| {
+                RouteError::InvalidRouteMetric {
+                    kind: "RTAX_RTT",
+                    error,
+                }
+            })?),
+            RTAX_RTTVAR => {
+                Self::RttVar(parse_u32(payload).map_err(|error| {
+                    RouteError::InvalidRouteMetric {
+                        kind: "RTAX_RTTVAR",
+                        error,
+                    }
+                })?)
             }
-            RTAX_RTTVAR => Self::RttVar(
-                parse_u32(payload).context("invalid RTAX_RTTVAR value")?,
-            ),
-            RTAX_SSTHRESH => Self::SsThresh(
-                parse_u32(payload).context("invalid RTAX_SSTHRESH value")?,
-            ),
-            RTAX_CWND => Self::Cwnd(
-                parse_u32(payload).context("invalid RTAX_CWND value")?,
-            ),
-            RTAX_ADVMSS => Self::Advmss(
-                parse_u32(payload).context("invalid RTAX_ADVMSS value")?,
-            ),
-            RTAX_REORDERING => Self::Reordering(
-                parse_u32(payload).context("invalid RTAX_REORDERING value")?,
-            ),
-            RTAX_HOPLIMIT => Self::Hoplimit(
-                parse_u32(payload).context("invalid RTAX_HOPLIMIT value")?,
-            ),
-            RTAX_INITCWND => Self::InitCwnd(
-                parse_u32(payload).context("invalid RTAX_INITCWND value")?,
-            ),
-            RTAX_FEATURES => Self::Features(
-                parse_u32(payload).context("invalid RTAX_FEATURES value")?,
-            ),
-            RTAX_RTO_MIN => Self::RtoMin(
-                parse_u32(payload).context("invalid RTAX_RTO_MIN value")?,
-            ),
-            RTAX_INITRWND => Self::InitRwnd(
-                parse_u32(payload).context("invalid RTAX_INITRWND value")?,
-            ),
-            RTAX_QUICKACK => Self::QuickAck(
-                parse_u32(payload).context("invalid RTAX_QUICKACK value")?,
-            ),
-            RTAX_CC_ALGO => Self::CcAlgo(
-                parse_u32(payload).context("invalid RTAX_CC_ALGO value")?,
-            ),
-            RTAX_FASTOPEN_NO_COOKIE => Self::FastopenNoCookie(
-                parse_u32(payload)
-                    .context("invalid RTAX_FASTOPEN_NO_COOKIE value")?,
-            ),
-            _ => Self::Other(
-                DefaultNla::parse(buf)
-                    .context("invalid NLA value (unknown type) value")?,
-            ),
+            RTAX_SSTHRESH => {
+                Self::SsThresh(parse_u32(payload).map_err(|error| {
+                    RouteError::InvalidRouteMetric {
+                        kind: "RTAX_SSHTHRESH",
+                        error,
+                    }
+                })?)
+            }
+            RTAX_CWND => Self::Cwnd(parse_u32(payload).map_err(|error| {
+                RouteError::InvalidRouteMetric {
+                    kind: "RTAX_CWND",
+                    error,
+                }
+            })?),
+            RTAX_ADVMSS => {
+                Self::Advmss(parse_u32(payload).map_err(|error| {
+                    RouteError::InvalidRouteMetric {
+                        kind: "RTAX_ADVMSS",
+                        error,
+                    }
+                })?)
+            }
+            RTAX_REORDERING => {
+                Self::Reordering(parse_u32(payload).map_err(|error| {
+                    RouteError::InvalidRouteMetric {
+                        kind: "RTAX_REORDERING",
+                        error,
+                    }
+                })?)
+            }
+            RTAX_HOPLIMIT => {
+                Self::Hoplimit(parse_u32(payload).map_err(|error| {
+                    RouteError::InvalidRouteMetric {
+                        kind: "RTAX_HOPLIMIT",
+                        error,
+                    }
+                })?)
+            }
+            RTAX_INITCWND => {
+                Self::InitCwnd(parse_u32(payload).map_err(|error| {
+                    RouteError::InvalidRouteMetric {
+                        kind: "RTAX_INITCWND",
+                        error,
+                    }
+                })?)
+            }
+            RTAX_FEATURES => {
+                Self::Features(parse_u32(payload).map_err(|error| {
+                    RouteError::InvalidRouteMetric {
+                        kind: "RTAX_FEATURES",
+                        error,
+                    }
+                })?)
+            }
+            RTAX_RTO_MIN => {
+                Self::RtoMin(parse_u32(payload).map_err(|error| {
+                    RouteError::InvalidRouteMetric {
+                        kind: "RTAX_RTO_MIN",
+                        error,
+                    }
+                })?)
+            }
+            RTAX_INITRWND => {
+                Self::InitRwnd(parse_u32(payload).map_err(|error| {
+                    RouteError::InvalidRouteMetric {
+                        kind: "RTAX_INITRWND",
+                        error,
+                    }
+                })?)
+            }
+            RTAX_QUICKACK => {
+                Self::QuickAck(parse_u32(payload).map_err(|error| {
+                    RouteError::InvalidRouteMetric {
+                        kind: "RTAX_QUICKACK",
+                        error,
+                    }
+                })?)
+            }
+            RTAX_CC_ALGO => {
+                Self::CcAlgo(parse_u32(payload).map_err(|error| {
+                    RouteError::InvalidRouteMetric {
+                        kind: "RTAX_CC_ALGO",
+                        error,
+                    }
+                })?)
+            }
+            RTAX_FASTOPEN_NO_COOKIE => {
+                Self::FastopenNoCookie(parse_u32(payload).map_err(|error| {
+                    RouteError::InvalidRouteMetric {
+                        kind: "RTAX_FASTOPEN_NO_COOKIE",
+                        error,
+                    }
+                })?)
+            }
+            _ => Self::Other(DefaultNla::parse(buf).map_err(|error| {
+                RouteError::InvalidRouteMetric {
+                    kind: "NLA unkwnon",
+                    error,
+                }
+            })?),
         })
     }
 }
@@ -194,12 +270,11 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for RouteMetric {
 pub(crate) struct VecRouteMetric(pub(crate) Vec<RouteMetric>);
 
 impl<T: AsRef<[u8]> + ?Sized> Parseable<T> for VecRouteMetric {
-    type Error = DecodeError;
-    fn parse(payload: &T) -> Result<Self, DecodeError> {
+    type Error = RouteError;
+    fn parse(payload: &T) -> Result<Self, RouteError> {
         let mut nlas = vec![];
         for nla in NlasIterator::new(payload) {
-            let nla = nla.context("Invalid RTA_METRICS")?;
-            nlas.push(RouteMetric::parse(&nla).context("Invalid RTA_METRICS")?);
+            nlas.push(RouteMetric::parse(&nla?)?);
         }
         Ok(Self(nlas))
     }

--- a/src/route/mfc_stats.rs
+++ b/src/route/mfc_stats.rs
@@ -22,6 +22,7 @@ buffer!(RouteMfcStatsBuffer(MFC_STATS_LEN) {
 });
 
 impl<T: AsRef<[u8]>> Parseable<RouteMfcStatsBuffer<T>> for RouteMfcStats {
+    type Error = DecodeError;
     fn parse(
         buf: &RouteMfcStatsBuffer<T>,
     ) -> Result<RouteMfcStats, DecodeError> {

--- a/src/route/mod.rs
+++ b/src/route/mod.rs
@@ -3,6 +3,7 @@
 mod address;
 mod attribute;
 mod cache_info;
+mod error;
 mod flags;
 mod header;
 mod lwtunnel;
@@ -21,6 +22,7 @@ mod tests;
 pub use self::address::RouteAddress;
 pub use self::attribute::RouteAttribute;
 pub use self::cache_info::{RouteCacheInfo, RouteCacheInfoBuffer};
+pub use self::error::RouteError;
 pub use self::header::{
     RouteHeader, RouteMessageBuffer, RouteProtocol, RouteScope, RouteType,
 };

--- a/src/route/mpls.rs
+++ b/src/route/mpls.rs
@@ -50,6 +50,7 @@ impl Nla for RouteMplsIpTunnel {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for RouteMplsIpTunnel
 {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();
         Ok(match buf.kind() {

--- a/src/route/mpls.rs
+++ b/src/route/mpls.rs
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
+use super::error::RouteError;
 use netlink_packet_utils::{
     nla::{DefaultNla, Nla, NlaBuffer},
     parsers::parse_u8,
     traits::{Emitable, Parseable},
-    DecodeError,
 };
 
 const MPLS_IPTUNNEL_DST: u16 = 1;
@@ -50,24 +49,20 @@ impl Nla for RouteMplsIpTunnel {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for RouteMplsIpTunnel
 {
-    type Error = DecodeError;
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+    type Error = RouteError;
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, RouteError> {
         let payload = buf.value();
         Ok(match buf.kind() {
-            MPLS_IPTUNNEL_DST => Self::Destination(
-                VecMplsLabel::parse(payload)
-                    .context(format!(
-                        "invalid MPLS_IPTUNNEL_DST value {:?}",
-                        payload
-                    ))?
-                    .0,
-            ),
+            MPLS_IPTUNNEL_DST => {
+                Self::Destination(VecMplsLabel::parse(payload)?.0)
+            }
             MPLS_IPTUNNEL_TTL => Self::Ttl(
-                parse_u8(payload).context("invalid MPLS_IPTUNNEL_TTL value")?,
+                parse_u8(payload)
+                    .map_err(RouteError::InvalidMplsIpTunnelTtl)?,
             ),
             _ => Self::Other(
                 DefaultNla::parse(buf)
-                    .context("invalid NLA value (unknown type) value")?,
+                    .map_err(RouteError::InvalidMplsIpTunnelTtl)?,
             ),
         })
     }
@@ -96,18 +91,16 @@ pub struct MplsLabel {
 }
 
 impl MplsLabel {
-    pub(crate) fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+    pub(crate) fn parse(payload: &[u8]) -> Result<Self, RouteError> {
         if payload.len() == 4 {
             Ok(Self::from(u32::from_be_bytes([
                 payload[0], payload[1], payload[2], payload[3],
             ])))
         } else {
-            Err(DecodeError::from(format!(
-                "Invalid u8 array length {}, expecting \
-                4 bytes for MPLS label, got {:?}",
-                payload.len(),
-                payload,
-            )))
+            Err(RouteError::ParseMplsLabel {
+                expected: 4,
+                got: payload.len(),
+            })
         }
     }
 }
@@ -149,7 +142,7 @@ impl From<MplsLabel> for u32 {
 pub(crate) struct VecMplsLabel(pub(crate) Vec<MplsLabel>);
 
 impl VecMplsLabel {
-    pub(crate) fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+    pub(crate) fn parse(payload: &[u8]) -> Result<Self, RouteError> {
         let mut labels = vec![];
         let mut i: usize = 0;
         while i + 4 <= payload.len() {

--- a/src/route/next_hops.rs
+++ b/src/route/next_hops.rs
@@ -100,6 +100,7 @@ impl<'a, T: AsRef<[u8]>>
         (AddressFamily, RouteType, RouteLwEnCapType),
     > for RouteNextHop
 {
+    type Error = DecodeError;
     fn parse_with_param(
         buf: &RouteNextHopBuffer<&T>,
         (address_family, route_type, encap_type): (
@@ -129,6 +130,7 @@ impl<'a, T: AsRef<[u8]> + 'a>
         (AddressFamily, RouteType, RouteLwEnCapType),
     > for Vec<RouteAttribute>
 {
+    type Error = DecodeError;
     fn parse_with_param(
         buf: &RouteNextHopBuffer<&'a T>,
         (address_family, route_type, encap_type): (

--- a/src/route/next_hops.rs
+++ b/src/route/next_hops.rs
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
+use super::{
+    super::AddressFamily, RouteAttribute, RouteError, RouteLwEnCapType,
+    RouteType,
+};
 use netlink_packet_utils::{
-    nla::{NlaBuffer, NlasIterator},
+    nla::{NlaBuffer, NlaError, NlasIterator},
     traits::{Emitable, ParseableParametrized},
     DecodeError,
-};
-
-use super::{
-    super::AddressFamily, RouteAttribute, RouteLwEnCapType, RouteType,
 };
 
 pub(crate) const RTNH_F_DEAD: u8 = 1;
@@ -54,18 +53,18 @@ impl<T: AsRef<[u8]>> RouteNextHopBuffer<T> {
     fn check_buffer_length(&self) -> Result<(), DecodeError> {
         let len = self.buffer.as_ref().len();
         if len < PAYLOAD_OFFSET {
-            return Err(format!(
-                "invalid RouteNextHopBuffer: length {len} < {PAYLOAD_OFFSET}"
-            )
-            .into());
+            return Err(DecodeError::InvalidBufferLength {
+                name: "RouteNextHopBuffer",
+                len,
+                buffer_len: PAYLOAD_OFFSET,
+            });
         }
         if len < self.length() as usize {
-            return Err(format!(
-                "invalid RouteNextHopBuffer: length {} < {}",
+            return Err(DecodeError::InvalidBufferLength {
+                name: "RouteNextHopBuffer",
                 len,
-                8 + self.length()
-            )
-            .into());
+                buffer_len: (8 + self.length()) as usize,
+            });
         }
         Ok(())
     }
@@ -74,7 +73,7 @@ impl<T: AsRef<[u8]>> RouteNextHopBuffer<T> {
 impl<'a, T: AsRef<[u8]> + ?Sized> RouteNextHopBuffer<&'a T> {
     pub fn attributes(
         &self,
-    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
+    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, NlaError>> {
         NlasIterator::new(
             &self.payload()[..(self.length() as usize - PAYLOAD_OFFSET)],
         )
@@ -100,7 +99,7 @@ impl<'a, T: AsRef<[u8]>>
         (AddressFamily, RouteType, RouteLwEnCapType),
     > for RouteNextHop
 {
-    type Error = DecodeError;
+    type Error = RouteError;
     fn parse_with_param(
         buf: &RouteNextHopBuffer<&T>,
         (address_family, route_type, encap_type): (
@@ -108,13 +107,11 @@ impl<'a, T: AsRef<[u8]>>
             RouteType,
             RouteLwEnCapType,
         ),
-    ) -> Result<RouteNextHop, DecodeError> {
+    ) -> Result<RouteNextHop, RouteError> {
         let attributes = Vec::<RouteAttribute>::parse_with_param(
-            &RouteNextHopBuffer::new_checked(buf.buffer)
-                .context("cannot parse route attributes in next-hop")?,
+            &RouteNextHopBuffer::new_checked(buf.buffer)?,
             (address_family, route_type, encap_type),
-        )
-        .context("cannot parse route attributes in next-hop")?;
+        )?;
         Ok(RouteNextHop {
             flags: RouteNextHopFlags::from_bits_retain(buf.flags()),
             hops: buf.hops(),
@@ -130,7 +127,7 @@ impl<'a, T: AsRef<[u8]> + 'a>
         (AddressFamily, RouteType, RouteLwEnCapType),
     > for Vec<RouteAttribute>
 {
-    type Error = DecodeError;
+    type Error = RouteError;
     fn parse_with_param(
         buf: &RouteNextHopBuffer<&'a T>,
         (address_family, route_type, encap_type): (
@@ -138,7 +135,7 @@ impl<'a, T: AsRef<[u8]> + 'a>
             RouteType,
             RouteLwEnCapType,
         ),
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, RouteError> {
         let mut nlas = vec![];
         for nla_buf in buf.attributes() {
             nlas.push(RouteAttribute::parse_with_param(

--- a/src/route/realm.rs
+++ b/src/route/realm.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_utils::{DecodeError, Emitable};
+use super::RouteError;
+use netlink_packet_utils::Emitable;
 
 const RULE_REALM_LEN: usize = 4;
 
@@ -11,7 +12,7 @@ pub struct RouteRealm {
 }
 
 impl RouteRealm {
-    pub(crate) fn parse(buf: &[u8]) -> Result<Self, DecodeError> {
+    pub(crate) fn parse(buf: &[u8]) -> Result<Self, RouteError> {
         let all = u32::from_ne_bytes([buf[0], buf[1], buf[2], buf[3]]);
         if buf.len() == RULE_REALM_LEN {
             Ok(Self {
@@ -19,11 +20,10 @@ impl RouteRealm {
                 destination: (all & 0xFFFF) as u16,
             })
         } else {
-            Err(DecodeError::from(format!(
-                "Invalid rule port range data, expecting \
-                {RULE_REALM_LEN} u8 array, but got {:?}",
-                buf
-            )))
+            Err(RouteError::InvalidRulePortRange {
+                expected: RULE_REALM_LEN,
+                got: buf.len(),
+            })
         }
     }
 }

--- a/src/route/via.rs
+++ b/src/route/via.rs
@@ -36,6 +36,7 @@ buffer!(RouteViaBuffer(RTVIA_LEN) {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<RouteViaBuffer<&'a T>>
     for RouteVia
 {
+    type Error = DecodeError;
     fn parse(buf: &RouteViaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let address_family: AddressFamily = (buf.address_family() as u8).into();
         Ok(match address_family {

--- a/src/rule/attribute.rs
+++ b/src/rule/attribute.rs
@@ -152,6 +152,7 @@ impl Nla for RuleAttribute {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for RuleAttribute
 {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();
 

--- a/src/rule/attribute.rs
+++ b/src/rule/attribute.rs
@@ -1,20 +1,17 @@
 // SPDX-License-Identifier: MIT
 
-use std::net::IpAddr;
-
-use anyhow::Context;
+use crate::{
+    ip::{emit_ip_addr, ip_addr_len, parse_ip_addr, IpProtocol},
+    route::{RouteProtocol, RouteRealm},
+    rule::{RuleError, RulePortRange, RuleUidRange},
+};
 use netlink_packet_utils::{
     byteorder::{ByteOrder, NativeEndian},
     nla::{DefaultNla, Nla, NlaBuffer},
     parsers::{parse_string, parse_u32, parse_u8},
-    DecodeError, Emitable, Parseable,
+    Emitable, Parseable,
 };
-
-use crate::{
-    ip::{emit_ip_addr, ip_addr_len, parse_ip_addr, IpProtocol},
-    route::{RouteProtocol, RouteRealm},
-    rule::{RulePortRange, RuleUidRange},
-};
+use std::net::IpAddr;
 
 const FRA_DST: u16 = 1;
 const FRA_SRC: u16 = 2;
@@ -152,79 +149,132 @@ impl Nla for RuleAttribute {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for RuleAttribute
 {
-    type Error = DecodeError;
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+    type Error = RuleError;
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, RuleError> {
         let payload = buf.value();
 
         Ok(match buf.kind() {
-            FRA_DST => Self::Destination(
-                parse_ip_addr(payload)
-                    .context(format!("Invalid FRA_DST value {payload:?}"))?,
-            ),
-            FRA_SRC => Self::Source(
-                parse_ip_addr(payload)
-                    .context(format!("Invalid FRA_SRC value {payload:?}"))?,
-            ),
-            FRA_IIFNAME => Self::Iifname(
-                parse_string(payload).context("invalid FRA_IIFNAME value")?,
-            ),
-            FRA_GOTO => Self::Goto(
-                parse_u32(payload).context("invalid FRA_GOTO value")?,
-            ),
-            FRA_PRIORITY => Self::Priority(
-                parse_u32(payload).context("invalid FRA_PRIORITY value")?,
-            ),
-            FRA_FWMARK => Self::FwMark(
-                parse_u32(payload).context("invalid FRA_FWMARK value")?,
-            ),
-            FRA_FLOW => Self::Realm(
-                RouteRealm::parse(payload).context("invalid FRA_FLOW value")?,
-            ),
-            FRA_TUN_ID => Self::TunId(
-                parse_u32(payload).context("invalid FRA_TUN_ID value")?,
-            ),
-            FRA_SUPPRESS_IFGROUP => Self::SuppressIfGroup(
-                parse_u32(payload)
-                    .context("invalid FRA_SUPPRESS_IFGROUP value")?,
-            ),
-            FRA_SUPPRESS_PREFIXLEN => Self::SuppressPrefixLen(
-                parse_u32(payload)
-                    .context("invalid FRA_SUPPRESS_PREFIXLEN value")?,
-            ),
-            FRA_TABLE => Self::Table(
-                parse_u32(payload).context("invalid FRA_TABLE value")?,
-            ),
-            FRA_FWMASK => Self::FwMask(
-                parse_u32(payload).context("invalid FRA_FWMASK value")?,
-            ),
-            FRA_OIFNAME => Self::Oifname(
-                parse_string(payload).context("invalid FRA_OIFNAME value")?,
-            ),
+            FRA_DST => {
+                Self::Destination(parse_ip_addr(payload).map_err(|error| {
+                    RuleError::InvalidValue {
+                        kind: "FRA_DST",
+                        error,
+                    }
+                })?)
+            }
+            FRA_SRC => {
+                Self::Source(parse_ip_addr(payload).map_err(|error| {
+                    RuleError::InvalidValue {
+                        kind: "FRA_DST",
+                        error,
+                    }
+                })?)
+            }
+            FRA_IIFNAME => {
+                Self::Iifname(parse_string(payload).map_err(|error| {
+                    RuleError::InvalidValue {
+                        kind: "FRA_IIFNAME",
+                        error,
+                    }
+                })?)
+            }
+            FRA_GOTO => Self::Goto(parse_u32(payload).map_err(|error| {
+                RuleError::InvalidValue {
+                    kind: "FRA_GOTO",
+                    error,
+                }
+            })?),
+            FRA_PRIORITY => {
+                Self::Priority(parse_u32(payload).map_err(|error| {
+                    RuleError::InvalidValue {
+                        kind: "FRA_PRIORITY",
+                        error,
+                    }
+                })?)
+            }
+            FRA_FWMARK => {
+                Self::FwMark(parse_u32(payload).map_err(|error| {
+                    RuleError::InvalidValue {
+                        kind: "FRA_FWMARK",
+                        error,
+                    }
+                })?)
+            }
+            FRA_FLOW => Self::Realm(RouteRealm::parse(payload)?),
+            FRA_TUN_ID => Self::TunId(parse_u32(payload).map_err(|error| {
+                RuleError::InvalidValue {
+                    kind: "FRA_TUN_ID",
+                    error,
+                }
+            })?),
+            FRA_SUPPRESS_IFGROUP => {
+                Self::SuppressIfGroup(parse_u32(payload).map_err(|error| {
+                    RuleError::InvalidValue {
+                        kind: "FRA_SUPPRESS_IFGROUP",
+                        error,
+                    }
+                })?)
+            }
+            FRA_SUPPRESS_PREFIXLEN => {
+                Self::SuppressPrefixLen(parse_u32(payload).map_err(
+                    |error| RuleError::InvalidValue {
+                        kind: "FRA_SUPPRESS_PREFIXLEN",
+                        error,
+                    },
+                )?)
+            }
+            FRA_TABLE => Self::Table(parse_u32(payload).map_err(|error| {
+                RuleError::InvalidValue {
+                    kind: "FRA_TABLE",
+                    error,
+                }
+            })?),
+            FRA_FWMASK => {
+                Self::FwMask(parse_u32(payload).map_err(|error| {
+                    RuleError::InvalidValue {
+                        kind: "FRA_FWMASK",
+                        error,
+                    }
+                })?)
+            }
+            FRA_OIFNAME => {
+                Self::Oifname(parse_string(payload).map_err(|error| {
+                    RuleError::InvalidValue {
+                        kind: "FRA_OIFNAME",
+                        error,
+                    }
+                })?)
+            }
             FRA_L3MDEV => Self::L3MDev(
-                parse_u8(payload).context("invalid FRA_L3MDEV value")? > 0,
+                parse_u8(payload).map_err(|error| RuleError::InvalidValue {
+                    kind: "FRA_L3MDEV",
+                    error,
+                })? > 0,
             ),
-            FRA_UID_RANGE => Self::UidRange(
-                RuleUidRange::parse(payload)
-                    .context("invalid FRA_UID_RANGE value")?,
-            ),
+            FRA_UID_RANGE => Self::UidRange(RuleUidRange::parse(payload)?),
             FRA_PROTOCOL => Self::Protocol(
                 parse_u8(payload)
-                    .context("invalid FRA_PROTOCOL value")?
+                    .map_err(|error| RuleError::InvalidValue {
+                        kind: "FRA_PROTOCOL",
+                        error,
+                    })?
                     .into(),
             ),
             FRA_IP_PROTO => Self::IpProtocol(IpProtocol::from(
-                parse_u8(payload).context("invalid FRA_IP_PROTO value")? as i32,
+                parse_u8(payload).map_err(|error| RuleError::InvalidValue {
+                    kind: "FRA_IP_PROTO",
+                    error,
+                })? as i32,
             )),
-            FRA_SPORT_RANGE => Self::SourcePortRange(
-                RulePortRange::parse(payload)
-                    .context("invalid FRA_SPORT_RANGE value")?,
-            ),
-            FRA_DPORT_RANGE => Self::DestinationPortRange(
-                RulePortRange::parse(payload)
-                    .context("invalid FRA_DPORT_RANGE value")?,
-            ),
-            _ => Self::Other(
-                DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?,
+            FRA_SPORT_RANGE => {
+                Self::SourcePortRange(RulePortRange::parse(payload)?)
+            }
+            FRA_DPORT_RANGE => {
+                Self::DestinationPortRange(RulePortRange::parse(payload)?)
+            }
+            kind => Self::Other(
+                DefaultNla::parse(buf)
+                    .map_err(|error| RuleError::UnknownNLA { kind, error })?,
             ),
         })
     }

--- a/src/rule/error.rs
+++ b/src/rule/error.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+
+use crate::route::RouteError;
+use netlink_packet_utils::{nla::NlaError, DecodeError};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum RuleError {
+    #[error("Invalid {kind}")]
+    InvalidValue {
+        kind: &'static str,
+        error: DecodeError,
+    },
+
+    #[error("Unknown NLA type: {kind}")]
+    UnknownNLA { kind: u16, error: DecodeError },
+
+    #[error(transparent)]
+    ParseNla(#[from] NlaError),
+
+    #[error(transparent)]
+    ParseFraFlow(#[from] RouteError),
+
+    #[error("Invalid rule uid range data, expecting {expected} u8 array, but got {got}")]
+    ParseUidRange { expected: usize, got: usize },
+
+    #[error("Invalid rule port range data, expecting {expected} u8 array, but got {got}")]
+    ParsePortRange { expected: usize, got: usize },
+}

--- a/src/rule/header.rs
+++ b/src/rule/header.rs
@@ -63,6 +63,7 @@ impl Emitable for RuleHeader {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<RuleMessageBuffer<&'a T>>
     for RuleHeader
 {
+    type Error = DecodeError;
     fn parse(buf: &RuleMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
         Ok(RuleHeader {
             family: buf.family().into(),

--- a/src/rule/header.rs
+++ b/src/rule/header.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 use netlink_packet_utils::{
-    nla::{NlaBuffer, NlasIterator},
+    nla::{NlaBuffer, NlaError, NlasIterator},
     traits::{Emitable, Parseable},
     DecodeError,
 };
@@ -26,7 +26,7 @@ buffer!(RuleMessageBuffer(RULE_HEADER_LEN) {
 impl<'a, T: AsRef<[u8]> + ?Sized> RuleMessageBuffer<&'a T> {
     pub fn attributes(
         &self,
-    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
+    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, NlaError>> {
         NlasIterator::new(self.payload())
     }
 }
@@ -63,8 +63,8 @@ impl Emitable for RuleHeader {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<RuleMessageBuffer<&'a T>>
     for RuleHeader
 {
-    type Error = DecodeError;
-    fn parse(buf: &RuleMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
+    type Error = ();
+    fn parse(buf: &RuleMessageBuffer<&'a T>) -> Result<Self, ()> {
         Ok(RuleHeader {
             family: buf.family().into(),
             dst_len: buf.dst_len(),

--- a/src/rule/message.rs
+++ b/src/rule/message.rs
@@ -31,6 +31,7 @@ impl Emitable for RuleMessage {
 impl<'a, T: AsRef<[u8]> + 'a> Parseable<RuleMessageBuffer<&'a T>>
     for RuleMessage
 {
+    type Error = DecodeError;
     fn parse(buf: &RuleMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
         let header = RuleHeader::parse(buf)
             .context("failed to parse link message header")?;
@@ -43,6 +44,7 @@ impl<'a, T: AsRef<[u8]> + 'a> Parseable<RuleMessageBuffer<&'a T>>
 impl<'a, T: AsRef<[u8]> + 'a> Parseable<RuleMessageBuffer<&'a T>>
     for Vec<RuleAttribute>
 {
+    type Error = DecodeError;
     fn parse(buf: &RuleMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
         let mut attributes = vec![];
         for nla_buf in buf.attributes() {

--- a/src/rule/message.rs
+++ b/src/rule/message.rs
@@ -1,12 +1,7 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
-use netlink_packet_utils::{
-    traits::{Emitable, Parseable},
-    DecodeError,
-};
-
-use super::{RuleAttribute, RuleHeader, RuleMessageBuffer};
+use super::{RuleAttribute, RuleError, RuleHeader, RuleMessageBuffer};
+use netlink_packet_utils::traits::{Emitable, Parseable};
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
@@ -31,12 +26,11 @@ impl Emitable for RuleMessage {
 impl<'a, T: AsRef<[u8]> + 'a> Parseable<RuleMessageBuffer<&'a T>>
     for RuleMessage
 {
-    type Error = DecodeError;
-    fn parse(buf: &RuleMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
-        let header = RuleHeader::parse(buf)
-            .context("failed to parse link message header")?;
-        let attributes = Vec::<RuleAttribute>::parse(buf)
-            .context("failed to parse link message NLAs")?;
+    type Error = RuleError;
+    fn parse(buf: &RuleMessageBuffer<&'a T>) -> Result<Self, RuleError> {
+        // unwrap: RuleHeader never fails to parse.
+        let header = RuleHeader::parse(buf).unwrap();
+        let attributes = Vec::<RuleAttribute>::parse(buf)?;
         Ok(RuleMessage { header, attributes })
     }
 }
@@ -44,8 +38,8 @@ impl<'a, T: AsRef<[u8]> + 'a> Parseable<RuleMessageBuffer<&'a T>>
 impl<'a, T: AsRef<[u8]> + 'a> Parseable<RuleMessageBuffer<&'a T>>
     for Vec<RuleAttribute>
 {
-    type Error = DecodeError;
-    fn parse(buf: &RuleMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
+    type Error = RuleError;
+    fn parse(buf: &RuleMessageBuffer<&'a T>) -> Result<Self, RuleError> {
         let mut attributes = vec![];
         for nla_buf in buf.attributes() {
             attributes.push(RuleAttribute::parse(&nla_buf?)?);

--- a/src/rule/mod.rs
+++ b/src/rule/mod.rs
@@ -2,6 +2,7 @@
 
 mod action;
 mod attribute;
+mod error;
 mod flags;
 mod header;
 mod message;
@@ -12,6 +13,7 @@ mod uid_range;
 
 pub use self::action::RuleAction;
 pub use self::attribute::RuleAttribute;
+pub use self::error::RuleError;
 pub use self::flags::RuleFlags;
 pub use self::header::{RuleHeader, RuleMessageBuffer};
 pub use self::message::RuleMessage;

--- a/src/rule/port_range.rs
+++ b/src/rule/port_range.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_utils::{DecodeError, Emitable};
+use crate::rule::RuleError;
+use netlink_packet_utils::Emitable;
 
 const RULE_PORT_RANGE_LEN: usize = 4;
 
@@ -11,18 +12,17 @@ pub struct RulePortRange {
 }
 
 impl RulePortRange {
-    pub(crate) fn parse(buf: &[u8]) -> Result<Self, DecodeError> {
+    pub(crate) fn parse(buf: &[u8]) -> Result<Self, RuleError> {
         if buf.len() == RULE_PORT_RANGE_LEN {
             Ok(Self {
                 start: u16::from_ne_bytes([buf[0], buf[1]]),
                 end: u16::from_ne_bytes([buf[2], buf[3]]),
             })
         } else {
-            Err(DecodeError::from(format!(
-                "Invalid rule port range data, expecting \
-                {RULE_PORT_RANGE_LEN} u8 array, but got {:?}",
-                buf
-            )))
+            Err(RuleError::ParsePortRange {
+                expected: RULE_PORT_RANGE_LEN,
+                got: buf.len(),
+            })
         }
     }
 }

--- a/src/rule/uid_range.rs
+++ b/src/rule/uid_range.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_utils::{DecodeError, Emitable};
+use crate::rule::RuleError;
+use netlink_packet_utils::Emitable;
 
 const RULE_UID_RANGE_LEN: usize = 8;
 
@@ -11,18 +12,17 @@ pub struct RuleUidRange {
 }
 
 impl RuleUidRange {
-    pub(crate) fn parse(buf: &[u8]) -> Result<Self, DecodeError> {
+    pub(crate) fn parse(buf: &[u8]) -> Result<Self, RuleError> {
         if buf.len() == RULE_UID_RANGE_LEN {
             Ok(Self {
                 start: u32::from_ne_bytes([buf[0], buf[1], buf[2], buf[3]]),
                 end: u32::from_ne_bytes([buf[4], buf[5], buf[6], buf[7]]),
             })
         } else {
-            Err(DecodeError::from(format!(
-                "Invalid rule port range data, expecting \
-                {RULE_UID_RANGE_LEN} u8 array, but got {:?}",
-                buf
-            )))
+            Err(RuleError::ParseUidRange {
+                expected: RULE_UID_RANGE_LEN,
+                got: buf.len(),
+            })
         }
     }
 }

--- a/src/tc/actions/action.rs
+++ b/src/tc/actions/action.rs
@@ -48,6 +48,7 @@ impl Nla for TcAction {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for TcAction {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let mut attributes = vec![];
         let mut kind = String::new();
@@ -214,6 +215,7 @@ where
     T: AsRef<[u8]> + ?Sized,
     S: AsRef<str>,
 {
+    type Error = DecodeError;
     fn parse_with_param(
         buf: &NlaBuffer<&'a T>,
         kind: S,
@@ -274,6 +276,7 @@ impl Emitable for TcActionGeneric {
 }
 
 impl<T: AsRef<[u8]>> Parseable<TcActionGenericBuffer<T>> for TcActionGeneric {
+    type Error = DecodeError;
     fn parse(buf: &TcActionGenericBuffer<T>) -> Result<Self, DecodeError> {
         Ok(Self {
             index: buf.index(),

--- a/src/tc/actions/mirror.rs
+++ b/src/tc/actions/mirror.rs
@@ -60,6 +60,7 @@ impl Nla for TcActionMirrorOption {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for TcActionMirrorOption
 {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();
         Ok(match buf.kind() {
@@ -105,6 +106,7 @@ impl Emitable for TcMirror {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<TcMirrorBuffer<&'a T>>
     for TcMirror
 {
+    type Error = DecodeError;
     fn parse(buf: &TcMirrorBuffer<&T>) -> Result<Self, DecodeError> {
         Ok(Self {
             generic: TcActionGeneric::parse(&TcActionGenericBuffer::new(

--- a/src/tc/actions/nat.rs
+++ b/src/tc/actions/nat.rs
@@ -60,6 +60,7 @@ impl Nla for TcActionNatOption {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for TcActionNatOption
 {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();
         Ok(match buf.kind() {
@@ -124,6 +125,7 @@ impl Emitable for TcNat {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<TcNatBuffer<&'a T>> for TcNat {
+    type Error = DecodeError;
     fn parse(buf: &TcNatBuffer<&T>) -> Result<Self, DecodeError> {
         Ok(Self {
             generic: TcActionGeneric::parse(&TcActionGenericBuffer::new(

--- a/src/tc/attribute.rs
+++ b/src/tc/attribute.rs
@@ -109,6 +109,7 @@ impl Nla for TcAttribute {
 impl<'a, T: AsRef<[u8]> + ?Sized> ParseableParametrized<NlaBuffer<&'a T>, &str>
     for TcAttribute
 {
+    type Error = DecodeError;
     fn parse_with_param(
         buf: &NlaBuffer<&'a T>,
         kind: &str,

--- a/src/tc/filters/cls_u32.rs
+++ b/src/tc/filters/cls_u32.rs
@@ -115,6 +115,7 @@ impl Nla for TcFilterU32Option {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for TcFilterU32Option
 {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();
         Ok(match buf.kind() {
@@ -219,6 +220,7 @@ impl Emitable for TcU32Selector {
 impl<T: AsRef<[u8]> + ?Sized> Parseable<TcU32SelectorBuffer<&T>>
     for TcU32Selector
 {
+    type Error = DecodeError;
     fn parse(buf: &TcU32SelectorBuffer<&T>) -> Result<Self, DecodeError> {
         let nkeys = buf.nkeys();
         let mut keys = Vec::<TcU32Key>::with_capacity(nkeys.into());
@@ -279,6 +281,7 @@ impl Emitable for TcU32Key {
 }
 
 impl<T: AsRef<[u8]>> Parseable<TcU32KeyBuffer<T>> for TcU32Key {
+    type Error = DecodeError;
     fn parse(buf: &TcU32KeyBuffer<T>) -> Result<Self, DecodeError> {
         Ok(Self {
             mask: buf.mask(),

--- a/src/tc/filters/matchall.rs
+++ b/src/tc/filters/matchall.rs
@@ -71,6 +71,7 @@ impl Nla for TcFilterMatchAllOption {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for TcFilterMatchAllOption
 {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();
         Ok(match buf.kind() {

--- a/src/tc/header.rs
+++ b/src/tc/header.rs
@@ -61,6 +61,7 @@ impl Emitable for TcHeader {
 }
 
 impl<T: AsRef<[u8]>> Parseable<TcMessageBuffer<T>> for TcHeader {
+    type Error = DecodeError;
     fn parse(buf: &TcMessageBuffer<T>) -> Result<Self, DecodeError> {
         Ok(Self {
             family: buf.family().into(),

--- a/src/tc/header.rs
+++ b/src/tc/header.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 use netlink_packet_utils::{
-    nla::{NlaBuffer, NlasIterator},
+    nla::{NlaBuffer, NlaError, NlasIterator},
     traits::{Emitable, Parseable},
     DecodeError,
 };
@@ -24,7 +24,7 @@ buffer!(TcMessageBuffer(TC_HEADER_LEN) {
 impl<'a, T: AsRef<[u8]> + ?Sized> TcMessageBuffer<&'a T> {
     pub fn attributes(
         &self,
-    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
+    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, NlaError>> {
         NlasIterator::new(self.payload())
     }
 }

--- a/src/tc/message.rs
+++ b/src/tc/message.rs
@@ -37,6 +37,7 @@ impl TcMessage {
 }
 
 impl<'a, T: AsRef<[u8]> + 'a> Parseable<TcMessageBuffer<&'a T>> for TcMessage {
+    type Error = DecodeError;
     fn parse(buf: &TcMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
         Ok(Self {
             header: TcHeader::parse(buf)
@@ -50,6 +51,7 @@ impl<'a, T: AsRef<[u8]> + 'a> Parseable<TcMessageBuffer<&'a T>> for TcMessage {
 impl<'a, T: AsRef<[u8]> + 'a> Parseable<TcMessageBuffer<&'a T>>
     for Vec<TcAttribute>
 {
+    type Error = DecodeError;
     fn parse(buf: &TcMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
         let mut attributes = vec![];
         let mut kind = String::new();

--- a/src/tc/options.rs
+++ b/src/tc/options.rs
@@ -62,6 +62,7 @@ impl<'a, T> ParseableParametrized<NlaBuffer<&'a T>, &str> for TcOption
 where
     T: AsRef<[u8]> + ?Sized,
 {
+    type Error = DecodeError;
     fn parse_with_param(
         buf: &NlaBuffer<&'a T>,
         kind: &str,
@@ -97,6 +98,7 @@ impl<'a, T> ParseableParametrized<NlaBuffer<&'a T>, &str> for VecTcOption
 where
     T: AsRef<[u8]> + ?Sized,
 {
+    type Error = DecodeError;
     fn parse_with_param(
         buf: &NlaBuffer<&'a T>,
         kind: &str,

--- a/src/tc/qdiscs/fq_codel.rs
+++ b/src/tc/qdiscs/fq_codel.rs
@@ -32,6 +32,7 @@ pub enum TcFqCodelXstats {
 }
 
 impl<T: AsRef<[u8]> + ?Sized> Parseable<T> for TcFqCodelXstats {
+    type Error = DecodeError;
     fn parse(buf: &T) -> Result<Self, DecodeError> {
         if buf.as_ref().len() < 4 {
             return Err(DecodeError::from(format!(
@@ -117,6 +118,7 @@ buffer!(TcFqCodelQdStatsBuffer(TC_FQ_CODEL_QD_STATS_LEN) {
 });
 
 impl<T: AsRef<[u8]>> Parseable<TcFqCodelQdStatsBuffer<T>> for TcFqCodelQdStats {
+    type Error = DecodeError;
     fn parse(buf: &TcFqCodelQdStatsBuffer<T>) -> Result<Self, DecodeError> {
         Ok(Self {
             maxpacket: buf.maxpacket(),
@@ -172,6 +174,7 @@ buffer!(TcFqCodelClStatsBuffer(TC_FQ_CODEL_CL_STATS_LEN) {
 });
 
 impl<T: AsRef<[u8]>> Parseable<TcFqCodelClStatsBuffer<T>> for TcFqCodelClStats {
+    type Error = DecodeError;
     fn parse(buf: &TcFqCodelClStatsBuffer<T>) -> Result<Self, DecodeError> {
         Ok(Self {
             deficit: buf.deficit(),
@@ -285,6 +288,7 @@ impl Nla for TcQdiscFqCodelOption {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for TcQdiscFqCodelOption
 {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();
         Ok(match buf.kind() {

--- a/src/tc/qdiscs/ingress.rs
+++ b/src/tc/qdiscs/ingress.rs
@@ -46,6 +46,7 @@ impl Nla for TcQdiscIngressOption {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for TcQdiscIngressOption
 {
+    type Error = DecodeError;
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         Ok(Self::Other(
             DefaultNla::parse(buf).context("failed to parse ingress nla")?,

--- a/src/tc/stats/basic.rs
+++ b/src/tc/stats/basic.rs
@@ -24,6 +24,7 @@ buffer!(TcStatsBasicBuffer(STATS_BASIC_LEN) {
 });
 
 impl<T: AsRef<[u8]>> Parseable<TcStatsBasicBuffer<T>> for TcStatsBasic {
+    type Error = DecodeError;
     fn parse(buf: &TcStatsBasicBuffer<T>) -> Result<Self, DecodeError> {
         Ok(TcStatsBasic {
             bytes: buf.bytes(),

--- a/src/tc/stats/compat.rs
+++ b/src/tc/stats/compat.rs
@@ -41,6 +41,7 @@ buffer!(TcStatsBuffer(STATS_LEN) {
 });
 
 impl<T: AsRef<[u8]>> Parseable<TcStatsBuffer<T>> for TcStats {
+    type Error = DecodeError;
     fn parse(buf: &TcStatsBuffer<T>) -> Result<Self, DecodeError> {
         Ok(Self {
             bytes: buf.bytes(),

--- a/src/tc/stats/queue.rs
+++ b/src/tc/stats/queue.rs
@@ -32,6 +32,7 @@ buffer!(TcStatsQueueBuffer( STATS_QUEUE_LEN) {
 });
 
 impl<T: AsRef<[u8]>> Parseable<TcStatsQueueBuffer<T>> for TcStatsQueue {
+    type Error = DecodeError;
     fn parse(buf: &TcStatsQueueBuffer<T>) -> Result<Self, DecodeError> {
         Ok(Self {
             qlen: buf.qlen(),

--- a/src/tc/stats/stats2.rs
+++ b/src/tc/stats/stats2.rs
@@ -65,6 +65,7 @@ impl<'a, T> ParseableParametrized<NlaBuffer<&'a T>, &str> for TcStats2
 where
     T: AsRef<[u8]> + ?Sized,
 {
+    type Error = DecodeError;
     fn parse_with_param(
         buf: &NlaBuffer<&'a T>,
         kind: &str,

--- a/src/tc/stats/xstats.rs
+++ b/src/tc/stats/xstats.rs
@@ -35,6 +35,7 @@ impl<'a, T> ParseableParametrized<NlaBuffer<&'a T>, &str> for TcXstats
 where
     T: AsRef<[u8]> + ?Sized,
 {
+    type Error = DecodeError;
     fn parse_with_param(
         buf: &NlaBuffer<&'a T>,
         kind: &str,


### PR DESCRIPTION
We recently had a need in our codebase to match against an error returned by this crate. Having logic based on various error scenarios at the moment required converting the error to a string and doing string comparisons. This is quite brittle and not ideal.

This is a proposal to return `thiserror` Errors instead of `anyhow` Errors in all the crate.

I'm currently taking the approach of converting every instance of `anyhow::Error` to equivalent variants of various enums deriving `thiserror::Error`.

I'm currently missing fixing the following directories:

- [ ] tc/*
- [ ] link/*

I'd like to do so in the same PR, but wanted to hear your thoughts on whether this is a direction you like.