### PR TITLE
Bump netlink-packet-utils and netlink-packet-core crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,12 @@ description = "netlink packet types"
 rich_nlas = []
 
 [dependencies]
-anyhow = "1.0.31"
 bitflags = "2"
 byteorder = "1.3.2"
 libc = "0.2.66"
 log = { version = "0.4.20", features = ["std"] }
-netlink-packet-core = { version = "0.7.0" }
-netlink-packet-utils = { version = "0.5.2" }
+netlink-packet-core = { git = "https://github.com/rust-netlink/netlink-packet-core.git", rev = "01e8dd1" }
+netlink-packet-utils = { version = "0.6.0" }
 
 [[example]]
 name = "dump_packet_links"

--- a/src/address/attribute.rs
+++ b/src/address/attribute.rs
@@ -3,7 +3,6 @@
 use std::mem::size_of;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
 use netlink_packet_utils::{
     nla::{DefaultNla, Nla, NlaBuffer},
@@ -107,10 +106,10 @@ impl Nla for AddressAttribute {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
-    for AddressAttribute
-{
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl<T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&T>> for AddressAttribute {
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&T>) -> Result<Self, Self::Error> {
         let payload = buf.value();
         Ok(match buf.kind() {
             IFA_ADDRESS => {
@@ -147,9 +146,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                     )));
                 }
             }
-            IFA_LABEL => Self::Label(
-                parse_string(payload).context("invalid IFA_LABEL value")?,
-            ),
+            IFA_LABEL => Self::Label(parse_string(payload)?),
             IFA_BROADCAST => {
                 if payload.len() == IPV4_ADDR_LEN {
                     let mut data = [0u8; IPV4_ADDR_LEN];
@@ -176,10 +173,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                     )));
                 }
             }
-            IFA_CACHEINFO => Self::CacheInfo(
-                CacheInfo::parse(&CacheInfoBuffer::new(payload))
-                    .context(format!("Invalid IFA_CACHEINFO {:?}", payload))?,
-            ),
+            IFA_CACHEINFO => Self::CacheInfo(CacheInfo::parse(
+                &CacheInfoBuffer::new(payload),
+            )?),
             IFA_MULTICAST => {
                 if payload.len() == IPV6_ADDR_LEN {
                     let mut data = [0u8; IPV6_ADDR_LEN];
@@ -193,13 +189,10 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                     )));
                 }
             }
-            IFA_FLAGS => Self::Flags(AddressFlags::from_bits_retain(
-                parse_u32(payload).context("invalid IFA_FLAGS value")?,
-            )),
-            kind => Self::Other(
-                DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {kind}"))?,
-            ),
+            IFA_FLAGS => {
+                Self::Flags(AddressFlags::from_bits_retain(parse_u32(payload)?))
+            }
+            _ => Self::Other(DefaultNla::parse(buf)?),
         })
     }
 }

