### PR TITLE
Avoid two panics during parsing

### DIFF
--- a/src/route/next_hops.rs
+++ b/src/route/next_hops.rs
@@ -63,7 +63,7 @@ impl<T: AsRef<[u8]>> RouteNextHopBuffer<T> {
             return Err(format!(
                 "invalid RouteNextHopBuffer: length {} < {}",
                 len,
-                8 + self.length()
+                self.length(),
             )
             .into());
         }

--- a/src/route/tests/route_flags.rs
+++ b/src/route/tests/route_flags.rs
@@ -8,7 +8,7 @@ use netlink_packet_utils::traits::{Emitable, Parseable};
 use crate::route::flags::RouteFlags;
 use crate::route::{
     RouteAttribute, RouteHeader, RouteMessage, RouteMessageBuffer,
-    RouteProtocol, RouteScope, RouteType,
+    RouteNextHopBuffer, RouteProtocol, RouteScope, RouteType,
 };
 use crate::AddressFamily;
 
@@ -53,4 +53,16 @@ fn test_ipv6_add_route_onlink() {
     expected.emit(&mut buf);
 
     assert_eq!(buf, raw);
+}
+
+// Verify that [`RouteNextHopBuffer`] rejects the buffer when provided with
+// an invalid length.
+#[test]
+fn test_next_hop_max_buffer_len() {
+    // Route next-hop buffer layout:
+    // |byte0|byte1|byte2|byte3|byte4|byte5|byte6|byte7|bytes8+|
+    // |-----|-----|-----|-----|-----|-----|-----|-----|-------|
+    // |  length   |flags|hops |    Interface Index    |Payload|
+    let buffer = [0xff, 0xff, 0, 0, 0, 0, 0, 0];
+    assert!(RouteNextHopBuffer::new_checked(buffer).is_err());
 }

--- a/src/tc/filters/mod.rs
+++ b/src/tc/filters/mod.rs
@@ -6,6 +6,7 @@ mod u32_flags;
 
 pub use self::cls_u32::{
     TcFilterU32, TcFilterU32Option, TcU32Key, TcU32Selector,
+    TcU32SelectorBuffer,
 };
 pub use self::matchall::{TcFilterMatchAll, TcFilterMatchAllOption};
 pub use u32_flags::{TcU32OptionFlags, TcU32SelectorFlags};

--- a/src/tc/mod.rs
+++ b/src/tc/mod.rs
@@ -20,7 +20,8 @@ pub use self::actions::{
 pub use self::attribute::TcAttribute;
 pub use self::filters::{
     TcFilterMatchAll, TcFilterMatchAllOption, TcFilterU32, TcFilterU32Option,
-    TcU32Key, TcU32OptionFlags, TcU32Selector, TcU32SelectorFlags,
+    TcU32Key, TcU32OptionFlags, TcU32Selector, TcU32SelectorBuffer,
+    TcU32SelectorFlags,
 };
 pub use self::header::{TcHandle, TcHeader, TcMessageBuffer};
 pub use self::message::TcMessage;

--- a/src/tc/tests/filter_u32.rs
+++ b/src/tc/tests/filter_u32.rs
@@ -9,6 +9,7 @@ use crate::{
         filters::{TcU32OptionFlags, TcU32SelectorFlags},
         TcAttribute, TcFilterU32Option, TcHandle, TcHeader, TcMessage,
         TcMessageBuffer, TcOption, TcU32Key, TcU32Selector,
+        TcU32SelectorBuffer,
     },
     AddressFamily,
 };
@@ -111,4 +112,24 @@ fn test_get_filter_u32() {
     expected.emit(&mut buf);
 
     assert_eq!(buf, raw);
+}
+
+// Verify that [`TcU32Selector`] fails to parse a buffer with an
+// invalid number of keys.
+#[test]
+fn test_tcu32_selector_invalid_nkeys() {
+    // TC u32 selector buffer layout:
+    // |byte0|byte1|byte2|byte3|byte4|byte5|byte6|byte7|
+    // |-----|-----|-----|-----|-----|-----|-----|-----|
+    // |flags|shift|nkeys|pad  |  offmask  |    off    |
+    // |-----|-----|-----|-----|-----|-----|-----|-----|
+    // |   offoff  |   hoff    |         hmask         |
+    // |-----|-----|-----|-----|-----|-----|-----|-----|
+    // |                     keys                      |
+    // |                      ...                      |
+    let buffer = [
+        0x00, 0x00, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00,
+    ];
+    assert!(TcU32SelectorBuffer::new_checked(buffer).is_err());
 }


### PR DESCRIPTION
The first occurs when checking the length of RouteNextHopBuffer. 
If the next-hops length is u16::MAX, adding 8 (the PAYLOAD_OFFSET) to
it would cause integer overflow and lead to a panic. Rather than
switching to `saturating_add`, remove the addition entirely. It was
unnecessary, as the provided length already accounts for the RTA struct.

The second occurs when parsing a TcU32Selector.
`TcU32SelectorBuffer::new_checked` returns an error when the underlying
buffer is not large enough to contain `nkeys`. This avoids an
index-out-of-bounds panic in `TcU32Selector::parse`, when extracting
keys from the underlying buffer.