### PR TITLE
route: Fix panic of integer underflow in `RouteNextHopBuffer`

### DIFF
--- a/src/route/next_hops.rs
+++ b/src/route/next_hops.rs
@@ -67,6 +67,14 @@ impl<T: AsRef<[u8]>> RouteNextHopBuffer<T> {
             )
             .into());
         }
+        if (self.length() as usize) < PAYLOAD_OFFSET {
+            return Err(format!(
+                "invalid RouteNextHopBuffer: length {} < {}",
+                self.length(),
+                PAYLOAD_OFFSET
+            )
+            .into());
+        }
         Ok(())
     }
 }

--- a/src/route/tests/route_flags.rs
+++ b/src/route/tests/route_flags.rs
@@ -66,3 +66,15 @@ fn test_next_hop_max_buffer_len() {
     let buffer = [0xff, 0xff, 0, 0, 0, 0, 0, 0];
     assert!(RouteNextHopBuffer::new_checked(buffer).is_err());
 }
+
+#[test]
+fn test_invalid_next_hop() {
+    let buffer = [
+        0, 0, // length
+        0, // flags,
+        0, // hops
+        0, 0, 0, 0, // interface index
+        0, 0, 0, 0, 0, 0, 0, 0, // payload
+    ];
+    assert!(RouteNextHopBuffer::new_checked(buffer).is_err());
+}


### PR DESCRIPTION
For buffer `[0u8; 8]`, the `RouteNextHopBuffer::attributes()` will panic
on `self.length() - 8` as `0u16 -8` will trigger underflow.

Fixed by raising error when `self.length() < PAYLOAD_OFFSET`.

We consider above all zero buffer as invalid data type instead of
skipping it during pasing is because:

 1. The length property is invalid, it should always bigger or equal than 8
    because it is the length of payload plus header.
 2. The same data will cause error in iproute2 also:

The iproute code `print_rta_multipath()` has:

```c
while (len >= sizeof(*nh)) {
    ...
    len -= NLMSG_ALIGN(nh->rtnh_len);
    nh = RTNH_NEXT(nh);
    close_json_object();
}
```

The `RTNH_NEXT` is defined as

```c
    ((struct rtnexthop*)(((char*)(rtnh)) + RTNH_ALIGN((rtnh)->rtnh_len)))
```

It will cause dead loop in iproute2 for `[0u8;8]` above as
NLMSG_ALIGN(0) is still 0.

Resolves: https://github.com/rust-netlink/netlink-packet-route/issues/152