--- a/src/address/cache_info.rs
+++ b/src/address/cache_info.rs
@@ -24,7 +24,9 @@ buffer!(CacheInfoBuffer(ADDRESSS_CACHE_INFO_LEN) {
 });
 
 impl<T: AsRef<[u8]>> Parseable<CacheInfoBuffer<T>> for CacheInfo {
-    fn parse(buf: &CacheInfoBuffer<T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &CacheInfoBuffer<T>) -> Result<Self, Self::Error> {
         Ok(CacheInfo {
             ifa_preferred: buf.ifa_preferred(),
             ifa_valid: buf.ifa_valid(),

--- a/src/link/af_spec/inet6.rs
+++ b/src/link/af_spec/inet6.rs
@@ -2,7 +2,6 @@
 
 use std::net::Ipv6Addr;
 
-use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
 use netlink_packet_utils::{
     nla::{DefaultNla, Nla, NlaBuffer, NlasIterator},
@@ -50,15 +49,13 @@ pub enum AfSpecInet6 {
 
 pub(crate) struct VecAfSpecInet6(pub(crate) Vec<AfSpecInet6>);
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
-    for VecAfSpecInet6
-{
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl<T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&T>> for VecAfSpecInet6 {
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&T>) -> Result<Self, Self::Error> {
         let mut nlas = vec![];
-        let err = "Invalid AF_INET6 NLA for IFLA_AF_SPEC(AF_UNSPEC)";
         for nla in NlasIterator::new(buf.into_inner()) {
-            let nla = nla.context(err)?;
-            nlas.push(AfSpecInet6::parse(&nla).context(err)?);
+            nlas.push(AfSpecInet6::parse(&nla?)?);
         }
         Ok(Self(nlas))
     }
@@ -110,50 +107,40 @@ impl Nla for AfSpecInet6 {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for AfSpecInet6 {
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl<T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&T>> for AfSpecInet6 {
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&T>) -> Result<Self, Self::Error> {
         use self::AfSpecInet6::*;
 
         let payload = buf.value();
         Ok(match buf.kind() {
-            IFLA_INET6_FLAGS => Flags(Inet6IfaceFlags::from_bits_retain(
-                parse_u32(payload).context("invalid IFLA_INET6_FLAGS value")?,
-            )),
-            IFLA_INET6_CACHEINFO => CacheInfo(
-                Inet6CacheInfo::parse(&Inet6CacheInfoBuffer::new(payload))
-                    .context(format!(
-                        "invalid IFLA_INET6_CACHEINFO value {:?}",
-                        payload
-                    ))?,
-            ),
-            IFLA_INET6_CONF => DevConf(
-                Inet6DevConf::parse(&Inet6DevConfBuffer::new(
+            IFLA_INET6_FLAGS => {
+                Flags(Inet6IfaceFlags::from_bits_retain(parse_u32(payload)?))
+            }
+            IFLA_INET6_CACHEINFO => CacheInfo(Inet6CacheInfo::parse(
+                &Inet6CacheInfoBuffer::new(payload),
+            )?),
+            IFLA_INET6_CONF => {
+                DevConf(Inet6DevConf::parse(&Inet6DevConfBuffer::new(
                     expand_buffer_if_small(
                         payload,
                         LINK_INET6_DEV_CONF_LEN,
                         "IFLA_INET6_CONF",
                     )
                     .as_slice(),
-                ))
-                .context(format!(
-                    "invalid IFLA_INET6_CONF value {:?}",
-                    payload
-                ))?,
-            ),
-            IFLA_INET6_STATS => Stats(
-                Inet6Stats::parse(&Inet6StatsBuffer::new(
+                ))?)
+            }
+            IFLA_INET6_STATS => {
+                Stats(Inet6Stats::parse(&Inet6StatsBuffer::new(
                     expand_buffer_if_small(
                         payload,
                         INET6_STATS_LEN,
                         "IFLA_INET6_STATS",
                     )
                     .as_slice(),
-                ))
-                .context(format!(
-                    "invalid IFLA_INET6_STATS value {:?}",
-                    payload
-                ))?,
-            ),
+                ))?)
+            }
             IFLA_INET6_ICMP6STATS => Icmp6Stats(
                 super::super::Icmp6Stats::parse(&Icmp6StatsBuffer::new(
                     expand_buffer_if_small(
@@ -162,27 +149,12 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for AfSpecInet6 {
                         "IFLA_INET6_ICMP6STATS",
                     )
                     .as_slice(),
-                ))
-                .context(format!(
-                    "invalid IFLA_INET6_ICMP6STATS value {:?}",
-                    payload
                 ))?,
             ),
-            IFLA_INET6_TOKEN => Token(
-                parse_ipv6_addr(payload)
-                    .context("invalid IFLA_INET6_TOKEN value")?,
-            ),
-            IFLA_INET6_ADDR_GEN_MODE => AddrGenMode(
-                parse_u8(payload)
-                    .context("invalid IFLA_INET6_ADDR_GEN_MODE value")?,
-            ),
-            IFLA_INET6_RA_MTU => RaMtu(
-                parse_u32(payload)
-                    .context("invalid IFLA_INET6_RA_MTU value")?,
-            ),
-            kind => Other(DefaultNla::parse(buf).context(format!(
-                "unknown AF_INET6 NLA type {kind} for IFLA_AF_SPEC(AF_UNSPEC)"
-            ))?),
+            IFLA_INET6_TOKEN => Token(parse_ipv6_addr(payload)?),
+            IFLA_INET6_ADDR_GEN_MODE => AddrGenMode(parse_u8(payload)?),
+            IFLA_INET6_RA_MTU => RaMtu(parse_u32(payload)?),
+            _ => Other(DefaultNla::parse(buf)?),
         })
     }
 }

--- a/src/link/af_spec/inet6_cache.rs
+++ b/src/link/af_spec/inet6_cache.rs
@@ -24,7 +24,9 @@ buffer!(Inet6CacheInfoBuffer(LINK_INET6_CACHE_INFO_LEN) {
 });
 
 impl<T: AsRef<[u8]>> Parseable<Inet6CacheInfoBuffer<T>> for Inet6CacheInfo {
-    fn parse(buf: &Inet6CacheInfoBuffer<T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &Inet6CacheInfoBuffer<T>) -> Result<Self, Self::Error> {
         Ok(Self {
             max_reasm_len: buf.max_reasm_len(),
             tstamp: buf.tstamp(),

--- a/src/link/af_spec/inet6_devconf.rs
+++ b/src/link/af_spec/inet6_devconf.rs
@@ -72,7 +72,9 @@ buffer!(Inet6DevConfBuffer(LINK_INET6_DEV_CONF_LEN) {
 });
 
 impl<T: AsRef<[u8]>> Parseable<Inet6DevConfBuffer<T>> for Inet6DevConf {
-    fn parse(buf: &Inet6DevConfBuffer<T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &Inet6DevConfBuffer<T>) -> Result<Self, Self::Error> {
         Ok(Self {
             forwarding: buf.forwarding(),
             hoplimit: buf.hoplimit(),

--- a/src/link/af_spec/inet6_icmp.rs
+++ b/src/link/af_spec/inet6_icmp.rs
@@ -28,7 +28,9 @@ buffer!(Icmp6StatsBuffer(ICMP6_STATS_LEN) {
 });
 
 impl<T: AsRef<[u8]>> Parseable<Icmp6StatsBuffer<T>> for Icmp6Stats {
-    fn parse(buf: &Icmp6StatsBuffer<T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &Icmp6StatsBuffer<T>) -> Result<Self, Self::Error> {
         Ok(Self {
             num: buf.num(),
             in_msgs: buf.in_msgs(),

--- a/src/link/af_spec/inet6_stats.rs
+++ b/src/link/af_spec/inet6_stats.rs
@@ -92,7 +92,9 @@ pub struct Inet6Stats {
 }
 
 impl<T: AsRef<[u8]>> Parseable<Inet6StatsBuffer<T>> for Inet6Stats {
-    fn parse(buf: &Inet6StatsBuffer<T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &Inet6StatsBuffer<T>) -> Result<Self, Self::Error> {
         Ok(Self {
             num: buf.num(),
             in_pkts: buf.in_pkts(),

--- a/src/link/event.rs
+++ b/src/link/event.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
 use netlink_packet_utils::{
     parsers::parse_u32, DecodeError, Emitable, Parseable,
@@ -59,10 +58,10 @@ impl From<LinkEvent> for u32 {
 }
 
 impl<T: AsRef<[u8]> + ?Sized> Parseable<T> for LinkEvent {
-    fn parse(buf: &T) -> Result<Self, DecodeError> {
-        Ok(LinkEvent::from(
-            parse_u32(buf.as_ref()).context("invalid IFLA_EVENT value")?,
-        ))
+    type Error = DecodeError;
+
+    fn parse(buf: &T) -> Result<Self, Self::Error> {
+        Ok(LinkEvent::from(parse_u32(buf.as_ref())?))
     }
 }
 

--- a/src/link/header.rs
+++ b/src/link/header.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 use netlink_packet_utils::{
-    nla::{NlaBuffer, NlasIterator},
+    nla::{NlaBuffer, NlaError, NlasIterator},
     traits::{Emitable, Parseable},
     DecodeError,
 };
@@ -25,7 +25,7 @@ buffer!(LinkMessageBuffer(LINK_HEADER_LEN) {
 impl<'a, T: AsRef<[u8]> + ?Sized> LinkMessageBuffer<&'a T> {
     pub fn attributes(
         &self,
-    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
+    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, NlaError>> {
         NlasIterator::new(self.payload())
     }
 }
@@ -86,7 +86,9 @@ impl Emitable for LinkHeader {
 }
 
 impl<T: AsRef<[u8]>> Parseable<LinkMessageBuffer<T>> for LinkHeader {
-    fn parse(buf: &LinkMessageBuffer<T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &LinkMessageBuffer<T>) -> Result<Self, Self::Error> {
         Ok(Self {
             interface_family: buf.interface_family().into(),
             link_layer_type: buf.link_layer_type().into(),

--- a/src/link/link_info/bridge.rs
+++ b/src/link/link_info/bridge.rs
@@ -2,7 +2,6 @@
 
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-use anyhow::Context;
 use byteorder::{BigEndian, ByteOrder, NativeEndian};
 use netlink_packet_utils::{
     nla::{DefaultNla, Nla, NlaBuffer, NlasIterator, NLA_F_NESTED},
@@ -304,214 +303,118 @@ impl Nla for InfoBridge {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoBridge {
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl<T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&T>> for InfoBridge {
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&T>) -> Result<Self, Self::Error> {
         let payload = buf.value();
         Ok(match buf.kind() {
             IFLA_BR_FDB_FLUSH => Self::FdbFlush,
-            IFLA_BR_HELLO_TIMER => Self::HelloTimer(
-                parse_u64(payload)
-                    .context("invalid IFLA_BR_HELLO_TIMER value")?,
-            ),
-            IFLA_BR_TCN_TIMER => Self::TcnTimer(
-                parse_u64(payload)
-                    .context("invalid IFLA_BR_TCN_TIMER value")?,
-            ),
-            IFLA_BR_TOPOLOGY_CHANGE_TIMER => Self::TopologyChangeTimer(
-                parse_u64(payload)
-                    .context("invalid IFLA_BR_TOPOLOGY_CHANGE_TIMER value")?,
-            ),
-            IFLA_BR_GC_TIMER => Self::GcTimer(
-                parse_u64(payload).context("invalid IFLA_BR_GC_TIMER value")?,
-            ),
+            IFLA_BR_HELLO_TIMER => Self::HelloTimer(parse_u64(payload)?),
+            IFLA_BR_TCN_TIMER => Self::TcnTimer(parse_u64(payload)?),
+            IFLA_BR_TOPOLOGY_CHANGE_TIMER => {
+                Self::TopologyChangeTimer(parse_u64(payload)?)
+            }
+            IFLA_BR_GC_TIMER => Self::GcTimer(parse_u64(payload)?),
             IFLA_BR_MCAST_LAST_MEMBER_INTVL => {
-                Self::MulticastLastMemberInterval(
-                    parse_u64(payload).context(
-                        "invalid IFLA_BR_MCAST_LAST_MEMBER_INTVL value",
-                    )?,
-                )
+                Self::MulticastLastMemberInterval(parse_u64(payload)?)
             }
             IFLA_BR_MCAST_MEMBERSHIP_INTVL => {
-                Self::MulticastMembershipInterval(
-                    parse_u64(payload).context(
-                        "invalid IFLA_BR_MCAST_MEMBERSHIP_INTVL value",
-                    )?,
-                )
+                Self::MulticastMembershipInterval(parse_u64(payload)?)
             }
-            IFLA_BR_MCAST_QUERIER_INTVL => Self::MulticastQuerierInterval(
-                parse_u64(payload)
-                    .context("invalid IFLA_BR_MCAST_QUERIER_INTVL value")?,
-            ),
-            IFLA_BR_MCAST_QUERY_INTVL => Self::MulticastQueryInterval(
-                parse_u64(payload)
-                    .context("invalid IFLA_BR_MCAST_QUERY_INTVL value")?,
-            ),
+            IFLA_BR_MCAST_QUERIER_INTVL => {
+                Self::MulticastQuerierInterval(parse_u64(payload)?)
+            }
+            IFLA_BR_MCAST_QUERY_INTVL => {
+                Self::MulticastQueryInterval(parse_u64(payload)?)
+            }
             IFLA_BR_MCAST_QUERY_RESPONSE_INTVL => {
-                Self::MulticastQueryResponseInterval(
-                    parse_u64(payload).context(
-                        "invalid IFLA_BR_MCAST_QUERY_RESPONSE_INTVL value",
-                    )?,
-                )
+                Self::MulticastQueryResponseInterval(parse_u64(payload)?)
             }
             IFLA_BR_MCAST_STARTUP_QUERY_INTVL => {
-                Self::MulticastStartupQueryInterval(
-                    parse_u64(payload).context(
-                        "invalid IFLA_BR_MCAST_STARTUP_QUERY_INTVL value",
-                    )?,
-                )
+                Self::MulticastStartupQueryInterval(parse_u64(payload)?)
             }
-            IFLA_BR_FORWARD_DELAY => Self::ForwardDelay(
-                parse_u32(payload)
-                    .context("invalid IFLA_BR_FORWARD_DELAY value")?,
-            ),
-            IFLA_BR_HELLO_TIME => Self::HelloTime(
-                parse_u32(payload)
-                    .context("invalid IFLA_BR_HELLO_TIME value")?,
-            ),
-            IFLA_BR_MAX_AGE => Self::MaxAge(
-                parse_u32(payload).context("invalid IFLA_BR_MAX_AGE value")?,
-            ),
-            IFLA_BR_AGEING_TIME => Self::AgeingTime(
-                parse_u32(payload)
-                    .context("invalid IFLA_BR_AGEING_TIME value")?,
-            ),
-            IFLA_BR_STP_STATE => Self::StpState(
-                parse_u32(payload)
-                    .context("invalid IFLA_BR_STP_STATE value")?,
-            ),
-            IFLA_BR_MCAST_HASH_ELASTICITY => Self::MulticastHashElasticity(
-                parse_u32(payload)
-                    .context("invalid IFLA_BR_MCAST_HASH_ELASTICITY value")?,
-            ),
-            IFLA_BR_MCAST_HASH_MAX => Self::MulticastHashMax(
-                parse_u32(payload)
-                    .context("invalid IFLA_BR_MCAST_HASH_MAX value")?,
-            ),
-            IFLA_BR_MCAST_LAST_MEMBER_CNT => Self::MulticastLastMemberCount(
-                parse_u32(payload)
-                    .context("invalid IFLA_BR_MCAST_LAST_MEMBER_CNT value")?,
-            ),
+            IFLA_BR_FORWARD_DELAY => Self::ForwardDelay(parse_u32(payload)?),
+            IFLA_BR_HELLO_TIME => Self::HelloTime(parse_u32(payload)?),
+            IFLA_BR_MAX_AGE => Self::MaxAge(parse_u32(payload)?),
+            IFLA_BR_AGEING_TIME => Self::AgeingTime(parse_u32(payload)?),
+            IFLA_BR_STP_STATE => Self::StpState(parse_u32(payload)?),
+            IFLA_BR_MCAST_HASH_ELASTICITY => {
+                Self::MulticastHashElasticity(parse_u32(payload)?)
+            }
+            IFLA_BR_MCAST_HASH_MAX => {
+                Self::MulticastHashMax(parse_u32(payload)?)
+            }
+            IFLA_BR_MCAST_LAST_MEMBER_CNT => {
+                Self::MulticastLastMemberCount(parse_u32(payload)?)
+            }
             IFLA_BR_MCAST_STARTUP_QUERY_CNT => {
-                Self::MulticastStartupQueryCount(
-                    parse_u32(payload).context(
-                        "invalid IFLA_BR_MCAST_STARTUP_QUERY_CNT value",
-                    )?,
-                )
+                Self::MulticastStartupQueryCount(parse_u32(payload)?)
             }
-            IFLA_BR_ROOT_PATH_COST => Self::RootPathCost(
-                parse_u32(payload)
-                    .context("invalid IFLA_BR_ROOT_PATH_COST value")?,
-            ),
-            IFLA_BR_PRIORITY => Self::Priority(
-                parse_u16(payload).context("invalid IFLA_BR_PRIORITY value")?,
-            ),
-            IFLA_BR_VLAN_PROTOCOL => Self::VlanProtocol(
-                parse_u16_be(payload)
-                    .context("invalid IFLA_BR_VLAN_PROTOCOL value")?,
-            ),
-            IFLA_BR_GROUP_FWD_MASK => Self::GroupFwdMask(
-                parse_u16(payload)
-                    .context("invalid IFLA_BR_GROUP_FWD_MASK value")?,
-            ),
-            IFLA_BR_ROOT_ID => Self::RootId(
-                BridgeId::parse(&BridgeIdBuffer::new(payload))
-                    .context("invalid IFLA_BR_ROOT_ID value")?,
-            ),
-            IFLA_BR_BRIDGE_ID => Self::BridgeId(
-                BridgeId::parse(&BridgeIdBuffer::new(payload))
-                    .context("invalid IFLA_BR_BRIDGE_ID value")?,
-            ),
-            IFLA_BR_GROUP_ADDR => Self::GroupAddr(
-                parse_mac(payload)
-                    .context("invalid IFLA_BR_GROUP_ADDR value")?,
-            ),
-            IFLA_BR_ROOT_PORT => Self::RootPort(
-                parse_u16(payload)
-                    .context("invalid IFLA_BR_ROOT_PORT value")?,
-            ),
-            IFLA_BR_VLAN_DEFAULT_PVID => Self::VlanDefaultPvid(
-                parse_u16(payload)
-                    .context("invalid IFLA_BR_VLAN_DEFAULT_PVID value")?,
-            ),
-            IFLA_BR_VLAN_FILTERING => Self::VlanFiltering(
-                parse_u8(payload)
-                    .context("invalid IFLA_BR_VLAN_FILTERING value")?
-                    > 0,
-            ),
-            IFLA_BR_TOPOLOGY_CHANGE => Self::TopologyChange(
-                parse_u8(payload)
-                    .context("invalid IFLA_BR_TOPOLOGY_CHANGE value")?,
-            ),
+            IFLA_BR_ROOT_PATH_COST => Self::RootPathCost(parse_u32(payload)?),
+            IFLA_BR_PRIORITY => Self::Priority(parse_u16(payload)?),
+            IFLA_BR_VLAN_PROTOCOL => Self::VlanProtocol(parse_u16_be(payload)?),
+            IFLA_BR_GROUP_FWD_MASK => Self::GroupFwdMask(parse_u16(payload)?),
+            IFLA_BR_ROOT_ID => {
+                Self::RootId(BridgeId::parse(&BridgeIdBuffer::new(payload))?)
+            }
+            IFLA_BR_BRIDGE_ID => {
+                Self::BridgeId(BridgeId::parse(&BridgeIdBuffer::new(payload))?)
+            }
+            IFLA_BR_GROUP_ADDR => Self::GroupAddr(parse_mac(payload)?),
+            IFLA_BR_ROOT_PORT => Self::RootPort(parse_u16(payload)?),
+            IFLA_BR_VLAN_DEFAULT_PVID => {
+                Self::VlanDefaultPvid(parse_u16(payload)?)
+            }
+            IFLA_BR_VLAN_FILTERING => {
+                Self::VlanFiltering(parse_u8(payload)? > 0)
+            }
+            IFLA_BR_TOPOLOGY_CHANGE => Self::TopologyChange(parse_u8(payload)?),
             IFLA_BR_TOPOLOGY_CHANGE_DETECTED => {
-                Self::TopologyChangeDetected(parse_u8(payload).context(
-                    "invalid IFLA_BR_TOPOLOGY_CHANGE_DETECTED value",
-                )?)
+                Self::TopologyChangeDetected(parse_u8(payload)?)
             }
-            IFLA_BR_MCAST_ROUTER => Self::MulticastRouter(
-                parse_u8(payload)
-                    .context("invalid IFLA_BR_MCAST_ROUTER value")?,
-            ),
-            IFLA_BR_MCAST_SNOOPING => Self::MulticastSnooping(
-                parse_u8(payload)
-                    .context("invalid IFLA_BR_MCAST_SNOOPING value")?,
-            ),
-            IFLA_BR_MCAST_QUERY_USE_IFADDR => Self::MulticastQueryUseIfaddr(
-                parse_u8(payload)
-                    .context("invalid IFLA_BR_MCAST_QUERY_USE_IFADDR value")?,
-            ),
-            IFLA_BR_MCAST_QUERIER => Self::MulticastQuerier(
-                parse_u8(payload)
-                    .context("invalid IFLA_BR_MCAST_QUERIER value")?,
-            ),
-            IFLA_BR_NF_CALL_IPTABLES => Self::NfCallIpTables(
-                parse_u8(payload)
-                    .context("invalid IFLA_BR_NF_CALL_IPTABLES value")?,
-            ),
-            IFLA_BR_NF_CALL_IP6TABLES => Self::NfCallIp6Tables(
-                parse_u8(payload)
-                    .context("invalid IFLA_BR_NF_CALL_IP6TABLES value")?,
-            ),
-            IFLA_BR_NF_CALL_ARPTABLES => Self::NfCallArpTables(
-                parse_u8(payload)
-                    .context("invalid IFLA_BR_NF_CALL_ARPTABLES value")?,
-            ),
-            IFLA_BR_VLAN_STATS_ENABLED => Self::VlanStatsEnabled(
-                parse_u8(payload)
-                    .context("invalid IFLA_BR_VLAN_STATS_ENABLED value")?,
-            ),
-            IFLA_BR_MCAST_STATS_ENABLED => Self::MulticastStatsEnabled(
-                parse_u8(payload)
-                    .context("invalid IFLA_BR_MCAST_STATS_ENABLED value")?,
-            ),
-            IFLA_BR_MCAST_IGMP_VERSION => Self::MulticastIgmpVersion(
-                parse_u8(payload)
-                    .context("invalid IFLA_BR_MCAST_IGMP_VERSION value")?,
-            ),
-            IFLA_BR_MCAST_MLD_VERSION => Self::MulticastMldVersion(
-                parse_u8(payload)
-                    .context("invalid IFLA_BR_MCAST_MLD_VERSION value")?,
-            ),
-            IFLA_BR_VLAN_STATS_PER_PORT => Self::VlanStatsPerHost(
-                parse_u8(payload)
-                    .context("invalid IFLA_BR_VLAN_STATS_PER_PORT value")?,
-            ),
-            IFLA_BR_MULTI_BOOLOPT => Self::MultiBoolOpt(
-                parse_u64(payload)
-                    .context("invalid IFLA_BR_MULTI_BOOLOPT value")?,
-            ),
+            IFLA_BR_MCAST_ROUTER => Self::MulticastRouter(parse_u8(payload)?),
+            IFLA_BR_MCAST_SNOOPING => {
+                Self::MulticastSnooping(parse_u8(payload)?)
+            }
+            IFLA_BR_MCAST_QUERY_USE_IFADDR => {
+                Self::MulticastQueryUseIfaddr(parse_u8(payload)?)
+            }
+            IFLA_BR_MCAST_QUERIER => Self::MulticastQuerier(parse_u8(payload)?),
+            IFLA_BR_NF_CALL_IPTABLES => {
+                Self::NfCallIpTables(parse_u8(payload)?)
+            }
+            IFLA_BR_NF_CALL_IP6TABLES => {
+                Self::NfCallIp6Tables(parse_u8(payload)?)
+            }
+            IFLA_BR_NF_CALL_ARPTABLES => {
+                Self::NfCallArpTables(parse_u8(payload)?)
+            }
+            IFLA_BR_VLAN_STATS_ENABLED => {
+                Self::VlanStatsEnabled(parse_u8(payload)?)
+            }
+            IFLA_BR_MCAST_STATS_ENABLED => {
+                Self::MulticastStatsEnabled(parse_u8(payload)?)
+            }
+            IFLA_BR_MCAST_IGMP_VERSION => {
+                Self::MulticastIgmpVersion(parse_u8(payload)?)
+            }
+            IFLA_BR_MCAST_MLD_VERSION => {
+                Self::MulticastMldVersion(parse_u8(payload)?)
+            }
+            IFLA_BR_VLAN_STATS_PER_PORT => {
+                Self::VlanStatsPerHost(parse_u8(payload)?)
+            }
+            IFLA_BR_MULTI_BOOLOPT => Self::MultiBoolOpt(parse_u64(payload)?),
             IFLA_BR_MCAST_QUERIER_STATE => {
                 let mut v = Vec::new();
-                let err = "failed to parse IFLA_BR_MCAST_QUERIER_STATE";
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(err)?;
-                    let parsed = BridgeQuerierState::parse(nla).context(err)?;
+                    let parsed = BridgeQuerierState::parse(&nla?)?;
                     v.push(parsed);
                 }
                 Self::MulticastQuerierState(v)
             }
-            _ => Self::Other(DefaultNla::parse(buf).context(
-                "invalid link info bridge NLA value (unknown type)",
-            )?),
+            _ => Self::Other(DefaultNla::parse(buf)?),
         })
     }
 }
@@ -530,14 +433,15 @@ buffer!(BridgeIdBuffer(BRIDGE_ID_LEN) {
 });
 
 impl<T: AsRef<[u8]> + ?Sized> Parseable<BridgeIdBuffer<&T>> for BridgeId {
-    fn parse(buf: &BridgeIdBuffer<&T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &BridgeIdBuffer<&T>) -> Result<Self, Self::Error> {
         // Priority is encoded in big endian. From kernel's
         // net/bridge/br_netlink.c br_fill_info():
         // u16 priority = (br->bridge_id.prio[0] << 8) | br->bridge_id.prio[1];
         Ok(Self {
             priority: u16::from_be(buf.priority()),
-            address: parse_mac(buf.address())
-                .context("invalid MAC address in BridgeId buffer")?,
+            address: parse_mac(buf.address())?,
         })
     }
 }
@@ -613,10 +517,10 @@ impl Nla for BridgeQuerierState {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
-    for BridgeQuerierState
-{
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl<T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&T>> for BridgeQuerierState {
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&T>) -> Result<Self, Self::Error> {
         use self::BridgeQuerierState::*;
         let payload = buf.value();
         Ok(match buf.kind() {
@@ -648,27 +552,16 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                     )));
                 }
             },
-            BRIDGE_QUERIER_IP_PORT => Ipv4Port(
-                parse_u32(payload)
-                    .context("invalid BRIDGE_QUERIER_IP_PORT value")?,
-            ),
-            BRIDGE_QUERIER_IPV6_PORT => Ipv6Port(
-                parse_u32(payload)
-                    .context("invalid BRIDGE_QUERIER_IPV6_PORT value")?,
-            ),
-            BRIDGE_QUERIER_IP_OTHER_TIMER => Ipv4OtherTimer(
-                parse_u64(payload)
-                    .context("invalid BRIDGE_QUERIER_IP_OTHER_TIMER value")?,
-            ),
-            BRIDGE_QUERIER_IPV6_OTHER_TIMER => Ipv6OtherTimer(
-                parse_u64(payload)
-                    .context("invalid BRIDGE_QUERIER_IPV6_OTHER_TIMER value")?,
-            ),
+            BRIDGE_QUERIER_IP_PORT => Ipv4Port(parse_u32(payload)?),
+            BRIDGE_QUERIER_IPV6_PORT => Ipv6Port(parse_u32(payload)?),
+            BRIDGE_QUERIER_IP_OTHER_TIMER => {
+                Ipv4OtherTimer(parse_u64(payload)?)
+            }
+            BRIDGE_QUERIER_IPV6_OTHER_TIMER => {
+                Ipv6OtherTimer(parse_u64(payload)?)
+            }
 
-            kind => Other(
-                DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {kind}"))?,
-            ),
+            _ => Other(DefaultNla::parse(buf)?),
         })
     }
 }

--- a/src/link/link_info/gre.rs
+++ b/src/link/link_info/gre.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
 use netlink_packet_utils::{
     nla::{DefaultNla, Nla, NlaBuffer},
     DecodeError, Parseable,
@@ -33,13 +32,12 @@ impl Nla for InfoGreTun {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoGreTun {
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, Self::Error> {
         #[allow(clippy::match_single_binding)]
         Ok(match buf.kind() {
-            kind => Self::Other(
-                DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {kind} for gre"))?,
-            ),
+            _ => Self::Other(DefaultNla::parse(buf)?),
         })
     }
 }

--- a/src/link/link_info/gre6.rs
+++ b/src/link/link_info/gre6.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
 use netlink_packet_utils::{
     nla::{DefaultNla, Nla, NlaBuffer},
     DecodeError, Parseable,
@@ -32,14 +31,13 @@ impl Nla for InfoGreTun6 {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoGreTun6 {
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl<T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&T>> for InfoGreTun6 {
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&T>) -> Result<Self, DecodeError> {
         #[allow(clippy::match_single_binding)]
         Ok(match buf.kind() {
-            kind => Self::Other(
-                DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {kind} for ip6gre"))?,
-            ),
+            _ => Self::Other(DefaultNla::parse(buf)?),
         })
     }
 }

--- a/src/link/link_info/gre_tap.rs
+++ b/src/link/link_info/gre_tap.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
 use netlink_packet_utils::{
     nla::{DefaultNla, Nla, NlaBuffer},
     DecodeError, Parseable,
@@ -32,14 +31,13 @@ impl Nla for InfoGreTap {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoGreTap {
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl<T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&T>> for InfoGreTap {
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&T>) -> Result<Self, Self::Error> {
         #[allow(clippy::match_single_binding)]
         Ok(match buf.kind() {
-            kind => Self::Other(
-                DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {kind} for gretap"))?,
-            ),
+            _ => Self::Other(DefaultNla::parse(buf)?),
         })
     }
 }

--- a/src/link/link_info/gre_tap6.rs
+++ b/src/link/link_info/gre_tap6.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
 use netlink_packet_utils::{
     nla::{DefaultNla, Nla, NlaBuffer},
     DecodeError, Parseable,
@@ -32,14 +31,13 @@ impl Nla for InfoGreTap6 {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoGreTap6 {
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl<T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&T>> for InfoGreTap6 {
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&T>) -> Result<Self, Self::Error> {
         #[allow(clippy::match_single_binding)]
         Ok(match buf.kind() {
-            kind => Self::Other(
-                DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {kind} for gretap6"))?,
-            ),
+            _ => Self::Other(DefaultNla::parse(buf)?),
         })
     }
 }

--- a/src/link/link_info/gtp.rs
+++ b/src/link/link_info/gtp.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
 use netlink_packet_utils::{
     nla::{DefaultNla, Nla, NlaBuffer},
     DecodeError, Parseable,
@@ -32,14 +31,13 @@ impl Nla for InfoGtp {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoGtp {
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl<T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&T>> for InfoGtp {
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&T>) -> Result<Self, Self::Error> {
         #[allow(clippy::match_single_binding)]
         Ok(match buf.kind() {
-            kind => Self::Other(
-                DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {kind} for gtp"))?,
-            ),
+            _ => Self::Other(DefaultNla::parse(buf)?),
         })
     }
 }

--- a/src/link/link_info/info_data.rs
+++ b/src/link/link_info/info_data.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
-
 use netlink_packet_utils::{
     nla::{Nla, NlaBuffer, NlasIterator},
     DecodeError, Emitable, Parseable,
@@ -118,10 +116,7 @@ impl InfoData {
             InfoKind::Bridge => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
-                    let parsed = InfoBridge::parse(nla)?;
+                    let parsed = InfoBridge::parse(&nla?)?;
                     v.push(parsed);
                 }
                 InfoData::Bridge(v)
@@ -129,10 +124,7 @@ impl InfoData {
             InfoKind::Vlan => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
-                    let parsed = InfoVlan::parse(nla)?;
+                    let parsed = InfoVlan::parse(&nla?)?;
                     v.push(parsed);
                 }
                 InfoData::Vlan(v)
@@ -140,28 +132,20 @@ impl InfoData {
             InfoKind::Tun => {
                 let mut nlas = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
-                    let parsed = InfoTun::parse(nla)?;
+                    let parsed = InfoTun::parse(&nla?)?;
                     nlas.push(parsed);
                 }
                 InfoData::Tun(nlas)
             }
             InfoKind::Veth => {
-                let nla_buf = NlaBuffer::new_checked(&payload).context(
-                    format!("invalid IFLA_INFO_DATA for {kind} {payload:?}"),
-                )?;
+                let nla_buf = NlaBuffer::new_checked(&payload)?;
                 let parsed = InfoVeth::parse(&nla_buf)?;
                 InfoData::Veth(parsed)
             }
             InfoKind::Vxlan => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
-                    let parsed = InfoVxlan::parse(nla)?;
+                    let parsed = InfoVxlan::parse(&nla?)?;
                     v.push(parsed);
                 }
                 InfoData::Vxlan(v)
@@ -169,10 +153,7 @@ impl InfoData {
             InfoKind::Bond => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
-                    let parsed = InfoBond::parse(nla)?;
+                    let parsed = InfoBond::parse(&nla?)?;
                     v.push(parsed);
                 }
                 InfoData::Bond(v)
@@ -180,10 +161,7 @@ impl InfoData {
             InfoKind::IpVlan => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
-                    let parsed = InfoIpVlan::parse(nla)?;
+                    let parsed = InfoIpVlan::parse(&nla?)?;
                     v.push(parsed);
                 }
                 InfoData::IpVlan(v)
@@ -191,10 +169,7 @@ impl InfoData {
             InfoKind::IpVtap => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
-                    let parsed = InfoIpVtap::parse(nla)?;
+                    let parsed = InfoIpVtap::parse(&nla?)?;
                     v.push(parsed);
                 }
                 InfoData::IpVtap(v)
@@ -202,10 +177,7 @@ impl InfoData {
             InfoKind::MacVlan => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
-                    let parsed = InfoMacVlan::parse(nla)?;
+                    let parsed = InfoMacVlan::parse(&nla?)?;
                     v.push(parsed);
                 }
                 InfoData::MacVlan(v)
@@ -213,10 +185,7 @@ impl InfoData {
             InfoKind::MacVtap => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
-                    let parsed = InfoMacVtap::parse(nla)?;
+                    let parsed = InfoMacVtap::parse(&nla?)?;
                     v.push(parsed);
                 }
                 InfoData::MacVtap(v)
@@ -224,10 +193,7 @@ impl InfoData {
             InfoKind::GreTap => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
-                    let parsed = InfoGreTap::parse(nla)?;
+                    let parsed = InfoGreTap::parse(&nla?)?;
                     v.push(parsed);
                 }
                 InfoData::GreTap(v)
@@ -235,10 +201,7 @@ impl InfoData {
             InfoKind::GreTap6 => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
-                    let parsed = InfoGreTap6::parse(nla)?;
+                    let parsed = InfoGreTap6::parse(&nla?)?;
                     v.push(parsed);
                 }
                 InfoData::GreTap6(v)
@@ -246,10 +209,7 @@ impl InfoData {
             InfoKind::SitTun => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
-                    let parsed = InfoSitTun::parse(nla)?;
+                    let parsed = InfoSitTun::parse(&nla?)?;
                     v.push(parsed);
                 }
                 InfoData::SitTun(v)
@@ -257,10 +217,7 @@ impl InfoData {
             InfoKind::GreTun => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
-                    let parsed = InfoGreTun::parse(nla)?;
+                    let parsed = InfoGreTun::parse(&nla?)?;
                     v.push(parsed);
                 }
                 InfoData::GreTun(v)
@@ -268,10 +225,7 @@ impl InfoData {
             InfoKind::GreTun6 => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
-                    let parsed = InfoGreTun6::parse(nla)?;
+                    let parsed = InfoGreTun6::parse(&nla?)?;
                     v.push(parsed);
                 }
                 InfoData::GreTun6(v)
@@ -279,10 +233,7 @@ impl InfoData {
             InfoKind::Vti => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
-                    let parsed = InfoVti::parse(nla)?;
+                    let parsed = InfoVti::parse(&nla?)?;
                     v.push(parsed);
                 }
                 InfoData::Vti(v)
@@ -290,10 +241,7 @@ impl InfoData {
             InfoKind::Vrf => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
-                    let parsed = InfoVrf::parse(nla)?;
+                    let parsed = InfoVrf::parse(&nla?)?;
                     v.push(parsed);
                 }
                 InfoData::Vrf(v)
@@ -301,10 +249,7 @@ impl InfoData {
             InfoKind::Gtp => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
-                    let parsed = InfoGtp::parse(nla)?;
+                    let parsed = InfoGtp::parse(&nla?)?;
                     v.push(parsed);
                 }
                 InfoData::Gtp(v)
@@ -312,10 +257,7 @@ impl InfoData {
             InfoKind::Ipoib => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
-                    let parsed = InfoIpoib::parse(nla)?;
+                    let parsed = InfoIpoib::parse(&nla?)?;
                     v.push(parsed);
                 }
                 InfoData::Ipoib(v)
@@ -323,10 +265,7 @@ impl InfoData {
             InfoKind::Xfrm => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
-                    let parsed = InfoXfrm::parse(nla)?;
+                    let parsed = InfoXfrm::parse(&nla?)?;
                     v.push(parsed);
                 }
                 InfoData::Xfrm(v)
@@ -334,10 +273,7 @@ impl InfoData {
             InfoKind::MacSec => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
-                    let parsed = InfoMacSec::parse(nla)?;
+                    let parsed = InfoMacSec::parse(&nla?)?;
                     v.push(parsed);
                 }
                 InfoData::MacSec(v)
@@ -345,10 +281,7 @@ impl InfoData {
             InfoKind::Hsr => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
-                    let parsed = InfoHsr::parse(nla)?;
+                    let parsed = InfoHsr::parse(&nla?)?;
                     v.push(parsed);
                 }
                 InfoData::Hsr(v)
@@ -356,10 +289,7 @@ impl InfoData {
             InfoKind::Geneve => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
-                    let parsed = InfoGeneve::parse(nla)?;
+                    let parsed = InfoGeneve::parse(&nla?)?;
                     v.push(parsed);
                 }
                 InfoData::Geneve(v)

--- a/src/link/link_info/infos.rs
+++ b/src/link/link_info/infos.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
 use netlink_packet_utils::{
     nla::{DefaultNla, Nla, NlaBuffer, NlasIterator},
     parsers::parse_string,
@@ -103,8 +102,10 @@ pub(crate) struct VecLinkInfo(pub(crate) Vec<LinkInfo>);
 //
 // The downside is that this impl will not be exposed.
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for VecLinkInfo {
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl<T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&T>> for VecLinkInfo {
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&T>) -> Result<Self, Self::Error> {
         let mut nlas = Vec::new();
         let mut link_info_kind: Option<InfoKind> = None;
         let mut link_info_port_kind: Option<InfoPortKind> = None;
@@ -159,12 +160,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for VecLinkInfo {
                             .into());
                     }
                 }
-                _kind => nlas.push(LinkInfo::Other(
-                    DefaultNla::parse(&nla).context(format!(
-                        "Unknown NLA type for IFLA_INFO_DATA {:?}",
-                        nla
-                    ))?,
-                )),
+                _kind => nlas.push(LinkInfo::Other(DefaultNla::parse(&nla)?)),
             }
         }
         Ok(Self(nlas))
@@ -293,8 +289,10 @@ impl Nla for InfoKind {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoKind {
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<InfoKind, DecodeError> {
+impl<T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&T>> for InfoKind {
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&T>) -> Result<InfoKind, Self::Error> {
         if buf.kind() != IFLA_INFO_KIND {
             return Err(format!(
                 "failed to parse IFLA_INFO_KIND: NLA type is {}",
@@ -302,8 +300,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoKind {
             )
             .into());
         }
-        let s = parse_string(buf.value())
-            .context("invalid IFLA_INFO_KIND value")?;
+        let s = parse_string(buf.value())?;
         Ok(match s.as_str() {
             DUMMY => Self::Dummy,
             IFB => Self::Ifb,

--- a/src/link/link_info/ipvlan.rs
+++ b/src/link/link_info/ipvlan.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
 use netlink_packet_utils::{
     nla::{DefaultNla, Nla, NlaBuffer},
@@ -48,23 +47,18 @@ impl Nla for InfoIpVlan {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoIpVlan {
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl<T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&T>> for InfoIpVlan {
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&T>) -> Result<Self, Self::Error> {
         use self::InfoIpVlan::*;
         let payload = buf.value();
         Ok(match buf.kind() {
-            IFLA_IPVLAN_MODE => Mode(
-                parse_u16(payload)
-                    .context("invalid IFLA_IPVLAN_MODE value")?
-                    .into(),
-            ),
-            IFLA_IPVLAN_FLAGS => Self::Flags(IpVlanFlags::from_bits_retain(
-                parse_u16(payload)
-                    .context("failed to parse IFLA_IPVLAN_FLAGS")?,
-            )),
-            kind => Other(DefaultNla::parse(buf).context(format!(
-                "unknown NLA type {kind} for IFLA_INFO_DATA(ipvlan)"
-            ))?),
+            IFLA_IPVLAN_MODE => Mode(parse_u16(payload)?.into()),
+            IFLA_IPVLAN_FLAGS => {
+                Self::Flags(IpVlanFlags::from_bits_retain(parse_u16(payload)?))
+            }
+            _ => Other(DefaultNla::parse(buf)?),
         })
     }
 }
@@ -105,23 +99,18 @@ impl Nla for InfoIpVtap {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoIpVtap {
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl<T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&T>> for InfoIpVtap {
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&T>) -> Result<Self, Self::Error> {
         use self::InfoIpVtap::*;
         let payload = buf.value();
         Ok(match buf.kind() {
-            IFLA_IPVLAN_MODE => Mode(
-                parse_u16(payload)
-                    .context("invalid IFLA_IPVLAN_MODE value")?
-                    .into(),
-            ),
-            IFLA_IPVLAN_FLAGS => Self::Flags(IpVtapFlags::from_bits_retain(
-                parse_u16(payload)
-                    .context("failed to parse IFLA_IPVLAN_FLAGS")?,
-            )),
-            kind => Other(DefaultNla::parse(buf).context(format!(
-                "unknown NLA type {kind} for IFLA_INFO_DATA(ipvlan)"
-            ))?),
+            IFLA_IPVLAN_MODE => Mode(parse_u16(payload)?.into()),
+            IFLA_IPVLAN_FLAGS => {
+                Self::Flags(IpVtapFlags::from_bits_retain(parse_u16(payload)?))
+            }
+            _ => Other(DefaultNla::parse(buf)?),
         })
     }
 }

--- a/src/link/link_info/mac_vlan.rs
+++ b/src/link/link_info/mac_vlan.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
 use netlink_packet_utils::{
     nla::{DefaultNla, Nla, NlaBuffer, NlasIterator},
@@ -89,57 +88,32 @@ impl Nla for InfoMacVlan {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoMacVlan {
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl<T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&T>> for InfoMacVlan {
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&T>) -> Result<Self, Self::Error> {
         use self::InfoMacVlan::*;
         let payload = buf.value();
         Ok(match buf.kind() {
-            IFLA_MACVLAN_MODE => Mode(
-                parse_u32(payload)
-                    .context("invalid IFLA_MACVLAN_MODE value")?
-                    .into(),
-            ),
-            IFLA_MACVLAN_FLAGS => Flags(
-                parse_u16(payload)
-                    .context("invalid IFLA_MACVLAN_FLAGS value")?,
-            ),
-            IFLA_MACVLAN_MACADDR_MODE => MacAddrMode(
-                parse_u32(payload)
-                    .context("invalid IFLA_MACVLAN_MACADDR_MODE value")?,
-            ),
-            IFLA_MACVLAN_MACADDR => MacAddr(
-                parse_mac(payload)
-                    .context("invalid IFLA_MACVLAN_MACADDR value")?,
-            ),
+            IFLA_MACVLAN_MODE => Mode(parse_u32(payload)?.into()),
+            IFLA_MACVLAN_FLAGS => Flags(parse_u16(payload)?),
+            IFLA_MACVLAN_MACADDR_MODE => MacAddrMode(parse_u32(payload)?),
+            IFLA_MACVLAN_MACADDR => MacAddr(parse_mac(payload)?),
             IFLA_MACVLAN_MACADDR_DATA => {
                 let mut mac_data = Vec::new();
-                let err = "failed to parse IFLA_MACVLAN_MACADDR_DATA";
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(err)?;
-                    let parsed = InfoMacVlan::parse(nla).context(err)?;
+                    let parsed = InfoMacVlan::parse(&nla?)?;
                     mac_data.push(parsed);
                 }
                 MacAddrData(mac_data)
             }
-            IFLA_MACVLAN_MACADDR_COUNT => MacAddrCount(
-                parse_u32(payload)
-                    .context("invalid IFLA_MACVLAN_MACADDR_COUNT value")?,
-            ),
-            IFLA_MACVLAN_BC_QUEUE_LEN => BcQueueLen(
-                parse_u32(payload)
-                    .context("invalid IFLA_MACVLAN_BC_QUEUE_LEN value")?,
-            ),
-            IFLA_MACVLAN_BC_QUEUE_LEN_USED => BcQueueLenUsed(
-                parse_u32(payload)
-                    .context("invalid IFLA_MACVLAN_BC_QUEUE_LEN_USED value")?,
-            ),
-            IFLA_MACVLAN_BC_CUTOFF => BcCutoff(
-                parse_i32(payload)
-                    .context("invalid IFLA_MACVLAN_BC_CUTOFF value")?,
-            ),
-            kind => Other(DefaultNla::parse(buf).context(format!(
-                "unknown NLA type {kind} for IFLA_INFO_DATA(mac_vlan)"
-            ))?),
+            IFLA_MACVLAN_MACADDR_COUNT => MacAddrCount(parse_u32(payload)?),
+            IFLA_MACVLAN_BC_QUEUE_LEN => BcQueueLen(parse_u32(payload)?),
+            IFLA_MACVLAN_BC_QUEUE_LEN_USED => {
+                BcQueueLenUsed(parse_u32(payload)?)
+            }
+            IFLA_MACVLAN_BC_CUTOFF => BcCutoff(parse_i32(payload)?),
+            _ => Other(DefaultNla::parse(buf)?),
         })
     }
 }
@@ -209,57 +183,32 @@ impl Nla for InfoMacVtap {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoMacVtap {
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl<T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&T>> for InfoMacVtap {
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&T>) -> Result<Self, Self::Error> {
         use self::InfoMacVtap::*;
         let payload = buf.value();
         Ok(match buf.kind() {
-            IFLA_MACVLAN_MODE => Mode(
-                parse_u32(payload)
-                    .context("invalid IFLA_MACVLAN_MODE value")?
-                    .into(),
-            ),
-            IFLA_MACVLAN_FLAGS => Flags(
-                parse_u16(payload)
-                    .context("invalid IFLA_MACVLAN_FLAGS value")?,
-            ),
-            IFLA_MACVLAN_MACADDR_MODE => MacAddrMode(
-                parse_u32(payload)
-                    .context("invalid IFLA_MACVLAN_MACADDR_MODE value")?,
-            ),
-            IFLA_MACVLAN_MACADDR => MacAddr(
-                parse_mac(payload)
-                    .context("invalid IFLA_MACVLAN_MACADDR value")?,
-            ),
+            IFLA_MACVLAN_MODE => Mode(parse_u32(payload)?.into()),
+            IFLA_MACVLAN_FLAGS => Flags(parse_u16(payload)?),
+            IFLA_MACVLAN_MACADDR_MODE => MacAddrMode(parse_u32(payload)?),
+            IFLA_MACVLAN_MACADDR => MacAddr(parse_mac(payload)?),
             IFLA_MACVLAN_MACADDR_DATA => {
                 let mut mac_data = Vec::new();
-                let err = "failed to parse IFLA_MACVLAN_MACADDR_DATA";
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(err)?;
-                    let parsed = InfoMacVtap::parse(nla).context(err)?;
+                    let parsed = InfoMacVtap::parse(&nla?)?;
                     mac_data.push(parsed);
                 }
                 MacAddrData(mac_data)
             }
-            IFLA_MACVLAN_MACADDR_COUNT => MacAddrCount(
-                parse_u32(payload)
-                    .context("invalid IFLA_MACVLAN_MACADDR_COUNT value")?,
-            ),
-            IFLA_MACVLAN_BC_QUEUE_LEN => BcQueueLen(
-                parse_u32(payload)
-                    .context("invalid IFLA_MACVLAN_BC_QUEUE_LEN value")?,
-            ),
-            IFLA_MACVLAN_BC_QUEUE_LEN_USED => BcQueueLenUsed(
-                parse_u32(payload)
-                    .context("invalid IFLA_MACVLAN_BC_QUEUE_LEN_USED value")?,
-            ),
-            IFLA_MACVLAN_BC_CUTOFF => BcCutoff(
-                parse_i32(payload)
-                    .context("invalid IFLA_MACVLAN_BC_CUTOFF value")?,
-            ),
-            kind => Other(DefaultNla::parse(buf).context(format!(
-                "unknown NLA type {kind} for IFLA_INFO_DATA(mac_vtap)"
-            ))?),
+            IFLA_MACVLAN_MACADDR_COUNT => MacAddrCount(parse_u32(payload)?),
+            IFLA_MACVLAN_BC_QUEUE_LEN => BcQueueLen(parse_u32(payload)?),
+            IFLA_MACVLAN_BC_QUEUE_LEN_USED => {
+                BcQueueLenUsed(parse_u32(payload)?)
+            }
+            IFLA_MACVLAN_BC_CUTOFF => BcCutoff(parse_i32(payload)?),
+            _ => Other(DefaultNla::parse(buf)?),
         })
     }
 }

--- a/src/link/link_info/macsec.rs
+++ b/src/link/link_info/macsec.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
 use netlink_packet_utils::{
     nla::{DefaultNla, Nla, NlaBuffer},
@@ -212,72 +211,28 @@ impl Nla for InfoMacSec {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoMacSec {
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl<T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&T>> for InfoMacSec {
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&T>) -> Result<Self, Self::Error> {
         use self::InfoMacSec::*;
         let payload = buf.value();
         Ok(match buf.kind() {
-            IFLA_MACSEC_SCI => {
-                Sci(parse_u64(payload)
-                    .context("invalid IFLA_MACSEC_SCI value")?)
-            }
-            IFLA_MACSEC_PORT => Port(
-                parse_u16(payload).context("invalid IFLA_MACSEC_PORT value")?,
-            ),
-            IFLA_MACSEC_ICV_LEN => IcvLen(
-                parse_u8(payload)
-                    .context("invalid IFLA_MACSEC_ICV_LEN value")?,
-            ),
-            IFLA_MACSEC_CIPHER_SUITE => CipherSuite(
-                parse_u64(payload)
-                    .context("invalid IFLA_MACSEC_CIPHER_SUITE value")?
-                    .into(),
-            ),
-            IFLA_MACSEC_WINDOW => Window(
-                parse_u32(payload)
-                    .context("invalid IFLA_MACSEC_WINDOW value")?,
-            ),
-            IFLA_MACSEC_ENCODING_SA => EncodingSa(
-                parse_u8(payload)
-                    .context("invalid IFLA_MACSEC_ENCODING_SA value")?,
-            ),
-            IFLA_MACSEC_ENCRYPT => Encrypt(
-                parse_u8(payload)
-                    .context("invalid IFLA_MACSEC_ENCRYPT value")?,
-            ),
-            IFLA_MACSEC_PROTECT => Protect(
-                parse_u8(payload)
-                    .context("invalid IFLA_MACSEC_PROTECT value")?,
-            ),
-            IFLA_MACSEC_INC_SCI => IncSci(
-                parse_u8(payload)
-                    .context("invalid IFLA_MACSEC_INC_SCI value")?,
-            ),
-            IFLA_MACSEC_ES => {
-                Es(parse_u8(payload).context("invalid IFLA_MACSEC_ES value")?)
-            }
-            IFLA_MACSEC_SCB => {
-                Scb(parse_u8(payload)
-                    .context("invalid IFLA_MACSEC_SCB value")?)
-            }
-            IFLA_MACSEC_REPLAY_PROTECT => ReplayProtect(
-                parse_u8(payload)
-                    .context("invalid IFLA_MACSEC_REPLAY_PROTECT value")?,
-            ),
-            IFLA_MACSEC_VALIDATION => Validation(
-                parse_u8(payload)
-                    .context("invalid IFLA_MACSEC_VALIDATION value")?
-                    .into(),
-            ),
-            IFLA_MACSEC_OFFLOAD => Offload(
-                parse_u8(payload)
-                    .context("invalid IFLA_MACSEC_OFFLOAD value")?
-                    .into(),
-            ),
-            kind => Other(
-                DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {kind}"))?,
-            ),
+            IFLA_MACSEC_SCI => Sci(parse_u64(payload)?),
+            IFLA_MACSEC_PORT => Port(parse_u16(payload)?),
+            IFLA_MACSEC_ICV_LEN => IcvLen(parse_u8(payload)?),
+            IFLA_MACSEC_CIPHER_SUITE => CipherSuite(parse_u64(payload)?.into()),
+            IFLA_MACSEC_WINDOW => Window(parse_u32(payload)?),
+            IFLA_MACSEC_ENCODING_SA => EncodingSa(parse_u8(payload)?),
+            IFLA_MACSEC_ENCRYPT => Encrypt(parse_u8(payload)?),
+            IFLA_MACSEC_PROTECT => Protect(parse_u8(payload)?),
+            IFLA_MACSEC_INC_SCI => IncSci(parse_u8(payload)?),
+            IFLA_MACSEC_ES => Es(parse_u8(payload)?),
+            IFLA_MACSEC_SCB => Scb(parse_u8(payload)?),
+            IFLA_MACSEC_REPLAY_PROTECT => ReplayProtect(parse_u8(payload)?),
+            IFLA_MACSEC_VALIDATION => Validation(parse_u8(payload)?.into()),
+            IFLA_MACSEC_OFFLOAD => Offload(parse_u8(payload)?.into()),
+            _ => Other(DefaultNla::parse(buf)?),
         })
     }
 }

--- a/src/link/link_info/sit.rs
+++ b/src/link/link_info/sit.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
 use netlink_packet_utils::{
     nla::{DefaultNla, Nla, NlaBuffer},
     DecodeError, Parseable,
@@ -32,14 +31,13 @@ impl Nla for InfoSitTun {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoSitTun {
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl<T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&T>> for InfoSitTun {
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&T>) -> Result<Self, Self::Error> {
         #[allow(clippy::match_single_binding)]
         Ok(match buf.kind() {
-            kind => Self::Other(
-                DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {kind} for sit"))?,
-            ),
+            _ => Self::Other(DefaultNla::parse(buf)?),
         })
     }
 }

--- a/src/link/link_info/tun.rs
+++ b/src/link/link_info/tun.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
 use netlink_packet_utils::{
     nla::{DefaultNla, Nla, NlaBuffer},
     DecodeError, Parseable,
@@ -32,13 +31,13 @@ impl Nla for InfoTun {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoTun {
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl<T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&T>> for InfoTun {
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&T>) -> Result<Self, Self::Error> {
         #[allow(clippy::match_single_binding)]
         Ok(match buf.kind() {
-            kind => Self::Other(DefaultNla::parse(buf).context(format!(
-                "unknown NLA type {kind} for IFLA_INFO_DATA(vrf)"
-            ))?),
+            _ => Self::Other(DefaultNla::parse(buf)?),
         })
     }
 }

--- a/src/link/link_info/vti.rs
+++ b/src/link/link_info/vti.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
 use netlink_packet_utils::{
     nla::{DefaultNla, Nla, NlaBuffer},
     DecodeError, Parseable,
@@ -32,14 +31,13 @@ impl Nla for InfoVti {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoVti {
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl<T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&T>> for InfoVti {
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&T>) -> Result<Self, Self::Error> {
         #[allow(clippy::match_single_binding)]
         Ok(match buf.kind() {
-            kind => Self::Other(
-                DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {kind} for vti"))?,
-            ),
+            _ => Self::Other(DefaultNla::parse(buf)?),
         })
     }
 }

--- a/src/link/link_info/xstats.rs
+++ b/src/link/link_info/xstats.rs
@@ -28,13 +28,15 @@ impl Emitable for LinkXstats {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized>
-    ParseableParametrized<NlaBuffer<&'a T>, &InfoKind> for LinkXstats
+impl<T: AsRef<[u8]> + ?Sized> ParseableParametrized<NlaBuffer<&T>, &InfoKind>
+    for LinkXstats
 {
+    type Error = DecodeError;
+
     fn parse_with_param(
-        buf: &NlaBuffer<&'a T>,
+        buf: &NlaBuffer<&T>,
         _kind: &InfoKind,
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, Self::Error> {
         Ok(Self::Other(buf.value().to_vec()))
     }
 }

--- a/src/link/map.rs
+++ b/src/link/map.rs
@@ -28,7 +28,9 @@ pub struct Map {
 }
 
 impl<T: AsRef<[u8]>> Parseable<MapBuffer<T>> for Map {
-    fn parse(buf: &MapBuffer<T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &MapBuffer<T>) -> Result<Self, Self::Error> {
         Ok(Self {
             memory_start: buf.memory_start(),
             memory_end: buf.memory_end(),

--- a/src/link/phys_id.rs
+++ b/src/link/phys_id.rs
@@ -15,7 +15,9 @@ pub struct LinkPhysId {
 }
 
 impl Parseable<[u8]> for LinkPhysId {
-    fn parse(buf: &[u8]) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &[u8]) -> Result<Self, Self::Error> {
         let len = buf.len() % MAX_PHYS_ITEM_ID_LEN;
         let mut id = [0; MAX_PHYS_ITEM_ID_LEN];
         id[..len].copy_from_slice(&buf[..len]);

--- a/src/link/prop_list.rs
+++ b/src/link/prop_list.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
 use netlink_packet_utils::{
     nla::{DefaultNla, Nla, NlaBuffer},
     parsers::parse_string,
@@ -48,18 +47,14 @@ impl Nla for Prop {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Prop {
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl<T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&T>> for Prop {
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&T>) -> Result<Self, Self::Error> {
         let payload = buf.value();
         Ok(match buf.kind() {
-            IFLA_ALT_IFNAME => Prop::AltIfName(
-                parse_string(payload)
-                    .context("invalid IFLA_ALT_IFNAME value")?,
-            ),
-            kind => Prop::Other(
-                DefaultNla::parse(buf)
-                    .context(format!("Unknown NLA type {kind}"))?,
-            ),
+            IFLA_ALT_IFNAME => Prop::AltIfName(parse_string(payload)?),
+            _ => Prop::Other(DefaultNla::parse(buf)?),
         })
     }
 }

--- a/src/link/proto_info/inet6.rs
+++ b/src/link/proto_info/inet6.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
 use netlink_packet_utils::{
     nla::{DefaultNla, Nla, NlaBuffer, NlasIterator},
     traits::Parseable,
@@ -15,17 +14,15 @@ pub enum LinkProtoInfoInet6 {
 
 pub(crate) struct VecLinkProtoInfoInet6(pub(crate) Vec<LinkProtoInfoInet6>);
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
+impl<T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&T>>
     for VecLinkProtoInfoInet6
 {
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&T>) -> Result<Self, Self::Error> {
         let mut nlas = vec![];
         for nla in NlasIterator::new(buf.into_inner()) {
-            let nla = nla.context(format!(
-                "invalid inet6 IFLA_PROTINFO {:?}",
-                buf.value()
-            ))?;
-            nlas.push(LinkProtoInfoInet6::parse(&nla)?);
+            nlas.push(LinkProtoInfoInet6::parse(&nla?)?);
         }
         Ok(Self(nlas))
     }
@@ -51,13 +48,10 @@ impl Nla for LinkProtoInfoInet6 {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
-    for LinkProtoInfoInet6
-{
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
-        Ok(Self::Other(DefaultNla::parse(buf).context(format!(
-            "invalid inet6 IFLA_PROTINFO {:?}",
-            buf.value()
-        ))?))
+impl<T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&T>> for LinkProtoInfoInet6 {
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&T>) -> Result<Self, Self::Error> {
+        Ok(Self::Other(DefaultNla::parse(buf)?))
     }
 }

--- a/src/link/sriov/broadcast.rs
+++ b/src/link/sriov/broadcast.rs
@@ -29,7 +29,9 @@ buffer!(VfInfoBroadcastBuffer(VF_INFO_BROADCAST_LEN) {
 impl<T: AsRef<[u8]> + ?Sized> Parseable<VfInfoBroadcastBuffer<&T>>
     for VfInfoBroadcast
 {
-    fn parse(buf: &VfInfoBroadcastBuffer<&T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &VfInfoBroadcastBuffer<&T>) -> Result<Self, Self::Error> {
         Ok(Self::new(buf.addr()))
     }
 }

--- a/src/link/sriov/guid.rs
+++ b/src/link/sriov/guid.rs
@@ -23,7 +23,9 @@ buffer!(VfInfoGuidBuffer(VF_INFO_GUID_LEN) {
 });
 
 impl<T: AsRef<[u8]> + ?Sized> Parseable<VfInfoGuidBuffer<&T>> for VfInfoGuid {
-    fn parse(buf: &VfInfoGuidBuffer<&T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &VfInfoGuidBuffer<&T>) -> Result<Self, Self::Error> {
         Ok(Self::new(buf.vf_id(), buf.guid()))
     }
 }

--- a/src/link/sriov/link_state.rs
+++ b/src/link/sriov/link_state.rs
@@ -25,7 +25,9 @@ buffer!(VfInfoLinkStateBuffer(VF_INFO_LINK_STATE_LEN) {
 impl<T: AsRef<[u8]> + ?Sized> Parseable<VfInfoLinkStateBuffer<&T>>
     for VfInfoLinkState
 {
-    fn parse(buf: &VfInfoLinkStateBuffer<&T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &VfInfoLinkStateBuffer<&T>) -> Result<Self, Self::Error> {
         Ok(Self::new(buf.vf_id(), buf.state().into()))
     }
 }

--- a/src/link/sriov/mac.rs
+++ b/src/link/sriov/mac.rs
@@ -34,7 +34,9 @@ buffer!(VfInfoMacBuffer(VF_INFO_MAC_LEN) {
 });
 
 impl<T: AsRef<[u8]> + ?Sized> Parseable<VfInfoMacBuffer<&T>> for VfInfoMac {
-    fn parse(buf: &VfInfoMacBuffer<&T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &VfInfoMacBuffer<&T>) -> Result<Self, Self::Error> {
         Ok(Self::new(buf.vf_id(), buf.mac()))
     }
 }

--- a/src/link/sriov/rate.rs
+++ b/src/link/sriov/rate.rs
@@ -29,7 +29,9 @@ buffer!(VfInfoRateBuffer(VF_INFO_RATE_LEN) {
 });
 
 impl<T: AsRef<[u8]> + ?Sized> Parseable<VfInfoRateBuffer<&T>> for VfInfoRate {
-    fn parse(buf: &VfInfoRateBuffer<&T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &VfInfoRateBuffer<&T>) -> Result<Self, Self::Error> {
         Ok(Self {
             vf_id: buf.vf_id(),
             min_tx_rate: buf.min_tx_rate(),

--- a/src/link/sriov/rss_query.rs
+++ b/src/link/sriov/rss_query.rs
@@ -25,7 +25,9 @@ buffer!(VfInfoRssQueryEnBuffer(VF_INFO_RSS_QUERY_EN_LEN) {
 impl<T: AsRef<[u8]> + ?Sized> Parseable<VfInfoRssQueryEnBuffer<&T>>
     for VfInfoRssQueryEn
 {
-    fn parse(buf: &VfInfoRssQueryEnBuffer<&T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &VfInfoRssQueryEnBuffer<&T>) -> Result<Self, Self::Error> {
         Ok(Self::new(
             buf.vf_id(),
             buf.setting() > 0 && buf.setting() != u32::MAX,

--- a/src/link/sriov/spoofchk.rs
+++ b/src/link/sriov/spoofchk.rs
@@ -25,7 +25,9 @@ buffer!(VfInfoSpoofCheckBuffer(VF_INFO_SPOOFCHK_LEN) {
 impl<T: AsRef<[u8]> + ?Sized> Parseable<VfInfoSpoofCheckBuffer<&T>>
     for VfInfoSpoofCheck
 {
-    fn parse(buf: &VfInfoSpoofCheckBuffer<&T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &VfInfoSpoofCheckBuffer<&T>) -> Result<Self, Self::Error> {
         Ok(Self::new(
             buf.vf_id(),
             buf.setting() > 0 && buf.setting() != u32::MAX,

--- a/src/link/sriov/stats.rs
+++ b/src/link/sriov/stats.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
 use netlink_packet_utils::{
     nla::{DefaultNla, Nla, NlaBuffer},
@@ -70,52 +69,20 @@ impl Nla for VfStats {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for VfStats {
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, Self::Error> {
         let payload = buf.value();
         Ok(match buf.kind() {
-            IFLA_VF_STATS_RX_PACKETS => {
-                Self::RxPackets(parse_u64(payload).context(format!(
-                    "invalid IFLA_VF_STATS_RX_PACKETS value {payload:?}"
-                ))?)
-            }
-            IFLA_VF_STATS_TX_PACKETS => {
-                Self::TxPackets(parse_u64(payload).context(format!(
-                    "invalid IFLA_VF_STATS_TX_PACKETS value {payload:?}"
-                ))?)
-            }
-            IFLA_VF_STATS_RX_BYTES => {
-                Self::RxBytes(parse_u64(payload).context(format!(
-                    "invalid IFLA_VF_STATS_RX_BYTES value {payload:?}"
-                ))?)
-            }
-            IFLA_VF_STATS_TX_BYTES => {
-                Self::TxBytes(parse_u64(payload).context(format!(
-                    "invalid IFLA_VF_STATS_TX_BYTES value {payload:?}"
-                ))?)
-            }
-            IFLA_VF_STATS_BROADCAST => {
-                Self::Broadcast(parse_u64(payload).context(format!(
-                    "invalid IFLA_VF_STATS_BROADCAST value {payload:?}"
-                ))?)
-            }
-            IFLA_VF_STATS_MULTICAST => {
-                Self::Multicast(parse_u64(payload).context(format!(
-                    "invalid IFLA_VF_STATS_MULTICAST value {payload:?}"
-                ))?)
-            }
-            IFLA_VF_STATS_RX_DROPPED => {
-                Self::RxDropped(parse_u64(payload).context(format!(
-                    "invalid IFLA_VF_STATS_RX_DROPPED value {payload:?}"
-                ))?)
-            }
-            IFLA_VF_STATS_TX_DROPPED => {
-                Self::TxDropped(parse_u64(payload).context(format!(
-                    "invalid IFLA_VF_STATS_TX_DROPPED value {payload:?}"
-                ))?)
-            }
-            kind => Self::Other(DefaultNla::parse(buf).context(format!(
-                "failed to parse {kind} as DefaultNla: {payload:?}"
-            ))?),
+            IFLA_VF_STATS_RX_PACKETS => Self::RxPackets(parse_u64(payload)?),
+            IFLA_VF_STATS_TX_PACKETS => Self::TxPackets(parse_u64(payload)?),
+            IFLA_VF_STATS_RX_BYTES => Self::RxBytes(parse_u64(payload)?),
+            IFLA_VF_STATS_TX_BYTES => Self::TxBytes(parse_u64(payload)?),
+            IFLA_VF_STATS_BROADCAST => Self::Broadcast(parse_u64(payload)?),
+            IFLA_VF_STATS_MULTICAST => Self::Multicast(parse_u64(payload)?),
+            IFLA_VF_STATS_RX_DROPPED => Self::RxDropped(parse_u64(payload)?),
+            IFLA_VF_STATS_TX_DROPPED => Self::TxDropped(parse_u64(payload)?),
+            _ => Self::Other(DefaultNla::parse(buf)?),
         })
     }
 }

--- a/src/link/sriov/trust.rs
+++ b/src/link/sriov/trust.rs
@@ -23,7 +23,9 @@ buffer!(VfInfoTrustBuffer(VF_INFO_TRUST_LEN) {
 });
 
 impl<T: AsRef<[u8]> + ?Sized> Parseable<VfInfoTrustBuffer<&T>> for VfInfoTrust {
-    fn parse(buf: &VfInfoTrustBuffer<&T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &VfInfoTrustBuffer<&T>) -> Result<Self, Self::Error> {
         Ok(Self::new(
             buf.vf_id(),
             buf.setting() > 0 && buf.setting() != u32::MAX,

--- a/src/link/sriov/tx_rate.rs
+++ b/src/link/sriov/tx_rate.rs
@@ -25,7 +25,9 @@ buffer!(VfInfoTxRateBuffer(VF_INFO_TX_RATE_LEN) {
 impl<T: AsRef<[u8]> + ?Sized> Parseable<VfInfoTxRateBuffer<&T>>
     for VfInfoTxRate
 {
-    fn parse(buf: &VfInfoTxRateBuffer<&T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &VfInfoTxRateBuffer<&T>) -> Result<Self, Self::Error> {
         Ok(Self {
             vf_id: buf.vf_id(),
             rate: buf.rate(),

--- a/src/link/sriov/vf_port.rs
+++ b/src/link/sriov/vf_port.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
 use netlink_packet_utils::{
     nla::{DefaultNla, Nla, NlaBuffer, NlasIterator},
     DecodeError, Emitable, Parseable,
@@ -12,13 +11,12 @@ pub(crate) struct VecLinkVfPort(pub(crate) Vec<LinkVfPort>);
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for VecLinkVfPort
 {
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, Self::Error> {
         let mut nlas = vec![];
         for nla in NlasIterator::new(buf.into_inner()) {
-            let nla = &nla.context(format!(
-                "invalid IFLA_VF_PORTS value: {:?}",
-                buf.value()
-            ))?;
+            let nla = &nla?;
             if nla.kind() == IFLA_VF_PORT {
                 nlas.push(LinkVfPort::parse(&NlaBuffer::new_checked(
                     nla.value(),
@@ -54,15 +52,13 @@ impl Nla for LinkVfPort {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for LinkVfPort {
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl<T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&T>> for LinkVfPort {
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&T>) -> Result<Self, Self::Error> {
         let mut nlas = vec![];
         for nla in NlasIterator::new(buf.into_inner()) {
-            let nla = &nla.context(format!(
-                "invalid IFLA_VF_PORT value {:?}",
-                buf.value()
-            ))?;
-            nlas.push(VfPort::parse(nla)?);
+            nlas.push(VfPort::parse(&nla?)?);
         }
         Ok(Self(nlas))
     }
@@ -112,14 +108,13 @@ impl Nla for VfPort {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for VfPort {
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
-        let payload = buf.value();
+impl<T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&T>> for VfPort {
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&T>) -> Result<Self, Self::Error> {
         #[allow(clippy::match_single_binding)]
         Ok(match buf.kind() {
-            kind => Self::Other(DefaultNla::parse(buf).context(format!(
-                "failed to parse {kind} as DefaultNla: {payload:?}"
-            ))?),
+            _ => Self::Other(DefaultNla::parse(buf)?),
         })
     }
 }

--- a/src/link/sriov/vlan.rs
+++ b/src/link/sriov/vlan.rs
@@ -29,7 +29,9 @@ buffer!(VfInfoVlanBuffer(VF_INFO_VLAN_LEN) {
 });
 
 impl<T: AsRef<[u8]> + ?Sized> Parseable<VfInfoVlanBuffer<&T>> for VfInfoVlan {
-    fn parse(buf: &VfInfoVlanBuffer<&T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &VfInfoVlanBuffer<&T>) -> Result<Self, Self::Error> {
         Ok(Self {
             vf_id: buf.vf_id(),
             vlan_id: buf.vlan_id(),

--- a/src/link/stats.rs
+++ b/src/link/stats.rs
@@ -86,7 +86,9 @@ buffer!(StatsBuffer(LINK_STATS_LEN) {
 });
 
 impl<T: AsRef<[u8]>> Parseable<StatsBuffer<T>> for Stats {
-    fn parse(buf: &StatsBuffer<T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &StatsBuffer<T>) -> Result<Self, Self::Error> {
         Ok(Self {
             rx_packets: buf.rx_packets(),
             tx_packets: buf.tx_packets(),

--- a/src/link/stats64.rs
+++ b/src/link/stats64.rs
@@ -89,7 +89,9 @@ pub struct Stats64 {
 }
 
 impl<T: AsRef<[u8]>> Parseable<Stats64Buffer<T>> for Stats64 {
-    fn parse(buf: &Stats64Buffer<T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &Stats64Buffer<T>) -> Result<Self, Self::Error> {
         Ok(Self {
             rx_packets: buf.rx_packets(),
             tx_packets: buf.tx_packets(),

--- a/src/link/wireless.rs
+++ b/src/link/wireless.rs
@@ -8,7 +8,9 @@ use netlink_packet_utils::{DecodeError, Emitable, Parseable};
 pub struct LinkWirelessEvent(Vec<u8>);
 
 impl<T: AsRef<[u8]> + ?Sized> Parseable<T> for LinkWirelessEvent {
-    fn parse(buf: &T) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &T) -> Result<Self, Self::Error> {
         Ok(LinkWirelessEvent(buf.as_ref().to_vec()))
     }
 }

--- a/src/neighbour/attribute.rs
+++ b/src/neighbour/attribute.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
 use byteorder::{BigEndian, ByteOrder, NativeEndian};
 use netlink_packet_utils::{
     nla::{DefaultNla, Nla, NlaBuffer},
@@ -102,61 +101,35 @@ impl Nla for NeighbourAttribute {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized>
-    ParseableParametrized<NlaBuffer<&'a T>, AddressFamily>
-    for NeighbourAttribute
+impl<T: AsRef<[u8]> + ?Sized>
+    ParseableParametrized<NlaBuffer<&T>, AddressFamily> for NeighbourAttribute
 {
+    type Error = DecodeError;
+
     fn parse_with_param(
-        buf: &NlaBuffer<&'a T>,
+        buf: &NlaBuffer<&T>,
         address_family: AddressFamily,
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, Self::Error> {
         let payload = buf.value();
         Ok(match buf.kind() {
-            NDA_DST => Self::Destination(
-                NeighbourAddress::parse_with_param(address_family, payload)
-                    .context(format!("invalid NDA_DST value {:?}", payload))?,
-            ),
+            NDA_DST => Self::Destination(NeighbourAddress::parse_with_param(
+                address_family,
+                payload,
+            )?),
             NDA_LLADDR => Self::LinkLocalAddress(payload.to_vec()),
-            NDA_CACHEINFO => Self::CacheInfo(
-                NeighbourCacheInfo::parse(
-                    &NeighbourCacheInfoBuffer::new_checked(payload).context(
-                        format!("invalid NDA_CACHEINFO value {:?}", payload),
-                    )?,
-                )
-                .context(format!(
-                    "invalid NDA_CACHEINFO value {:?}",
-                    payload
-                ))?,
-            ),
-            NDA_PROBES => {
-                Self::Probes(parse_u32(payload).context(format!(
-                    "invalid NDA_PROBES value {:?}",
-                    payload
-                ))?)
-            }
+            NDA_CACHEINFO => Self::CacheInfo(NeighbourCacheInfo::parse(
+                &NeighbourCacheInfoBuffer::new_checked(payload)?,
+            )?),
+            NDA_PROBES => Self::Probes(parse_u32(payload)?),
             NDA_VLAN => Self::Vlan(parse_u16(payload)?),
-            NDA_PORT => Self::Port(
-                parse_u16_be(payload)
-                    .context(format!("invalid NDA_PORT value {payload:?}"))?,
-            ),
+            NDA_PORT => Self::Port(parse_u16_be(payload)?),
             NDA_VNI => Self::Vni(parse_u32(payload)?),
             NDA_IFINDEX => Self::IfIndex(parse_u32(payload)?),
-            NDA_CONTROLLER => Self::Controller(parse_u32(payload).context(
-                format!("invalid NDA_CONTROLLER value {payload:?}"),
-            )?),
-            NDA_LINK_NETNSID => Self::LinkNetNsId(parse_u32(payload).context(
-                format!("invalid NDA_LINK_NETNSID value {payload:?}"),
-            )?),
+            NDA_CONTROLLER => Self::Controller(parse_u32(payload)?),
+            NDA_LINK_NETNSID => Self::LinkNetNsId(parse_u32(payload)?),
             NDA_SRC_VNI => Self::SourceVni(parse_u32(payload)?),
-            NDA_PROTOCOL => {
-                Self::Protocol(RouteProtocol::parse(payload).context(
-                    format!("invalid NDA_PROTOCOL value {:?}", payload),
-                )?)
-            }
-            _ => Self::Other(
-                DefaultNla::parse(buf)
-                    .context("invalid link NLA value (unknown type)")?,
-            ),
+            NDA_PROTOCOL => Self::Protocol(RouteProtocol::parse(payload)?),
+            _ => Self::Other(DefaultNla::parse(buf)?),
         })
     }
 }

--- a/src/neighbour/cache_info.rs
+++ b/src/neighbour/cache_info.rs
@@ -26,7 +26,9 @@ buffer!(NeighbourCacheInfoBuffer(NEIGHBOUR_CACHE_INFO_LEN) {
 impl<T: AsRef<[u8]>> Parseable<NeighbourCacheInfoBuffer<T>>
     for NeighbourCacheInfo
 {
-    fn parse(buf: &NeighbourCacheInfoBuffer<T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &NeighbourCacheInfoBuffer<T>) -> Result<Self, Self::Error> {
         Ok(Self {
             confirmed: buf.confirmed(),
             used: buf.used(),

--- a/src/neighbour/header.rs
+++ b/src/neighbour/header.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 use netlink_packet_utils::{
-    nla::{NlaBuffer, NlasIterator},
+    nla::{NlaBuffer, NlaError, NlasIterator},
     traits::{Emitable, Parseable},
     DecodeError,
 };
@@ -23,7 +23,7 @@ buffer!(NeighbourMessageBuffer(NEIGHBOUR_HEADER_LEN) {
 impl<'a, T: AsRef<[u8]> + ?Sized> NeighbourMessageBuffer<&'a T> {
     pub fn attributes(
         &self,
-    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
+    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, NlaError>> {
         NlasIterator::new(self.payload())
     }
 }
@@ -58,7 +58,9 @@ pub struct NeighbourHeader {
 }
 
 impl<T: AsRef<[u8]>> Parseable<NeighbourMessageBuffer<T>> for NeighbourHeader {
-    fn parse(buf: &NeighbourMessageBuffer<T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &NeighbourMessageBuffer<T>) -> Result<Self, Self::Error> {
         Ok(Self {
             family: buf.family().into(),
             ifindex: buf.ifindex(),

--- a/src/neighbour/message.rs
+++ b/src/neighbour/message.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
 use netlink_packet_utils::{
     traits::{Emitable, Parseable, ParseableParametrized},
     DecodeError,
@@ -31,32 +30,34 @@ impl Emitable for NeighbourMessage {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<NeighbourMessageBuffer<&'a T>>
+impl<T: AsRef<[u8]>> Parseable<NeighbourMessageBuffer<&T>>
     for NeighbourMessage
 {
-    fn parse(buf: &NeighbourMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
-        let header = NeighbourHeader::parse(buf)
-            .context("failed to parse neighbour message header")?;
+    type Error = DecodeError;
+
+    fn parse(buf: &NeighbourMessageBuffer<&T>) -> Result<Self, Self::Error> {
+        let header = NeighbourHeader::parse(buf)?;
         let address_family = header.family;
         Ok(NeighbourMessage {
             header,
             attributes: Vec::<NeighbourAttribute>::parse_with_param(
                 buf,
                 address_family,
-            )
-            .context("failed to parse neighbour message NLAs")?,
+            )?,
         })
     }
 }
 
-impl<'a, T: AsRef<[u8]> + 'a>
-    ParseableParametrized<NeighbourMessageBuffer<&'a T>, AddressFamily>
+impl<T: AsRef<[u8]>>
+    ParseableParametrized<NeighbourMessageBuffer<&T>, AddressFamily>
     for Vec<NeighbourAttribute>
 {
+    type Error = DecodeError;
+
     fn parse_with_param(
-        buf: &NeighbourMessageBuffer<&'a T>,
+        buf: &NeighbourMessageBuffer<&T>,
         address_family: AddressFamily,
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, Self::Error> {
         let mut attributes = vec![];
         for nla_buf in buf.attributes() {
             attributes.push(NeighbourAttribute::parse_with_param(

--- a/src/neighbour_table/config.rs
+++ b/src/neighbour_table/config.rs
@@ -36,7 +36,9 @@ buffer!(NeighbourTableConfigBuffer(CONFIG_LEN) {
 impl<T: AsRef<[u8]>> Parseable<NeighbourTableConfigBuffer<T>>
     for NeighbourTableConfig
 {
-    fn parse(buf: &NeighbourTableConfigBuffer<T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &NeighbourTableConfigBuffer<T>) -> Result<Self, Self::Error> {
         Ok(Self {
             key_len: buf.key_len(),
             entry_size: buf.entry_size(),

--- a/src/neighbour_table/header.rs
+++ b/src/neighbour_table/header.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 use netlink_packet_utils::{
-    nla::{NlaBuffer, NlasIterator},
+    nla::{NlaBuffer, NlaError, NlasIterator},
     traits::{Emitable, Parseable},
     DecodeError,
 };
@@ -18,7 +18,7 @@ buffer!(NeighbourTableMessageBuffer(NEIGHBOUR_TABLE_HEADER_LEN) {
 impl<'a, T: AsRef<[u8]> + ?Sized> NeighbourTableMessageBuffer<&'a T> {
     pub fn attributes(
         &self,
-    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
+    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, NlaError>> {
         NlasIterator::new(self.payload())
     }
 }
@@ -32,9 +32,11 @@ pub struct NeighbourTableHeader {
 impl<T: AsRef<[u8]>> Parseable<NeighbourTableMessageBuffer<T>>
     for NeighbourTableHeader
 {
+    type Error = DecodeError;
+
     fn parse(
         buf: &NeighbourTableMessageBuffer<T>,
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, Self::Error> {
         Ok(Self {
             family: buf.family().into(),
         })

--- a/src/neighbour_table/message.rs
+++ b/src/neighbour_table/message.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
 use netlink_packet_utils::{
     traits::{Emitable, Parseable},
     DecodeError,
@@ -30,27 +29,29 @@ impl Emitable for NeighbourTableMessage {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<NeighbourTableMessageBuffer<&'a T>>
+impl<T: AsRef<[u8]>> Parseable<NeighbourTableMessageBuffer<&T>>
     for NeighbourTableMessage
 {
+    type Error = DecodeError;
+
     fn parse(
-        buf: &NeighbourTableMessageBuffer<&'a T>,
-    ) -> Result<Self, DecodeError> {
+        buf: &NeighbourTableMessageBuffer<&T>,
+    ) -> Result<Self, Self::Error> {
         Ok(NeighbourTableMessage {
-            header: NeighbourTableHeader::parse(buf)
-                .context("failed to parse neighbour table message header")?,
-            attributes: Vec::<NeighbourTableAttribute>::parse(buf)
-                .context("failed to parse neighbour table message NLAs")?,
+            header: NeighbourTableHeader::parse(buf)?,
+            attributes: Vec::<NeighbourTableAttribute>::parse(buf)?,
         })
     }
 }
 
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<NeighbourTableMessageBuffer<&'a T>>
+impl<T: AsRef<[u8]>> Parseable<NeighbourTableMessageBuffer<&T>>
     for Vec<NeighbourTableAttribute>
 {
+    type Error = DecodeError;
+
     fn parse(
-        buf: &NeighbourTableMessageBuffer<&'a T>,
-    ) -> Result<Self, DecodeError> {
+        buf: &NeighbourTableMessageBuffer<&T>,
+    ) -> Result<Self, Self::Error> {
         let mut attributes = vec![];
         for nla_buf in buf.attributes() {
             attributes.push(NeighbourTableAttribute::parse(&nla_buf?)?);

--- a/src/neighbour_table/param.rs
+++ b/src/neighbour_table/param.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
 use netlink_packet_utils::{
     nla::{DefaultNla, Nla, NlaBuffer, NlasIterator},
@@ -132,95 +131,35 @@ impl Nla for NeighbourTableParameter {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
+impl<T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&T>>
     for NeighbourTableParameter
 {
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&T>) -> Result<Self, Self::Error> {
         let payload = buf.value();
         Ok(match buf.kind() {
-            NDTPA_IFINDEX => {
-                Self::Ifindex(parse_u32(payload).context(format!(
-                    "invalid NDTPA_IFINDEX value {payload:?}"
-                ))?)
-            }
-            NDTPA_REFCNT => {
-                Self::ReferenceCount(parse_u32(payload).context(format!(
-                    "invalid NDTPA_REFCNT value {payload:?}"
-                ))?)
-            }
-            NDTPA_REACHABLE_TIME => {
-                Self::ReachableTime(parse_u64(payload).context(format!(
-                    "invalid NDTPA_REACHABLE_TIME value {payload:?}"
-                ))?)
-            }
+            NDTPA_IFINDEX => Self::Ifindex(parse_u32(payload)?),
+            NDTPA_REFCNT => Self::ReferenceCount(parse_u32(payload)?),
+            NDTPA_REACHABLE_TIME => Self::ReachableTime(parse_u64(payload)?),
             NDTPA_BASE_REACHABLE_TIME => {
-                Self::BaseReachableTime(parse_u64(payload).context(format!(
-                    "invalid NDTPA_BASE_REACHABLE_TIME value {payload:?}"
-                ))?)
+                Self::BaseReachableTime(parse_u64(payload)?)
             }
-            NDTPA_RETRANS_TIME => {
-                Self::RetransTime(parse_u64(payload).context(format!(
-                    "invalid NDTPA_RETRANS_TIME value {payload:?}"
-                ))?)
+            NDTPA_DELAY_PROBE_TIME => Self::DelayProbeTime(parse_u64(payload)?),
+            NDTPA_QUEUE_LEN => Self::QueueLen(parse_u32(payload)?),
+            NDTPA_APP_PROBES => Self::AppProbes(parse_u32(payload)?),
+            NDTPA_UCAST_PROBES => Self::UcastProbes(parse_u32(payload)?),
+            NDTPA_MCAST_PROBES => Self::McastProbes(parse_u32(payload)?),
+            NDTPA_ANYCAST_DELAY => Self::AnycastDelay(parse_u64(payload)?),
+            NDTPA_PROXY_DELAY => Self::ProxyDelay(parse_u64(payload)?),
+            NDTPA_PROXY_QLEN => Self::ProxyQlen(parse_u32(payload)?),
+            NDTPA_LOCKTIME => Self::Locktime(parse_u64(payload)?),
+            NDTPA_QUEUE_LENBYTES => Self::QueueLenbytes(parse_u32(payload)?),
+            NDTPA_MCAST_REPROBES => Self::McastReprobes(parse_u32(payload)?),
+            NDTPA_INTERVAL_PROBE_TIME_MS => {
+                Self::IntervalProbeTimeMs(parse_u64(payload)?)
             }
-            NDTPA_GC_STALETIME => {
-                Self::GcStaletime(parse_u64(payload).context(format!(
-                    "invalid NDTPA_GC_STALE_TIME value {payload:?}"
-                ))?)
-            }
-            NDTPA_DELAY_PROBE_TIME => {
-                Self::DelayProbeTime(parse_u64(payload).context(format!(
-                    "invalid NDTPA_DELAY_PROBE_TIME value {payload:?}"
-                ))?)
-            }
-            NDTPA_QUEUE_LEN => Self::QueueLen(parse_u32(payload).context(
-                format!("invalid NDTPA_QUEUE_LEN value {payload:?}"),
-            )?),
-            NDTPA_APP_PROBES => Self::AppProbes(parse_u32(payload).context(
-                format!("invalid NDTPA_APP_PROBES value {payload:?}"),
-            )?),
-            NDTPA_UCAST_PROBES => {
-                Self::UcastProbes(parse_u32(payload).context(format!(
-                    "invalid NDTPA_UCAST_PROBES value {payload:?}"
-                ))?)
-            }
-            NDTPA_MCAST_PROBES => {
-                Self::McastProbes(parse_u32(payload).context(format!(
-                    "invalid NDTPA_MCAST_PROBES value {payload:?}"
-                ))?)
-            }
-            NDTPA_ANYCAST_DELAY => {
-                Self::AnycastDelay(parse_u64(payload).context(format!(
-                    "invalid NDTPA_ANYCAST_DELAY value {payload:?}"
-                ))?)
-            }
-            NDTPA_PROXY_DELAY => Self::ProxyDelay(parse_u64(payload).context(
-                format!("invalid NDTPA_PROXY_DELAY value {payload:?}"),
-            )?),
-            NDTPA_PROXY_QLEN => Self::ProxyQlen(parse_u32(payload).context(
-                format!("invalid NDTPA_PROXY_QLEN value {payload:?}"),
-            )?),
-            NDTPA_LOCKTIME => Self::Locktime(parse_u64(payload).context(
-                format!("invalid NDTPA_LOCKTIME value {payload:?}"),
-            )?),
-            NDTPA_QUEUE_LENBYTES => {
-                Self::QueueLenbytes(parse_u32(payload).context(format!(
-                    "invalid NDTPA_QUEUE_LENBYTES value {payload:?}"
-                ))?)
-            }
-            NDTPA_MCAST_REPROBES => {
-                Self::McastReprobes(parse_u32(payload).context(format!(
-                    "invalid NDTPA_MCAST_PROBES value {payload:?}"
-                ))?)
-            }
-            NDTPA_INTERVAL_PROBE_TIME_MS => Self::IntervalProbeTimeMs(
-                parse_u64(payload).context(format!(
-                    "invalid NDTPA_INTERVAL_PROBE_TIME_MS value {payload:?}"
-                ))?,
-            ),
-            _ => Self::Other(DefaultNla::parse(buf).context(format!(
-                "invalid NDTA_PARMS attribute {payload:?}"
-            ))?),
+            _ => Self::Other(DefaultNla::parse(buf)?),
         })
     }
 }
@@ -230,15 +169,15 @@ pub(crate) struct VecNeighbourTableParameter(
     pub(crate) Vec<NeighbourTableParameter>,
 );
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
+impl<T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&T>>
     for VecNeighbourTableParameter
 {
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&T>) -> Result<Self, Self::Error> {
         let mut nlas = vec![];
-        let err = "invalid NDTA_PARMS attribute";
         for nla in NlasIterator::new(buf.into_inner()) {
-            let nla = nla.context(err)?;
-            nlas.push(NeighbourTableParameter::parse(&nla).context(err)?);
+            nlas.push(NeighbourTableParameter::parse(&nla?)?);
         }
         Ok(Self(nlas))
     }

--- a/src/neighbour_table/stats.rs
+++ b/src/neighbour_table/stats.rs
@@ -39,7 +39,9 @@ buffer!(NeighbourTableStatsBuffer(STATS_LEN) {
 impl<T: AsRef<[u8]>> Parseable<NeighbourTableStatsBuffer<T>>
     for NeighbourTableStats
 {
-    fn parse(buf: &NeighbourTableStatsBuffer<T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &NeighbourTableStatsBuffer<T>) -> Result<Self, Self::Error> {
         Ok(Self {
             allocs: buf.allocs(),
             destroys: buf.destroys(),

--- a/src/nsid/header.rs
+++ b/src/nsid/header.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 use netlink_packet_utils::{
-    nla::{NlaBuffer, NlasIterator},
+    nla::{NlaBuffer, NlaError, NlasIterator},
     DecodeError, Emitable, Parseable,
 };
 
@@ -17,7 +17,7 @@ buffer!(NsidMessageBuffer(NSID_HEADER_LEN) {
 impl<'a, T: AsRef<[u8]> + ?Sized> NsidMessageBuffer<&'a T> {
     pub fn attributes(
         &self,
-    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
+    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, NlaError>> {
         NlasIterator::new(self.payload())
     }
 }
@@ -39,7 +39,9 @@ impl Emitable for NsidHeader {
 }
 
 impl<T: AsRef<[u8]>> Parseable<NsidMessageBuffer<T>> for NsidHeader {
-    fn parse(buf: &NsidMessageBuffer<T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &NsidMessageBuffer<T>) -> Result<Self, Self::Error> {
         Ok(NsidHeader {
             family: buf.family().into(),
         })

--- a/src/nsid/message.rs
+++ b/src/nsid/message.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
 use netlink_packet_utils::{
     traits::{Emitable, Parseable},
     DecodeError,
@@ -15,23 +14,21 @@ pub struct NsidMessage {
     pub attributes: Vec<NsidAttribute>,
 }
 
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<NsidMessageBuffer<&'a T>>
-    for NsidMessage
-{
-    fn parse(buf: &NsidMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl<T: AsRef<[u8]>> Parseable<NsidMessageBuffer<&T>> for NsidMessage {
+    type Error = DecodeError;
+
+    fn parse(buf: &NsidMessageBuffer<&T>) -> Result<Self, Self::Error> {
         Ok(Self {
-            header: NsidHeader::parse(buf)
-                .context("failed to parse nsid message header")?,
-            attributes: Vec::<NsidAttribute>::parse(buf)
-                .context("failed to parse nsid message NLAs")?,
+            header: NsidHeader::parse(buf)?,
+            attributes: Vec::<NsidAttribute>::parse(buf)?,
         })
     }
 }
 
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<NsidMessageBuffer<&'a T>>
-    for Vec<NsidAttribute>
-{
-    fn parse(buf: &NsidMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl<T: AsRef<[u8]>> Parseable<NsidMessageBuffer<&T>> for Vec<NsidAttribute> {
+    type Error = DecodeError;
+
+    fn parse(buf: &NsidMessageBuffer<&T>) -> Result<Self, Self::Error> {
         let mut attributes = vec![];
         for nla_buf in buf.attributes() {
             attributes.push(NsidAttribute::parse(&nla_buf?)?);

--- a/src/prefix/cache_info.rs
+++ b/src/prefix/cache_info.rs
@@ -17,7 +17,9 @@ buffer!(CacheInfoBuffer(CACHE_INFO_LEN) {
 });
 
 impl<T: AsRef<[u8]>> Parseable<CacheInfoBuffer<T>> for CacheInfo {
-    fn parse(buf: &CacheInfoBuffer<T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &CacheInfoBuffer<T>) -> Result<Self, Self::Error> {
         Ok(CacheInfo {
             preferred_time: buf.preferred_time(),
             valid_time: buf.valid_time(),

--- a/src/prefix/header.rs
+++ b/src/prefix/header.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 use netlink_packet_utils::{
-    nla::{NlaBuffer, NlasIterator},
+    nla::{NlaBuffer, NlaError, NlasIterator},
     DecodeError, Emitable,
 };
 
@@ -22,7 +22,7 @@ buffer!(PrefixMessageBuffer(PREFIX_HEADER_LEN) {
 impl<'a, T: AsRef<[u8]> + ?Sized> PrefixMessageBuffer<&'a T> {
     pub fn nlas(
         &self,
-    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
+    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, NlaError>> {
         NlasIterator::new(self.payload())
     }
 }

--- a/src/route/cache_info.rs
+++ b/src/route/cache_info.rs
@@ -32,7 +32,9 @@ buffer!(RouteCacheInfoBuffer(CACHE_INFO_LEN) {
 });
 
 impl<T: AsRef<[u8]>> Parseable<RouteCacheInfoBuffer<T>> for RouteCacheInfo {
-    fn parse(buf: &RouteCacheInfoBuffer<T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &RouteCacheInfoBuffer<T>) -> Result<Self, Self::Error> {
         Ok(Self {
             clntref: buf.clntref(),
             last_use: buf.last_use(),

--- a/src/route/lwtunnel.rs
+++ b/src/route/lwtunnel.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
 use netlink_packet_utils::{
     nla::{DefaultNla, Nla, NlaBuffer, NlasIterator},
     traits::{Emitable, Parseable, ParseableParametrized},
@@ -136,15 +135,17 @@ impl Nla for RouteLwTunnelEncap {
     }
 }
 
-impl<'a, T> ParseableParametrized<NlaBuffer<&'a T>, RouteLwEnCapType>
+impl<T> ParseableParametrized<NlaBuffer<&T>, RouteLwEnCapType>
     for RouteLwTunnelEncap
 where
     T: AsRef<[u8]> + ?Sized,
 {
+    type Error = DecodeError;
+
     fn parse_with_param(
-        buf: &NlaBuffer<&'a T>,
+        buf: &NlaBuffer<&T>,
         kind: RouteLwEnCapType,
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, Self::Error> {
         Ok(match kind {
             RouteLwEnCapType::Mpls => {
                 Self::Mpls(RouteMplsIpTunnel::parse(buf)?)
@@ -158,22 +159,20 @@ where
 #[non_exhaustive]
 pub(crate) struct VecRouteLwTunnelEncap(pub(crate) Vec<RouteLwTunnelEncap>);
 
-impl<'a, T> ParseableParametrized<NlaBuffer<&'a T>, RouteLwEnCapType>
+impl<T> ParseableParametrized<NlaBuffer<&T>, RouteLwEnCapType>
     for VecRouteLwTunnelEncap
 where
     T: AsRef<[u8]> + ?Sized,
 {
+    type Error = DecodeError;
+
     fn parse_with_param(
-        buf: &NlaBuffer<&'a T>,
+        buf: &NlaBuffer<&T>,
         kind: RouteLwEnCapType,
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, Self::Error> {
         let mut ret = Vec::new();
         for nla in NlasIterator::new(buf.value()) {
-            let nla =
-                nla.context(format!("Invalid RTA_ENCAP for kind: {kind}"))?;
-            ret.push(RouteLwTunnelEncap::parse_with_param(&nla, kind).context(
-                format!("Failed to parse RTA_ENCAP for kind: {kind}",),
-            )?)
+            ret.push(RouteLwTunnelEncap::parse_with_param(&nla?, kind)?)
         }
         Ok(Self(ret))
     }

--- a/src/route/metrics.rs
+++ b/src/route/metrics.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
 use std::mem::size_of;
 
@@ -126,66 +125,32 @@ impl Nla for RouteMetric {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for RouteMetric {
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl<T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&T>> for RouteMetric {
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&T>) -> Result<Self, Self::Error> {
         let payload = buf.value();
         Ok(match buf.kind() {
-            RTAX_LOCK => Self::Lock(
-                parse_u32(payload).context("invalid RTAX_LOCK value")?,
-            ),
-            RTAX_MTU => {
-                Self::Mtu(parse_u32(payload).context("invalid RTAX_MTU value")?)
+            RTAX_LOCK => Self::Lock(parse_u32(payload)?),
+            RTAX_MTU => Self::Mtu(parse_u32(payload)?),
+            RTAX_WINDOW => Self::Window(parse_u32(payload)?),
+            RTAX_RTT => Self::Rtt(parse_u32(payload)?),
+            RTAX_RTTVAR => Self::RttVar(parse_u32(payload)?),
+            RTAX_SSTHRESH => Self::SsThresh(parse_u32(payload)?),
+            RTAX_CWND => Self::Cwnd(parse_u32(payload)?),
+            RTAX_ADVMSS => Self::Advmss(parse_u32(payload)?),
+            RTAX_REORDERING => Self::Reordering(parse_u32(payload)?),
+            RTAX_HOPLIMIT => Self::Hoplimit(parse_u32(payload)?),
+            RTAX_INITCWND => Self::InitCwnd(parse_u32(payload)?),
+            RTAX_FEATURES => Self::Features(parse_u32(payload)?),
+            RTAX_RTO_MIN => Self::RtoMin(parse_u32(payload)?),
+            RTAX_INITRWND => Self::InitRwnd(parse_u32(payload)?),
+            RTAX_QUICKACK => Self::QuickAck(parse_u32(payload)?),
+            RTAX_CC_ALGO => Self::CcAlgo(parse_u32(payload)?),
+            RTAX_FASTOPEN_NO_COOKIE => {
+                Self::FastopenNoCookie(parse_u32(payload)?)
             }
-            RTAX_WINDOW => Self::Window(
-                parse_u32(payload).context("invalid RTAX_WINDOW value")?,
-            ),
-            RTAX_RTT => {
-                Self::Rtt(parse_u32(payload).context("invalid RTAX_RTT value")?)
-            }
-            RTAX_RTTVAR => Self::RttVar(
-                parse_u32(payload).context("invalid RTAX_RTTVAR value")?,
-            ),
-            RTAX_SSTHRESH => Self::SsThresh(
-                parse_u32(payload).context("invalid RTAX_SSTHRESH value")?,
-            ),
-            RTAX_CWND => Self::Cwnd(
-                parse_u32(payload).context("invalid RTAX_CWND value")?,
-            ),
-            RTAX_ADVMSS => Self::Advmss(
-                parse_u32(payload).context("invalid RTAX_ADVMSS value")?,
-            ),
-            RTAX_REORDERING => Self::Reordering(
-                parse_u32(payload).context("invalid RTAX_REORDERING value")?,
-            ),
-            RTAX_HOPLIMIT => Self::Hoplimit(
-                parse_u32(payload).context("invalid RTAX_HOPLIMIT value")?,
-            ),
-            RTAX_INITCWND => Self::InitCwnd(
-                parse_u32(payload).context("invalid RTAX_INITCWND value")?,
-            ),
-            RTAX_FEATURES => Self::Features(
-                parse_u32(payload).context("invalid RTAX_FEATURES value")?,
-            ),
-            RTAX_RTO_MIN => Self::RtoMin(
-                parse_u32(payload).context("invalid RTAX_RTO_MIN value")?,
-            ),
-            RTAX_INITRWND => Self::InitRwnd(
-                parse_u32(payload).context("invalid RTAX_INITRWND value")?,
-            ),
-            RTAX_QUICKACK => Self::QuickAck(
-                parse_u32(payload).context("invalid RTAX_QUICKACK value")?,
-            ),
-            RTAX_CC_ALGO => Self::CcAlgo(
-                parse_u32(payload).context("invalid RTAX_CC_ALGO value")?,
-            ),
-            RTAX_FASTOPEN_NO_COOKIE => Self::FastopenNoCookie(
-                parse_u32(payload)
-                    .context("invalid RTAX_FASTOPEN_NO_COOKIE value")?,
-            ),
-            _ => Self::Other(
-                DefaultNla::parse(buf)
-                    .context("invalid NLA value (unknown type) value")?,
-            ),
+            _ => Self::Other(DefaultNla::parse(buf)?),
         })
     }
 }
@@ -193,11 +158,12 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for RouteMetric {
 pub(crate) struct VecRouteMetric(pub(crate) Vec<RouteMetric>);
 
 impl<T: AsRef<[u8]> + ?Sized> Parseable<T> for VecRouteMetric {
-    fn parse(payload: &T) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(payload: &T) -> Result<Self, Self::Error> {
         let mut nlas = vec![];
         for nla in NlasIterator::new(payload) {
-            let nla = nla.context("Invalid RTA_METRICS")?;
-            nlas.push(RouteMetric::parse(&nla).context("Invalid RTA_METRICS")?);
+            nlas.push(RouteMetric::parse(&nla?)?);
         }
         Ok(Self(nlas))
     }

--- a/src/route/mfc_stats.rs
+++ b/src/route/mfc_stats.rs
@@ -22,9 +22,11 @@ buffer!(RouteMfcStatsBuffer(MFC_STATS_LEN) {
 });
 
 impl<T: AsRef<[u8]>> Parseable<RouteMfcStatsBuffer<T>> for RouteMfcStats {
+    type Error = DecodeError;
+
     fn parse(
         buf: &RouteMfcStatsBuffer<T>,
-    ) -> Result<RouteMfcStats, DecodeError> {
+    ) -> Result<RouteMfcStats, Self::Error> {
         Ok(RouteMfcStats {
             packets: buf.packets(),
             bytes: buf.bytes(),

--- a/src/route/mpls.rs
+++ b/src/route/mpls.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
 use netlink_packet_utils::{
     nla::{DefaultNla, Nla, NlaBuffer},
     parsers::parse_u8,
@@ -47,27 +46,17 @@ impl Nla for RouteMplsIpTunnel {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
-    for RouteMplsIpTunnel
-{
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl<T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&T>> for RouteMplsIpTunnel {
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&T>) -> Result<Self, Self::Error> {
         let payload = buf.value();
         Ok(match buf.kind() {
-            MPLS_IPTUNNEL_DST => Self::Destination(
-                VecMplsLabel::parse(payload)
-                    .context(format!(
-                        "invalid MPLS_IPTUNNEL_DST value {:?}",
-                        payload
-                    ))?
-                    .0,
-            ),
-            MPLS_IPTUNNEL_TTL => Self::Ttl(
-                parse_u8(payload).context("invalid MPLS_IPTUNNEL_TTL value")?,
-            ),
-            _ => Self::Other(
-                DefaultNla::parse(buf)
-                    .context("invalid NLA value (unknown type) value")?,
-            ),
+            MPLS_IPTUNNEL_DST => {
+                Self::Destination(VecMplsLabel::parse(payload)?.0)
+            }
+            MPLS_IPTUNNEL_TTL => Self::Ttl(parse_u8(payload)?),
+            _ => Self::Other(DefaultNla::parse(buf)?),
         })
     }
 }

--- a/src/route/via.rs
+++ b/src/route/via.rs
@@ -33,10 +33,10 @@ buffer!(RouteViaBuffer(RTVIA_LEN) {
     address: (slice, RTVIA_LEN..),
 });
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<RouteViaBuffer<&'a T>>
-    for RouteVia
-{
-    fn parse(buf: &RouteViaBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl<T: AsRef<[u8]> + ?Sized> Parseable<RouteViaBuffer<&T>> for RouteVia {
+    type Error = DecodeError;
+
+    fn parse(buf: &RouteViaBuffer<&T>) -> Result<Self, Self::Error> {
         let address_family: AddressFamily = (buf.address_family() as u8).into();
         Ok(match address_family {
             AddressFamily::Inet => Self::Inet(parse_ipv4_addr(buf.address())?),

--- a/src/rule/header.rs
+++ b/src/rule/header.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 use netlink_packet_utils::{
-    nla::{NlaBuffer, NlasIterator},
+    nla::{NlaBuffer, NlaError, NlasIterator},
     traits::{Emitable, Parseable},
     DecodeError,
 };
@@ -26,7 +26,7 @@ buffer!(RuleMessageBuffer(RULE_HEADER_LEN) {
 impl<'a, T: AsRef<[u8]> + ?Sized> RuleMessageBuffer<&'a T> {
     pub fn attributes(
         &self,
-    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
+    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, NlaError>> {
         NlasIterator::new(self.payload())
     }
 }
@@ -60,10 +60,10 @@ impl Emitable for RuleHeader {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<RuleMessageBuffer<&'a T>>
-    for RuleHeader
-{
-    fn parse(buf: &RuleMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl<T: AsRef<[u8]> + ?Sized> Parseable<RuleMessageBuffer<&T>> for RuleHeader {
+    type Error = DecodeError;
+
+    fn parse(buf: &RuleMessageBuffer<&T>) -> Result<Self, Self::Error> {
         Ok(RuleHeader {
             family: buf.family().into(),
             dst_len: buf.dst_len(),

--- a/src/rule/message.rs
+++ b/src/rule/message.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
 use netlink_packet_utils::{
     traits::{Emitable, Parseable},
     DecodeError,
@@ -28,22 +27,20 @@ impl Emitable for RuleMessage {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<RuleMessageBuffer<&'a T>>
-    for RuleMessage
-{
-    fn parse(buf: &RuleMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
-        let header = RuleHeader::parse(buf)
-            .context("failed to parse link message header")?;
-        let attributes = Vec::<RuleAttribute>::parse(buf)
-            .context("failed to parse link message NLAs")?;
+impl<T: AsRef<[u8]>> Parseable<RuleMessageBuffer<&T>> for RuleMessage {
+    type Error = DecodeError;
+
+    fn parse(buf: &RuleMessageBuffer<&T>) -> Result<Self, Self::Error> {
+        let header = RuleHeader::parse(buf)?;
+        let attributes = Vec::<RuleAttribute>::parse(buf)?;
         Ok(RuleMessage { header, attributes })
     }
 }
 
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<RuleMessageBuffer<&'a T>>
-    for Vec<RuleAttribute>
-{
-    fn parse(buf: &RuleMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl<T: AsRef<[u8]>> Parseable<RuleMessageBuffer<&T>> for Vec<RuleAttribute> {
+    type Error = DecodeError;
+
+    fn parse(buf: &RuleMessageBuffer<&T>) -> Result<Self, Self::Error> {
         let mut attributes = vec![];
         for nla_buf in buf.attributes() {
             attributes.push(RuleAttribute::parse(&nla_buf?)?);

--- a/src/tc/actions/header.rs
+++ b/src/tc/actions/header.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_utils::nla::{NlaBuffer, NlasIterator};
+use netlink_packet_utils::nla::{NlaBuffer, NlaError, NlasIterator};
 use netlink_packet_utils::{DecodeError, Emitable, Parseable};
 
 use crate::AddressFamily;
@@ -18,7 +18,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> TcActionMessageBuffer<&'a T> {
     /// Returns an iterator over the attributes of a `TcActionMessageBuffer`.
     pub fn attributes(
         &self,
-    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
+    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, NlaError>> {
         NlasIterator::new(self.payload())
     }
 }
@@ -44,7 +44,9 @@ impl Emitable for TcActionMessageHeader {
 impl<T: AsRef<[u8]>> Parseable<TcActionMessageBuffer<T>>
     for TcActionMessageHeader
 {
-    fn parse(buf: &TcActionMessageBuffer<T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &TcActionMessageBuffer<T>) -> Result<Self, Self::Error> {
         Ok(TcActionMessageHeader {
             family: buf.family().into(),
         })

--- a/src/tc/actions/mirror.rs
+++ b/src/tc/actions/mirror.rs
@@ -65,10 +65,12 @@ impl Nla for TcActionMirrorOption {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
+impl<T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&T>>
     for TcActionMirrorOption
 {
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&T>) -> Result<Self, Self::Error> {
         let payload = buf.value();
         Ok(match buf.kind() {
             TCA_MIRRED_TM => {
@@ -117,7 +119,9 @@ impl Emitable for TcMirror {
 }
 
 impl<T: AsRef<[u8]> + ?Sized> Parseable<TcMirrorBuffer<&T>> for TcMirror {
-    fn parse(buf: &TcMirrorBuffer<&T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &TcMirrorBuffer<&T>) -> Result<Self, Self::Error> {
         Ok(Self {
             generic: TcActionGeneric::parse(&TcActionGenericBuffer::new(
                 buf.generic(),

--- a/src/tc/actions/nat.rs
+++ b/src/tc/actions/nat.rs
@@ -68,7 +68,9 @@ impl Nla for TcActionNatOption {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for TcActionNatOption
 {
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, Self::Error> {
         let payload = buf.value();
         Ok(match buf.kind() {
             TCA_NAT_TM => {
@@ -140,7 +142,9 @@ impl Emitable for TcNat {
 }
 
 impl<T: AsRef<[u8]> + ?Sized> Parseable<TcNatBuffer<&T>> for TcNat {
-    fn parse(buf: &TcNatBuffer<&T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &TcNatBuffer<&T>) -> Result<Self, Self::Error> {
         Ok(Self {
             generic: TcActionGeneric::parse(&TcActionGenericBuffer::new(
                 buf.generic(),

--- a/src/tc/attribute.rs
+++ b/src/tc/attribute.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
 use netlink_packet_utils::{
     nla::{DefaultNla, Nla, NlaBuffer, NlasIterator},
@@ -105,57 +104,41 @@ impl Nla for TcAttribute {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> ParseableParametrized<NlaBuffer<&'a T>, &str>
+impl<T: AsRef<[u8]> + ?Sized> ParseableParametrized<NlaBuffer<&T>, &str>
     for TcAttribute
 {
+    type Error = DecodeError;
+
     fn parse_with_param(
-        buf: &NlaBuffer<&'a T>,
+        buf: &NlaBuffer<&T>,
         kind: &str,
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, Self::Error> {
         let payload = buf.value();
         Ok(match buf.kind() {
-            TCA_KIND => TcAttribute::Kind(
-                parse_string(payload).context("invalid TCA_KIND")?,
-            ),
+            TCA_KIND => TcAttribute::Kind(parse_string(payload)?),
             TCA_OPTIONS => TcAttribute::Options(
-                VecTcOption::parse_with_param(buf, kind)
-                    .context(format!("Invalid TCA_OPTIONS for kind: {kind}"))?
-                    .0,
+                VecTcOption::parse_with_param(buf, kind)?.0,
             ),
-            TCA_STATS => TcAttribute::Stats(
-                TcStats::parse(
-                    &TcStatsBuffer::new_checked(payload)
-                        .context("invalid TCA_STATS")?,
-                )
-                .context("failed to parse TCA_STATS")?,
-            ),
-            TCA_XSTATS => TcAttribute::Xstats(
-                TcXstats::parse_with_param(buf, kind)
-                    .context("invalid TCA_XSTATS")?,
-            ),
+            TCA_STATS => TcAttribute::Stats(TcStats::parse(
+                &TcStatsBuffer::new_checked(payload)?,
+            )?),
+            TCA_XSTATS => {
+                TcAttribute::Xstats(TcXstats::parse_with_param(buf, kind)?)
+            }
             TCA_RATE => TcAttribute::Rate(payload.to_vec()),
             TCA_FCNT => TcAttribute::Fcnt(payload.to_vec()),
             TCA_STATS2 => {
                 let mut nlas = vec![];
                 for nla in NlasIterator::new(payload) {
-                    let nla = nla.context("invalid TCA_STATS2")?;
-                    nlas.push(TcStats2::parse_with_param(&nla, kind).context(
-                        format!("failed to parse TCA_STATS2 for kind {kind}"),
-                    )?);
+                    nlas.push(TcStats2::parse_with_param(&nla?, kind)?)
                 }
                 TcAttribute::Stats2(nlas)
             }
             TCA_STAB => TcAttribute::Stab(payload.to_vec()),
-            TCA_CHAIN => TcAttribute::Chain(
-                parse_u32(payload).context("failed to parse TCA_CHAIN")?,
-            ),
-            TCA_HW_OFFLOAD => TcAttribute::HwOffload(
-                parse_u8(payload).context("failed to parse TCA_HW_OFFLOAD")?,
-            ),
+            TCA_CHAIN => TcAttribute::Chain(parse_u32(payload)?),
+            TCA_HW_OFFLOAD => TcAttribute::HwOffload(parse_u8(payload)?),
             TCA_DUMP_INVISIBLE => TcAttribute::DumpInvisible(true),
-            _ => TcAttribute::Other(
-                DefaultNla::parse(buf).context("failed to parse tc nla")?,
-            ),
+            _ => TcAttribute::Other(DefaultNla::parse(buf)?),
         })
     }
 }

--- a/src/tc/header.rs
+++ b/src/tc/header.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 use netlink_packet_utils::{
-    nla::{NlaBuffer, NlasIterator},
+    nla::{NlaBuffer, NlaError, NlasIterator},
     traits::{Emitable, Parseable},
     DecodeError,
 };
@@ -24,7 +24,7 @@ buffer!(TcMessageBuffer(TC_HEADER_LEN) {
 impl<'a, T: AsRef<[u8]> + ?Sized> TcMessageBuffer<&'a T> {
     pub fn attributes(
         &self,
-    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
+    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, NlaError>> {
         NlasIterator::new(self.payload())
     }
 }
@@ -61,7 +61,9 @@ impl Emitable for TcHeader {
 }
 
 impl<T: AsRef<[u8]>> Parseable<TcMessageBuffer<T>> for TcHeader {
-    fn parse(buf: &TcMessageBuffer<T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &TcMessageBuffer<T>) -> Result<Self, Self::Error> {
         Ok(Self {
             family: buf.family().into(),
             index: buf.index(),

--- a/src/tc/message.rs
+++ b/src/tc/message.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
 use netlink_packet_utils::{
     traits::{Emitable, Parseable, ParseableParametrized},
     DecodeError,
@@ -36,21 +35,21 @@ impl TcMessage {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<TcMessageBuffer<&'a T>> for TcMessage {
-    fn parse(buf: &TcMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl<T: AsRef<[u8]>> Parseable<TcMessageBuffer<&T>> for TcMessage {
+    type Error = DecodeError;
+
+    fn parse(buf: &TcMessageBuffer<&T>) -> Result<Self, Self::Error> {
         Ok(Self {
-            header: TcHeader::parse(buf)
-                .context("failed to parse tc message header")?,
-            attributes: Vec::<TcAttribute>::parse(buf)
-                .context("failed to parse tc message NLAs")?,
+            header: TcHeader::parse(buf)?,
+            attributes: Vec::<TcAttribute>::parse(buf)?,
         })
     }
 }
 
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<TcMessageBuffer<&'a T>>
-    for Vec<TcAttribute>
-{
-    fn parse(buf: &TcMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl<T: AsRef<[u8]>> Parseable<TcMessageBuffer<&T>> for Vec<TcAttribute> {
+    type Error = DecodeError;
+
+    fn parse(buf: &TcMessageBuffer<&T>) -> Result<Self, Self::Error> {
         let mut attributes = vec![];
         let mut kind = String::new();
 

--- a/src/tc/qdiscs/fq_codel.rs
+++ b/src/tc/qdiscs/fq_codel.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
 use netlink_packet_utils::{
     nla::{DefaultNla, Nla, NlaBuffer},
@@ -32,7 +31,9 @@ pub enum TcFqCodelXstats {
 }
 
 impl<T: AsRef<[u8]> + ?Sized> Parseable<T> for TcFqCodelXstats {
-    fn parse(buf: &T) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &T) -> Result<Self, Self::Error> {
         if buf.as_ref().len() < 4 {
             return Err(DecodeError::from(format!(
                 "Invalid TcFqCodelXstats {:?}",
@@ -117,7 +118,9 @@ buffer!(TcFqCodelQdStatsBuffer(TC_FQ_CODEL_QD_STATS_LEN) {
 });
 
 impl<T: AsRef<[u8]>> Parseable<TcFqCodelQdStatsBuffer<T>> for TcFqCodelQdStats {
-    fn parse(buf: &TcFqCodelQdStatsBuffer<T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &TcFqCodelQdStatsBuffer<T>) -> Result<Self, Self::Error> {
         Ok(Self {
             maxpacket: buf.maxpacket(),
             drop_overlimit: buf.drop_overlimit(),
@@ -172,7 +175,9 @@ buffer!(TcFqCodelClStatsBuffer(TC_FQ_CODEL_CL_STATS_LEN) {
 });
 
 impl<T: AsRef<[u8]>> Parseable<TcFqCodelClStatsBuffer<T>> for TcFqCodelClStats {
-    fn parse(buf: &TcFqCodelClStatsBuffer<T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &TcFqCodelClStatsBuffer<T>) -> Result<Self, Self::Error> {
         Ok(Self {
             deficit: buf.deficit(),
             ldelay: buf.ldelay(),
@@ -285,58 +290,29 @@ impl Nla for TcQdiscFqCodelOption {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for TcQdiscFqCodelOption
 {
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, Self::Error> {
         let payload = buf.value();
         Ok(match buf.kind() {
-            TCA_FQ_CODEL_TARGET => Self::Target(
-                parse_u32(payload)
-                    .context("failed to parse TCA_FQ_CODEL_TARGET")?,
-            ),
-            TCA_FQ_CODEL_LIMIT => Self::Limit(
-                parse_u32(payload)
-                    .context("failed to parse TCA_FQ_CODEL_LIMIT")?,
-            ),
-            TCA_FQ_CODEL_INTERVAL => Self::Interval(
-                parse_u32(payload)
-                    .context("failed to parse TCA_FQ_CODEL_INTERVAL")?,
-            ),
-            TCA_FQ_CODEL_ECN => Self::Ecn(
-                parse_u32(payload)
-                    .context("failed to parse TCA_FQ_CODEL_ECN")?,
-            ),
-            TCA_FQ_CODEL_FLOWS => Self::Flows(
-                parse_u32(payload)
-                    .context("failed to parse TCA_FQ_CODEL_FLOWS")?,
-            ),
-            TCA_FQ_CODEL_QUANTUM => Self::Quantum(
-                parse_u32(payload)
-                    .context("failed to parse TCA_FQ_CODEL_QUANTUM")?,
-            ),
-            TCA_FQ_CODEL_CE_THRESHOLD => Self::CeThreshold(
-                parse_u32(payload)
-                    .context("failed to parse TCA_FQ_CODEL_CETHRESHOLD")?,
-            ),
-            TCA_FQ_CODEL_DROP_BATCH_SIZE => Self::DropBatchSize(
-                parse_u32(payload)
-                    .context("failed to parse TCA_FQ_CODEL_DROP_BATCH_SIZE")?,
-            ),
-            TCA_FQ_CODEL_MEMORY_LIMIT => Self::MemoryLimit(
-                parse_u32(payload)
-                    .context("failed to parse TCA_FQ_CODEL_MEMORY_LIMIT")?,
-            ),
+            TCA_FQ_CODEL_TARGET => Self::Target(parse_u32(payload)?),
+            TCA_FQ_CODEL_LIMIT => Self::Limit(parse_u32(payload)?),
+            TCA_FQ_CODEL_INTERVAL => Self::Interval(parse_u32(payload)?),
+            TCA_FQ_CODEL_ECN => Self::Ecn(parse_u32(payload)?),
+            TCA_FQ_CODEL_FLOWS => Self::Flows(parse_u32(payload)?),
+            TCA_FQ_CODEL_QUANTUM => Self::Quantum(parse_u32(payload)?),
+            TCA_FQ_CODEL_CE_THRESHOLD => Self::CeThreshold(parse_u32(payload)?),
+            TCA_FQ_CODEL_DROP_BATCH_SIZE => {
+                Self::DropBatchSize(parse_u32(payload)?)
+            }
+            TCA_FQ_CODEL_MEMORY_LIMIT => Self::MemoryLimit(parse_u32(payload)?),
             TCA_FQ_CODEL_CE_THRESHOLD_SELECTOR => {
-                Self::CeThresholdSelector(parse_u8(payload).context(
-                    "failed to parse TCA_FQ_CODEL_CE_THRESHOLD_SELECTOR",
-                )?)
+                Self::CeThresholdSelector(parse_u8(payload)?)
             }
             TCA_FQ_CODEL_CE_THRESHOLD_MASK => {
-                Self::CeThresholdMask(parse_u8(payload).context(
-                    "failed to parse TCA_FQ_CODEL_CE_THRESHOLD_MASK",
-                )?)
+                Self::CeThresholdMask(parse_u8(payload)?)
             }
-            _ => Self::Other(
-                DefaultNla::parse(buf).context("failed to parse u32 nla")?,
-            ),
+            _ => Self::Other(DefaultNla::parse(buf)?),
         })
     }
 }

--- a/src/tc/qdiscs/ingress.rs
+++ b/src/tc/qdiscs/ingress.rs
@@ -3,7 +3,6 @@
 // Currently, the qdisc ingress does not have any attribute, kernel
 // just start a empty nla_nest. This is just a place holder
 
-use anyhow::Context;
 use netlink_packet_utils::{
     nla::{DefaultNla, Nla, NlaBuffer},
     DecodeError, Parseable,
@@ -46,9 +45,9 @@ impl Nla for TcQdiscIngressOption {
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for TcQdiscIngressOption
 {
-    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
-        Ok(Self::Other(
-            DefaultNla::parse(buf).context("failed to parse ingress nla")?,
-        ))
+    type Error = DecodeError;
+
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, Self::Error> {
+        Ok(Self::Other(DefaultNla::parse(buf)?))
     }
 }

--- a/src/tc/stats/basic.rs
+++ b/src/tc/stats/basic.rs
@@ -24,7 +24,9 @@ buffer!(TcStatsBasicBuffer(STATS_BASIC_LEN) {
 });
 
 impl<T: AsRef<[u8]>> Parseable<TcStatsBasicBuffer<T>> for TcStatsBasic {
-    fn parse(buf: &TcStatsBasicBuffer<T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &TcStatsBasicBuffer<T>) -> Result<Self, Self::Error> {
         Ok(TcStatsBasic {
             bytes: buf.bytes(),
             packets: buf.packets(),

--- a/src/tc/stats/compat.rs
+++ b/src/tc/stats/compat.rs
@@ -41,7 +41,9 @@ buffer!(TcStatsBuffer(STATS_LEN) {
 });
 
 impl<T: AsRef<[u8]>> Parseable<TcStatsBuffer<T>> for TcStats {
-    fn parse(buf: &TcStatsBuffer<T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &TcStatsBuffer<T>) -> Result<Self, Self::Error> {
         Ok(Self {
             bytes: buf.bytes(),
             packets: buf.packets(),

--- a/src/tc/stats/queue.rs
+++ b/src/tc/stats/queue.rs
@@ -32,7 +32,9 @@ buffer!(TcStatsQueueBuffer( STATS_QUEUE_LEN) {
 });
 
 impl<T: AsRef<[u8]>> Parseable<TcStatsQueueBuffer<T>> for TcStatsQueue {
-    fn parse(buf: &TcStatsQueueBuffer<T>) -> Result<Self, DecodeError> {
+    type Error = DecodeError;
+
+    fn parse(buf: &TcStatsQueueBuffer<T>) -> Result<Self, Self::Error> {
         Ok(Self {
             qlen: buf.qlen(),
             backlog: buf.backlog(),

--- a/src/tc/stats/stats2.rs
+++ b/src/tc/stats/stats2.rs
@@ -61,12 +61,13 @@ impl Nla for TcStats2 {
     }
 }
 
-impl<'a, T> ParseableParametrized<NlaBuffer<&'a T>, &str> for TcStats2
+impl<T> ParseableParametrized<NlaBuffer<&T>, &str> for TcStats2
 where
     T: AsRef<[u8]> + ?Sized,
 {
+    type Error = DecodeError;
     fn parse_with_param(
-        buf: &NlaBuffer<&'a T>,
+        buf: &NlaBuffer<&T>,
         kind: &str,
     ) -> Result<Self, DecodeError> {
         let payload = buf.value();

--- a/src/tc/stats/xstats.rs
+++ b/src/tc/stats/xstats.rs
@@ -31,14 +31,16 @@ impl Emitable for TcXstats {
     }
 }
 
-impl<'a, T> ParseableParametrized<NlaBuffer<&'a T>, &str> for TcXstats
+impl<T> ParseableParametrized<NlaBuffer<&T>, &str> for TcXstats
 where
     T: AsRef<[u8]> + ?Sized,
 {
+    type Error = DecodeError;
+
     fn parse_with_param(
-        buf: &NlaBuffer<&'a T>,
+        buf: &NlaBuffer<&T>,
         kind: &str,
-    ) -> Result<TcXstats, DecodeError> {
+    ) -> Result<TcXstats, Self::Error> {
         Ok(match kind {
             TcQdiscFqCodel::KIND => {
                 TcXstats::FqCodel(TcFqCodelXstats::parse(buf.value())?)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4,7 +4,7 @@
 // detailed sub-component parsing. Each component has their own tests moduel.
 
 use netlink_packet_core::{NetlinkHeader, NetlinkMessage, NetlinkPayload};
-use netlink_packet_utils::Emitable;
+use netlink_packet_utils::traits::Emitable;
 
 use crate::{
     link::{LinkAttribute, LinkExtentMask, LinkMessage},


### PR DESCRIPTION
_“Bump netlink-packet-utils, get rid of anyhow, and adjust the code accordingly.”_

In practice, the PR is not ready yet; but I could do with some feedback.

What's missing:

- A newer version for `netlink-packet-core`
- It feels like we're losing a lot of context by discarding all error messages when doing the adjustments, so I'm not sure I've been using the right approach (at the same time, I really hope I don't need to redo all adjustments :sweat_smile:)
- There are some changes that I had to do on error types to make the code compile, but I don't think they're correct. I'm not sure what the right approach is, though.
- Two tests break; but that's probably something we want to address last.