### PR TITLE
attribute: fix decoding error on empty IFLA_VFINFO_LIST payload

### DIFF
--- a/src/link/attribute.rs
+++ b/src/link/attribute.rs
@@ -376,14 +376,20 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
             IFLA_VFINFO_LIST => {
                 let err =
                     |payload| format!("invalid IFLA_VFINFO_LIST {payload:?}");
-                Self::VfInfoList(
-                    VecLinkVfInfo::parse(
-                        &NlaBuffer::new_checked(payload)
-                            .context(err(payload))?,
+                if !payload.is_empty() {
+                    Self::VfInfoList(
+                        VecLinkVfInfo::parse(
+                            &NlaBuffer::new_checked(payload)
+                                .context(err(payload))?,
+                        )
+                        .context(err(payload))?
+                        .0,
                     )
-                    .context(err(payload))?
-                    .0,
-                )
+                } else {
+                    // Empty IFLA_VFINFO_LIST, this is likely a netdevsim device
+                    // no need to parse it, it is empty
+                    Self::VfInfoList(vec![])
+                }
             }
             IFLA_VF_PORTS => {
                 let err =

--- a/src/link/tests/sriov.rs
+++ b/src/link/tests/sriov.rs
@@ -183,3 +183,20 @@ fn test_parsing_link_sriov() {
 
     assert_eq!(buf, raw);
 }
+
+// tcpdump capture of nlmon on a netdevsim device without VF info configure.
+// Only IFLA_VFINFO_LIST was included.
+#[test]
+fn test_parsing_empty_link_sriov_vf_info() {
+    let raw = vec![0x04, 0x00, 0x16, 0x00];
+    let expected = LinkAttribute::VfInfoList(vec![]);
+
+    assert_eq!(
+        expected,
+        LinkAttribute::parse_with_param(
+            &NlaBuffer::new_checked(&raw).unwrap(),
+            AddressFamily::Unspec
+        )
+        .unwrap(),
+    );
+}


### PR DESCRIPTION
Using netdevsim driver, it sends empty IFLA_VFINFO_LIST if not configured. When this happens, the payload length is 0. As we are using new_checked() function for NlaBuffer creation, we check that the payload size can allocate the NLA size for that type.

The kernel shouldn't send an empty IFLA_VFINFO_LIST on netdevsim driver when not configured but until that is fixed, this is a proper solution.

It fixes the following error:

```
thread 'main' panicked at links_dump.rs:62:52:
called `Result::unwrap()` on an `Err` value: DecodeError { inner: Failed to parse message with type 16

Caused by:
    Decode error occurred: invalid link message }
```