### PR TITLE
Add support for Seg6 encapsulation type

### DIFF
--- a/src/route/attribute.rs
+++ b/src/route/attribute.rs
@@ -186,6 +186,16 @@ impl Nla for RouteAttribute {
             Self::Other(ref attr) => attr.kind(),
         }
     }
+
+    fn is_nested(&self) -> bool {
+        if let Self::Encap(encap) = self {
+            encap
+                .iter()
+                .any(|e| matches!(e, RouteLwTunnelEncap::Seg6(_)))
+        } else {
+            false
+        }
+    }
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized>

--- a/src/route/lwtunnel.rs
+++ b/src/route/lwtunnel.rs
@@ -7,7 +7,7 @@ use netlink_packet_utils::{
     DecodeError,
 };
 
-use super::RouteMplsIpTunnel;
+use super::{RouteMplsIpTunnel, RouteSeg6IpTunnel};
 
 const LWTUNNEL_ENCAP_NONE: u16 = 0;
 const LWTUNNEL_ENCAP_MPLS: u16 = 1;
@@ -110,6 +110,7 @@ impl std::fmt::Display for RouteLwEnCapType {
 #[non_exhaustive]
 pub enum RouteLwTunnelEncap {
     Mpls(RouteMplsIpTunnel),
+    Seg6(RouteSeg6IpTunnel),
     Other(DefaultNla),
 }
 
@@ -117,6 +118,7 @@ impl Nla for RouteLwTunnelEncap {
     fn value_len(&self) -> usize {
         match self {
             Self::Mpls(v) => v.value_len(),
+            Self::Seg6(v) => v.value_len(),
             Self::Other(v) => v.value_len(),
         }
     }
@@ -124,6 +126,7 @@ impl Nla for RouteLwTunnelEncap {
     fn emit_value(&self, buffer: &mut [u8]) {
         match self {
             Self::Mpls(v) => v.emit_value(buffer),
+            Self::Seg6(v) => v.emit_value(buffer),
             Self::Other(v) => v.emit_value(buffer),
         }
     }
@@ -131,6 +134,7 @@ impl Nla for RouteLwTunnelEncap {
     fn kind(&self) -> u16 {
         match self {
             Self::Mpls(v) => v.kind(),
+            Self::Seg6(v) => v.kind(),
             Self::Other(v) => v.kind(),
         }
     }
@@ -148,6 +152,9 @@ where
         Ok(match kind {
             RouteLwEnCapType::Mpls => {
                 Self::Mpls(RouteMplsIpTunnel::parse(buf)?)
+            }
+            RouteLwEnCapType::Seg6 => {
+                Self::Seg6(RouteSeg6IpTunnel::parse(buf)?)
             }
             _ => Self::Other(DefaultNla::parse(buf)?),
         })

--- a/src/route/mod.rs
+++ b/src/route/mod.rs
@@ -13,6 +13,7 @@ mod mpls;
 mod next_hops;
 mod preference;
 mod realm;
+mod seg6;
 mod via;
 
 #[cfg(test)]
@@ -34,5 +35,6 @@ pub use self::next_hops::{
 };
 pub use self::preference::RoutePreference;
 pub use self::realm::RouteRealm;
+pub use self::seg6::{RouteSeg6IpTunnel, Seg6Header, Seg6Mode};
 pub use self::via::{RouteVia, RouteViaBuffer};
 pub use flags::RouteFlags;

--- a/src/route/seg6.rs
+++ b/src/route/seg6.rs
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: MIT
+
+use anyhow::Context;
+use byteorder::{ByteOrder, NativeEndian};
+use netlink_packet_utils::{
+    nla::{DefaultNla, Nla, NlaBuffer},
+    Parseable,
+};
+use std::net::Ipv6Addr;
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[non_exhaustive]
+pub enum Seg6Mode {
+    // Inline mode for Seg6
+    Inline,
+    // Encapsulation mode for Seg6
+    Encap,
+    // L2ENCAP = 2,
+    // ENCAP_RED = 3,
+    // L2ENCAP_RED = 4
+    Other(u32),
+}
+
+impl From<Seg6Mode> for u32 {
+    fn from(value: Seg6Mode) -> Self {
+        match value {
+            Seg6Mode::Inline => 0,
+            Seg6Mode::Encap => 1,
+            Seg6Mode::Other(i) => i,
+        }
+    }
+}
+
+impl From<u32> for Seg6Mode {
+    fn from(value: u32) -> Self {
+        match value {
+            0 => Seg6Mode::Inline,
+            1 => Seg6Mode::Encap,
+            v => Seg6Mode::Other(v),
+        }
+    }
+}
+
+const SEG6_IPTUNNEL_SRH: u16 = 1;
+
+/// Netlink attributes for `RTA_ENCAP` with `RTA_ENCAP_TYPE` set to
+/// `LWTUNNEL_ENCAP_SEG6`.
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
+pub enum RouteSeg6IpTunnel {
+    // Use an IPv6 segment routing header
+    Seg6(Seg6Header),
+    Other(DefaultNla),
+}
+
+impl Nla for RouteSeg6IpTunnel {
+    fn value_len(&self) -> usize {
+        match self {
+            RouteSeg6IpTunnel::Seg6(v) => v.value_len(),
+            RouteSeg6IpTunnel::Other(v) => v.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            RouteSeg6IpTunnel::Seg6(v) => v.kind(),
+            RouteSeg6IpTunnel::Other(v) => v.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            RouteSeg6IpTunnel::Seg6(v) => v.emit_value(buffer),
+            RouteSeg6IpTunnel::Other(v) => v.emit_value(buffer),
+        }
+    }
+}
+
+/// Netlink attributes for `RTA_ENCAP` with `RTA_ENCAP_TYPE` set to
+/// `LWTUNNEL_ENCAP_SEG6`.
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
+pub struct Seg6Header {
+    // Operation mode
+    pub mode: Seg6Mode,
+    // List of segments
+    pub segments: Vec<Ipv6Addr>,
+}
+
+impl Nla for Seg6Header {
+    fn value_len(&self) -> usize {
+        let segments = match self.mode {
+            Seg6Mode::Inline => self.segments.len() + 1,
+            Seg6Mode::Encap => self.segments.len(),
+            Seg6Mode::Other(_) => self.segments.len(),
+        };
+        12 + 16 * segments
+    }
+
+    fn kind(&self) -> u16 {
+        SEG6_IPTUNNEL_SRH
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        // Some sources for understanding the format of Seg6 in Netlink
+        // https://github.com/torvalds/linux/blob/master/include/uapi/linux/seg6.h
+        // https://github.com/iproute2/iproute2/blob/main/include/uapi/linux/seg6_iptunnel.h#L27
+        // https://github.com/iproute2/iproute2/blob/e3f9681d4a777fb2595a322b421abf0036ab1aae/ip/iproute_lwtunnel.c#L952
+
+        let mut number_segments = self.segments.len();
+        if matches!(self.mode, Seg6Mode::Inline) {
+            number_segments += 1 // last segment (::) added
+        }
+
+        let srhlen = 8 + 16 * number_segments;
+
+        // mode : 4 bytes
+        NativeEndian::write_u32(&mut buffer[..4], self.mode.into());
+        // nexthdr : 1 bytes
+        buffer[4] = 0;
+        // hdrlen : 1 bytes
+        buffer[5] = ((srhlen >> 3) - 1) as u8;
+        // type : 1 byte
+        buffer[6] = 4;
+        // segments_left : 1 byte
+        buffer[7] = (number_segments - 1) as u8;
+        // first_segment : 1 byte
+        buffer[8] = (number_segments - 1) as u8;
+        // flags : 1 byte
+        buffer[9] = 0;
+        // tag : 2 bytes
+        NativeEndian::write_u16(&mut buffer[10..12], 0);
+
+        let mut offset = 12;
+
+        // Add the last segment (::) if working in inline mode
+        if matches!(self.mode, Seg6Mode::Inline) {
+            let addr: Ipv6Addr = "::".parse().expect("Impossible error");
+            buffer[offset..offset + 16].copy_from_slice(&addr.octets());
+            offset += 16;
+        }
+
+        // Add all segments in reverse order
+        for addr in self.segments.iter().rev() {
+            buffer[offset..offset + 16].copy_from_slice(&addr.octets());
+            offset += 16;
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
+    for RouteSeg6IpTunnel
+{
+    fn parse(
+        buf: &NlaBuffer<&'a T>,
+    ) -> Result<Self, netlink_packet_utils::DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            SEG6_IPTUNNEL_SRH => {
+                let mode = NativeEndian::read_u32(payload).into();
+
+                let number_segments = payload[7];
+
+                let mut offset = 12;
+                let mut segments: Vec<Ipv6Addr> = vec![];
+                for _ in 0..number_segments + 1 {
+                    let slice: [u8; 16] = payload[offset..offset + 16]
+                        .try_into()
+                        .expect("Impossible to fail");
+                    let ip_addr = Ipv6Addr::from(slice);
+                    segments.push(ip_addr);
+                    offset += 16;
+                }
+
+                let mut segments: Vec<Ipv6Addr> =
+                    segments.into_iter().rev().collect();
+
+                if matches!(mode, Seg6Mode::Inline) {
+                    segments.pop(); // remove last inline segment
+                }
+
+                RouteSeg6IpTunnel::Seg6(Seg6Header { mode, segments })
+            }
+            _ => Self::Other(
+                DefaultNla::parse(buf)
+                    .context("invalid NLA value (unknown type) value")?,
+            ),
+        })
+    }
+}

--- a/src/route/tests/mod.rs
+++ b/src/route/tests/mod.rs
@@ -15,6 +15,8 @@ mod realm;
 #[cfg(test)]
 mod route_flags;
 #[cfg(test)]
+mod seg6;
+#[cfg(test)]
 mod uid;
 #[cfg(test)]
 mod via;

--- a/src/route/tests/seg6.rs
+++ b/src/route/tests/seg6.rs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MIT
+
+use std::net::Ipv6Addr;
+use std::str::FromStr;
+
+use netlink_packet_utils::{Emitable, Parseable};
+
+use crate::{
+    route::{
+        seg6::{RouteSeg6IpTunnel, Seg6Mode},
+        RouteAttribute, RouteFlags, RouteHeader, RouteLwEnCapType,
+        RouteLwTunnelEncap, RouteMessage, RouteMessageBuffer, RouteProtocol,
+        RouteScope, RouteType, Seg6Header,
+    },
+    AddressFamily,
+};
+
+// Setup:
+//      ip link add dummy1 type dummy
+//      ip link set dummy1 up
+//      ip route add fe80::/32 encap seg6 mode encap \
+//          segs fe80::1,fe80::2 dev dummy1
+// wireshark capture(netlink message header removed) of nlmon against command:
+//      ip -6 route show dev dummy1
+#[test]
+fn test_encap() {
+    let raw = vec![
+        0x0a, 0x20, 0x00, 0x00, 0xfe, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+        0x14, 0x00, 0x01, 0x00, 0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x34, 0x00, 0x16, 0x80,
+        0x30, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x04, 0x04, 0x01,
+        0x01, 0x00, 0x00, 0x00, 0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xfe, 0x80, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+        0x06, 0x00, 0x15, 0x00, 0x05, 0x00, 0x00, 0x00, 0x08, 0x00, 0x04, 0x00,
+        0x02, 0x00, 0x00, 0x00,
+    ];
+
+    let expected = RouteMessage {
+        header: RouteHeader {
+            address_family: AddressFamily::Inet6,
+            destination_prefix_length: 32,
+            source_prefix_length: 0,
+            tos: 0,
+            table: 254,
+            protocol: RouteProtocol::Boot,
+            scope: RouteScope::Universe,
+            kind: RouteType::Unicast,
+            flags: RouteFlags::empty(),
+        },
+        attributes: vec![
+            RouteAttribute::Destination(
+                Ipv6Addr::from_str("fe80::").unwrap().into(),
+            ),
+            RouteAttribute::Encap(vec![RouteLwTunnelEncap::Seg6(
+                RouteSeg6IpTunnel::Seg6(Seg6Header {
+                    mode: Seg6Mode::Encap,
+                    segments: vec![
+                        Ipv6Addr::from_str("fe80::1").unwrap().into(),
+                        Ipv6Addr::from_str("fe80::2").unwrap().into(),
+                    ],
+                }),
+            )]),
+            RouteAttribute::EncapType(RouteLwEnCapType::Seg6),
+            RouteAttribute::Oif(2),
+        ],
+    };
+
+    assert_eq!(
+        expected,
+        RouteMessage::parse(&RouteMessageBuffer::new(&raw)).unwrap()
+    );
+
+    let mut buf = vec![0; expected.buffer_len()];
+
+    expected.emit(&mut buf);
+
+    assert_eq!(buf, raw);
+}
+
+// Setup:
+//      ip link add dummy1 type dummy
+//      ip link set dummy1 up
+//      ip route add fe80::/32 encap seg6 mode inline \
+//          segs fe80::1,fe80::2 dev dummy1
+// wireshark capture(netlink message header removed) of nlmon against command:
+//      ip -6 route show dev dummy1
+#[test]
+fn test_inline() {
+    let raw = vec![
+        0x0a, 0x20, 0x00, 0x00, 0xfe, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+        0x14, 0x00, 0x01, 0x00, 0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x44, 0x00, 0x16, 0x80,
+        0x40, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x06, 0x04, 0x02,
+        0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xfe, 0x80, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
+        0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x01, 0x06, 0x00, 0x15, 0x00, 0x05, 0x00, 0x00, 0x00,
+        0x08, 0x00, 0x04, 0x00, 0x02, 0x00, 0x00, 0x00,
+    ];
+
+    let expected = RouteMessage {
+        header: RouteHeader {
+            address_family: AddressFamily::Inet6,
+            destination_prefix_length: 32,
+            source_prefix_length: 0,
+            tos: 0,
+            table: 254,
+            protocol: RouteProtocol::Boot,
+            scope: RouteScope::Universe,
+            kind: RouteType::Unicast,
+            flags: RouteFlags::empty(),
+        },
+        attributes: vec![
+            RouteAttribute::Destination(
+                Ipv6Addr::from_str("fe80::").unwrap().into(),
+            ),
+            RouteAttribute::Encap(vec![RouteLwTunnelEncap::Seg6(
+                RouteSeg6IpTunnel::Seg6(Seg6Header {
+                    mode: Seg6Mode::Inline,
+                    segments: vec![
+                        Ipv6Addr::from_str("fe80::1").unwrap().into(),
+                        Ipv6Addr::from_str("fe80::2").unwrap().into(),
+                    ],
+                }),
+            )]),
+            RouteAttribute::EncapType(RouteLwEnCapType::Seg6),
+            RouteAttribute::Oif(2),
+        ],
+    };
+
+    assert_eq!(
+        expected,
+        RouteMessage::parse(&RouteMessageBuffer::new(&raw)).unwrap()
+    );
+
+    let mut buf = vec![0; expected.buffer_len()];
+
+    expected.emit(&mut buf);
+
+    assert_eq!(buf, raw);
+}


### PR DESCRIPTION
This commit provide some basic support for Seg6
(https://segment-routing.org/). Support for Inline and Encap more are added. (Further support could be enhanced in the future to support the remaining type, but this is in my opinion a good starting point).
Additional tests are also included by comparing the resulting messages with messaged captured in wireshark.

Note: two expect() are called in the code, but only whenever it is logically impossible to have an exception (checked bounds for IPv6 and parsing of a static IPv6 address)