### PR TITLE
New release 0.21.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,25 @@
 # Changelog
+## [0.21.0] - 2024-09-12
+### Breaking changes
+ - `InfoIpVlan::Flags` changed from u16 to `IpVlanFlags`. (321e4d5)
+ - `AfSpecBridge::Flags` changed from u16 to `BridgeFlag`. (40d090b)
+ - `InfoBond::ArpValidate` changed from u32 to `BondArpValidate`.(5246712)
+ - `InfoVxlan::Group` changed from `Vec<u8>` to `Ipv4Addr`. (538e13b)
+ - `InfoVxlan::Group6` changed from `Vec<u8>` to `Ipv6Addr`. (538e13b)
+ - `InfoVxlan::Local` changed from `Vec<u8>` to `Ipv4Addr`. (538e13b)
+ - `InfoVxlan::Local6` changed from `Vec<u8>` to `Ipv6Addr`. (538e13b)
+
+### New features
+ - bridge port: Introduce BridgeFlag, BridgeMode and BridgeVlanTunnelInfo.
+   (40d090b)
+ - Add support for geneve links. (7391b19)
+
+### Bug fixes
+ - Avoid panic in TcU32Selector parsing. (c49e3ac)
+ - Avoid panic in RouteNextHopBuffer length checks. (666edbc)
+ - Check NLA buffers on creation. (fceb9c2)
+ - Check Map buffers on creation. (d53bbad)
+
 ## [0.20.1] - 2024-06-29
 ### Breaking changes
  - N/A

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-packet-route"
-version = "0.20.1"
+version = "0.21.0"
 edition = "2021"
 
 homepage = "https://github.com/rust-netlink/netlink-packet-route"

--- a/tools/make_release.sh
+++ b/tools/make_release.sh
@@ -55,7 +55,7 @@ git fetch upstream || (git remote add upstream $UPSTERAM_GIT; \
 git reset --hard upstream/$MAIN_BRANCH_NAME
 
 echo "Checking 'cargo publish --dry-run'"
-
+cargo set-version $NEXT_VERSION
 cargo publish --dry-run
 
 echo "# Changelog" > $TMP_CHANGELOG_FILE
@@ -75,13 +75,11 @@ if [ $(wc -l < $TMP_CHANGELOG_FILE) -lt 2 ];then
     exit 1
 fi
 
-cargo set-version $NEXT_VERSION
-
 CHANGELOG_STR=$(sed -n '3,$p' $TMP_CHANGELOG_FILE|tr '#' '=')
 sed -n '2,$p' CHANGELOG >> $TMP_CHANGELOG_FILE
 
 mv $TMP_CHANGELOG_FILE $CODE_BASE_DIR/CHANGELOG
-git commit --signoff $CODE_BASE_DIR/CHANGELOG -m "New release ${NEXT_VERSION}" \
+git commit --signoff -a -m "New release ${NEXT_VERSION}" \
     -m "$CHANGELOG_STR"
 git push origin +new_release
 echo "Please visit github to create pull request for this breach"


### PR DESCRIPTION
=== Breaking changes
 - `InfoIpVlan::Flags` changed from u16 to `IpVlanFlags`. (321e4d5)
 - `AfSpecBridge::Flags` changed from u16 to `BridgeFlag`. (40d090b)
 - `InfoBond::ArpValidate` changed from u32 to `BondArpValidate`.(5246712)
 - `InfoVxlan::Group` changed from `Vec<u8>` to `Ipv4Addr`. (538e13b)
 - `InfoVxlan::Group6` changed from `Vec<u8>` to `Ipv6Addr`. (538e13b)
 - `InfoVxlan::Local` changed from `Vec<u8>` to `Ipv4Addr`. (538e13b)
 - `InfoVxlan::Local6` changed from `Vec<u8>` to `Ipv6Addr`. (538e13b)

=== New features
 - bridge port: Introduce BridgeFlag, BridgeMode and BridgeVlanTunnelInfo.
   (40d090b)
 - Add support for geneve links. (7391b19)

=== Bug fixes
 - Avoid panic in TcU32Selector parsing. (c49e3ac)
 - Avoid panic in RouteNextHopBuffer length checks. (666edbc)
 - Check NLA buffers on creation. (fceb9c2)
 - Check Map buffers on creation. (d53bbad)