### PR TITLE
fix: enable the latest rtnetlink on Android

### DIFF
--- a/src/address_family_linux.rs
+++ b/src/address_family_linux.rs
@@ -39,7 +39,9 @@ pub enum AddressFamily {
     Pppox,
     Wanpipe,
     Llc,
+    #[cfg(not(target_os = "android"))]
     Ib,
+    #[cfg(not(target_os = "android"))]
     Mpls,
     Can,
     Tipc,
@@ -93,7 +95,9 @@ impl From<u8> for AddressFamily {
             d if d == libc::AF_PPPOX as u8 => Self::Pppox,
             d if d == libc::AF_WANPIPE as u8 => Self::Wanpipe,
             d if d == libc::AF_LLC as u8 => Self::Llc,
+            #[cfg(not(target_os = "android"))]
             d if d == libc::AF_IB as u8 => Self::Ib,
+            #[cfg(not(target_os = "android"))]
             d if d == libc::AF_MPLS as u8 => Self::Mpls,
             d if d == libc::AF_CAN as u8 => Self::Can,
             d if d == libc::AF_TIPC as u8 => Self::Tipc,
@@ -149,7 +153,9 @@ impl From<AddressFamily> for u8 {
             AddressFamily::Pppox => libc::AF_PPPOX as u8,
             AddressFamily::Wanpipe => libc::AF_WANPIPE as u8,
             AddressFamily::Llc => libc::AF_LLC as u8,
+            #[cfg(not(target_os = "android"))]
             AddressFamily::Ib => libc::AF_IB as u8,
+            #[cfg(not(target_os = "android"))]
             AddressFamily::Mpls => libc::AF_MPLS as u8,
             AddressFamily::Can => libc::AF_CAN as u8,
             AddressFamily::Tipc => libc::AF_TIPC as u8,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,9 +38,13 @@ mod tests;
 
 pub(crate) mod ip;
 
-#[cfg(any(target_os = "linux", target_os = "fuchsia"))]
+#[cfg(any(target_os = "linux", target_os = "fuchsia", target_os = "android"))]
 mod address_family_linux;
-#[cfg(any(target_os = "linux", target_os = "fuchsia"))]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "fuchsia",
+    target_os = "android"
+))]
 pub use self::address_family_linux::AddressFamily;
 
 #[cfg(target_os = "freebsd")]
@@ -52,12 +56,14 @@ pub use self::address_family_freebsd::AddressFamily;
     target_os = "linux",
     target_os = "fuchsia",
     target_os = "freebsd",
+    target_os = "android",
 )))]
 mod address_family_fallback;
 #[cfg(not(any(
     target_os = "linux",
     target_os = "fuchsia",
     target_os = "freebsd",
+    target_os = "android",
 )))]
 pub use self::address_family_fallback::AddressFamily;
 

--- a/src/link/af_spec/bridge.rs
+++ b/src/link/af_spec/bridge.rs
@@ -102,10 +102,10 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for AfSpecBridge {
     }
 }
 
-#[cfg(any(target_os = "linux", target_os = "fuchsia"))]
+#[cfg(any(target_os = "linux", target_os = "fuchsia", target_os = "android"))]
 pub(crate) struct VecAfSpecBridge(pub(crate) Vec<AfSpecBridge>);
 
-#[cfg(any(target_os = "linux", target_os = "fuchsia"))]
+#[cfg(any(target_os = "linux", target_os = "fuchsia", target_os = "android"))]
 impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for VecAfSpecBridge
 {

--- a/src/link/af_spec/mod.rs
+++ b/src/link/af_spec/mod.rs
@@ -23,7 +23,11 @@ pub use self::inet6_iface_flag::Inet6IfaceFlags;
 pub use self::inet6_stats::{Inet6Stats, Inet6StatsBuffer};
 pub use self::unspec::AfSpecUnspec;
 
-#[cfg(any(target_os = "linux", target_os = "fuchsia"))]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "fuchsia",
+    target_os = "android"
+))]
 pub(crate) use self::bridge::VecAfSpecBridge;
 pub(crate) use self::inet::VecAfSpecInet;
 pub(crate) use self::inet6::VecAfSpecInet6;

--- a/src/link/attribute.rs
+++ b/src/link/attribute.rs
@@ -11,9 +11,17 @@ use netlink_packet_utils::{
     DecodeError,
 };
 
-#[cfg(any(target_os = "linux", target_os = "fuchsia",))]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "fuchsia",
+    target_os = "android"
+))]
 use super::af_spec::VecAfSpecBridge;
-#[cfg(any(target_os = "linux", target_os = "fuchsia",))]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "fuchsia",
+    target_os = "android"
+))]
 use super::proto_info::VecLinkProtoInfoBridge;
 use super::{
     af_spec::VecAfSpecUnspec,
@@ -441,7 +449,11 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
                         .context(err(payload))?
                         .0,
                     ),
-                    #[cfg(any(target_os = "linux", target_os = "fuchsia",))]
+                    #[cfg(any(
+                        target_os = "linux",
+                        target_os = "fuchsia",
+                        target_os = "android"
+                    ))]
                     AddressFamily::Bridge => Self::ProtoInfoBridge(
                         VecLinkProtoInfoBridge::parse(&NlaBuffer::new_checked(
                             payload,
@@ -650,7 +662,11 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
                         .0,
                     )
                 }
-                #[cfg(any(target_os = "linux", target_os = "fuchsia",))]
+                #[cfg(any(
+                    target_os = "linux",
+                    target_os = "fuchsia",
+                    target_os = "android"
+                ))]
                 AddressFamily::Bridge => {
                     let err = "invalid IFLA_AF_SPEC value for AF_BRIDGE";
                     Self::AfSpecBridge(


### PR DESCRIPTION
The latest version of the rtnetlink crate cannot compile on Android. The reason is that Android uses the AddressFamily defined in address_family_fallback.rs, while the correct one should be that in address_family_linux.rs. This leads to `AddressFamily::Bridge` used in rtnetlink being undefined on Android.

This patch fixes this by adding necessary `target_os="android"` configs. Since `libc::AF_IB` & `libc::AF_MPLS` are not defined on Android, we still confine branches related to those enums to only linux and fuchsia.