### PR TITLE
DO NOT MERGE: Demonstrate lacking test coverage

### DIFF
--- a/src/link/attribute.rs
+++ b/src/link/attribute.rs
@@ -158,6 +158,21 @@ pub enum LinkAttribute {
     GsoMaxSegs(u32),
     GsoMaxSize(u32),
     /// The minimum MTU for the device.
+    ///```
+    ///   # use netlink_packet_route::link::LinkAttribute;
+    ///   let _link_attribute: LinkAttribute = LinkAttribute::MinMtu(0);
+    ///   let _link_attribute: LinkAttribute = LinkAttribute::MinMtu(0xffff_ffff);
+    ///```
+    /// ```compile_fail
+    ///    # use netlink_packet_route::link::LinkAttribute;
+    ///    # fn test_min_mtu() {}
+    ///    let _link_attribute: LinkAttribute = LinkAttribute::MinMtu(-1);
+    /// ```
+    /// ```compile_fail
+    ///    # use netlink_packet_route::link::LinkAttribute;
+    ///    # fn test_min_mtu() {}
+    ///    let _link_attribute: LinkAttribute = LinkAttribute::MinMtu(0x1_0000_0000);
+    /// ```
     MinMtu(i32),
     /// The maximum MTU for the device.
     MaxMtu(u32),

--- a/src/link/attribute.rs
+++ b/src/link/attribute.rs
@@ -158,7 +158,7 @@ pub enum LinkAttribute {
     GsoMaxSegs(u32),
     GsoMaxSize(u32),
     /// The minimum MTU for the device.
-    MinMtu(u32),
+    MinMtu(i32),
     /// The maximum MTU for the device.
     MaxMtu(u32),
     LinkNetNsId(i32),
@@ -284,8 +284,11 @@ impl Nla for LinkAttribute {
             | Self::CarrierDownCount(value)
             | Self::GsoMaxSegs(value)
             | Self::GsoMaxSize(value)
-            | Self::MinMtu(value)
-            | Self::MaxMtu(value) => NativeEndian::write_u32(buffer, *value),
+            => NativeEndian::write_u32(buffer, *value),
+
+            Self::MinMtu(value) => NativeEndian::write_i32(buffer, *value),
+
+            Self::MaxMtu(value) => NativeEndian::write_u32(buffer, *value),
 
             Self::ExtMask(value) => NativeEndian::write_u32(
                 buffer,
@@ -598,7 +601,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
                     .context("invalid IFLA_GSO_MAX_SIZE value")?,
             ),
             IFLA_MIN_MTU => Self::MinMtu(
-                parse_u32(payload).context("invalid IFLA_MIN_MTU value")?,
+                parse_i32(payload).context("invalid IFLA_MIN_MTU value")?,
             ),
             IFLA_MAX_MTU => Self::MaxMtu(
                 parse_u32(payload).context("invalid IFLA_MAX_MTU value")?,


### PR DESCRIPTION
To demonstrate that the current test strategy is lacking test coverage,
break the MinMtu data type without breaking the existing test cases.

The second commit introduces Boundary Value Analysis based test cases using doc tests in lack of a better alternative. This is not a proposal for doing the tests exactly as this as I don't have the experience with Rust in how to organize tests best and it might also not be the best tool to use this. This is merely a demonstration about how tests catch problem.

As a note, a boundary value analysis for FailOverMac with [-1, 3] as the bad cases and [0, 2] might have led to using an Enum from the beginning instead of u8, avoiding the later cleanup in https://github.com/rust-netlink/netlink-packet-route/commit/327086345c837a999ecf3c8c53d1a6b33db34df1
