### PR TITLE
New release 0.23.0

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,4 +1,5 @@
 max_width = 80
 wrap_comments = true
 reorder_imports = true
+format_strings = true
 edition = "2021"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,17 @@
 # Changelog
+## [0.23.0] - 2025-04-30
+### Breaking changes
+ - `InfoBond::ArpAllTargets` changed to enum. (507ea73)
+ - `InfoBond::XmitHashPolicy` changed to enum. (b2572da)
+ - `InfoBond::FailOverMac` changed to enum. (3270863)
+
+### New features
+ - tc: Add support of tunnel key. (f5535f3)
+
+### Bug fixes
+ - Fix compile on Andriod. (d44d500)
+ - Fix panic of integer underflow in `RouteNextHopBuffer`. (a285aba)
+
 ## [0.22.0] - 2025-03-17
 ### Breaking changes
  - Changed `tc::TcActionMirrorOption::Tm` from `Vec<u8>` to `Tcf`. (f3953b8)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-packet-route"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2021"
 
 homepage = "https://github.com/rust-netlink/netlink-packet-route"

--- a/examples/dump_neighbour_tables.rs
+++ b/examples/dump_neighbour_tables.rs
@@ -50,7 +50,7 @@ fn main() {
                 NetlinkPayload::InnerMessage(
                     RouteNetlinkMessage::NewNeighbourTable(entry),
                 ) => {
-                    println!("HAHA {:?}", entry);
+                    println!("HAHA {entry:?}");
                 }
                 NetlinkPayload::Error(err) => {
                     eprintln!("Received a netlink error message: {err:?}");

--- a/src/address/attribute.rs
+++ b/src/address/attribute.rs
@@ -124,9 +124,8 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                     Self::Address(IpAddr::from(data))
                 } else {
                     return Err(DecodeError::from(format!(
-                        "Invalid IFA_LOCAL, got unexpected length \
-                            of payload {:?}",
-                        payload
+                        "Invalid IFA_LOCAL, got unexpected length of payload \
+                         {payload:?}"
                     )));
                 }
             }
@@ -141,9 +140,8 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                     Self::Local(IpAddr::from(data))
                 } else {
                     return Err(DecodeError::from(format!(
-                        "Invalid IFA_LOCAL, got unexpected length \
-                        of payload {:?}",
-                        payload
+                        "Invalid IFA_LOCAL, got unexpected length of payload \
+                         {payload:?}"
                     )));
                 }
             }
@@ -157,9 +155,8 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                     Self::Broadcast(Ipv4Addr::from(data))
                 } else {
                     return Err(DecodeError::from(format!(
-                        "Invalid IFA_BROADCAST, got unexpected length \
-                        of IPv4 address payload {:?}",
-                        payload
+                        "Invalid IFA_BROADCAST, got unexpected length of IPv4 \
+                         address payload {payload:?}"
                     )));
                 }
             }
@@ -170,15 +167,14 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                     Self::Anycast(Ipv6Addr::from(data))
                 } else {
                     return Err(DecodeError::from(format!(
-                        "Invalid IFA_ANYCAST, got unexpected length \
-                        of IPv6 address payload {:?}",
-                        payload
+                        "Invalid IFA_ANYCAST, got unexpected length of IPv6 \
+                         address payload {payload:?}"
                     )));
                 }
             }
             IFA_CACHEINFO => Self::CacheInfo(
                 CacheInfo::parse(&CacheInfoBuffer::new(payload))
-                    .context(format!("Invalid IFA_CACHEINFO {:?}", payload))?,
+                    .context(format!("Invalid IFA_CACHEINFO {payload:?}"))?,
             ),
             IFA_MULTICAST => {
                 if payload.len() == IPV6_ADDR_LEN {
@@ -187,9 +183,8 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                     Self::Multicast(Ipv6Addr::from(data))
                 } else {
                     return Err(DecodeError::from(format!(
-                        "Invalid IFA_MULTICAST, got unexpected length \
-                        of IPv6 address payload {:?}",
-                        payload
+                        "Invalid IFA_MULTICAST, got unexpected length of IPv6 \
+                         address payload {payload:?}"
                     )));
                 }
             }

--- a/src/ip.rs
+++ b/src/ip.rs
@@ -12,8 +12,8 @@ pub(crate) fn parse_ipv4_addr(raw: &[u8]) -> Result<Ipv4Addr, DecodeError> {
         Ok(Ipv4Addr::new(raw[0], raw[1], raw[2], raw[3]))
     } else {
         Err(DecodeError::from(format!(
-            "Invalid u8 array length {}, expecting \
-            {IPV4_ADDR_LEN} for IPv4 address, got {:?}",
+            "Invalid u8 array length {}, expecting {IPV4_ADDR_LEN} for IPv4 \
+             address, got {:?}",
             raw.len(),
             raw,
         )))
@@ -27,8 +27,8 @@ pub(crate) fn parse_ipv6_addr(raw: &[u8]) -> Result<Ipv6Addr, DecodeError> {
         Ok(Ipv6Addr::from(data))
     } else {
         Err(DecodeError::from(format!(
-            "Invalid u8 array length {}, expecting {IPV6_ADDR_LEN} \
-            for IPv6 address, got {:?}",
+            "Invalid u8 array length {}, expecting {IPV6_ADDR_LEN} for IPv6 \
+             address, got {:?}",
             raw.len(),
             raw,
         )))
@@ -49,8 +49,8 @@ pub(crate) fn parse_ip_addr(raw: &[u8]) -> Result<IpAddr, DecodeError> {
         parse_ipv4_addr(raw).map(IpAddr::from)
     } else {
         Err(DecodeError::from(format!(
-            "Invalid u8 array length {}, expecting {IPV6_ADDR_LEN} \
-            for IPv6 address or {IPV4_ADDR_LEN} for IPv4 address, got {:?}",
+            "Invalid u8 array length {}, expecting {IPV6_ADDR_LEN} for IPv6 \
+             address or {IPV4_ADDR_LEN} for IPv4 address, got {:?}",
             raw.len(),
             raw,
         )))

--- a/src/link/af_spec/bridge.rs
+++ b/src/link/af_spec/bridge.rs
@@ -189,8 +189,8 @@ impl TryFrom<&[u8]> for BridgeVlanInfo {
             })
         } else {
             Err(DecodeError::from(format!(
-                "Invalid IFLA_BRIDGE_VLAN_INFO value, expecting [u8;4], \
-                but got {raw:?}"
+                "Invalid IFLA_BRIDGE_VLAN_INFO value, expecting [u8;4], but \
+                 got {raw:?}"
             )))
         }
     }

--- a/src/link/af_spec/inet6.rs
+++ b/src/link/af_spec/inet6.rs
@@ -122,8 +122,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for AfSpecInet6 {
             IFLA_INET6_CACHEINFO => CacheInfo(
                 Inet6CacheInfo::parse(&Inet6CacheInfoBuffer::new(payload))
                     .context(format!(
-                        "invalid IFLA_INET6_CACHEINFO value {:?}",
-                        payload
+                        "invalid IFLA_INET6_CACHEINFO value {payload:?}"
                     ))?,
             ),
             IFLA_INET6_CONF => DevConf(
@@ -136,8 +135,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for AfSpecInet6 {
                     .as_slice(),
                 ))
                 .context(format!(
-                    "invalid IFLA_INET6_CONF value {:?}",
-                    payload
+                    "invalid IFLA_INET6_CONF value {payload:?}"
                 ))?,
             ),
             IFLA_INET6_STATS => Stats(
@@ -150,8 +148,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for AfSpecInet6 {
                     .as_slice(),
                 ))
                 .context(format!(
-                    "invalid IFLA_INET6_STATS value {:?}",
-                    payload
+                    "invalid IFLA_INET6_STATS value {payload:?}"
                 ))?,
             ),
             IFLA_INET6_ICMP6STATS => Icmp6Stats(
@@ -164,8 +161,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for AfSpecInet6 {
                     .as_slice(),
                 ))
                 .context(format!(
-                    "invalid IFLA_INET6_ICMP6STATS value {:?}",
-                    payload
+                    "invalid IFLA_INET6_ICMP6STATS value {payload:?}"
                 ))?,
             ),
             IFLA_INET6_TOKEN => Token(

--- a/src/link/af_spec/unspec.rs
+++ b/src/link/af_spec/unspec.rs
@@ -76,7 +76,8 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                 }
                 kind => AfSpecUnspec::Other(DefaultNla::parse(&nla).context(
                     format!(
-                        "Unknown AF_XXX type {kind} for IFLA_AF_SPEC(AF_UNSPEC)"
+                        "Unknown AF_XXX type {kind} for \
+                         IFLA_AF_SPEC(AF_UNSPEC)"
                     ),
                 )?),
             })

--- a/src/link/attribute.rs
+++ b/src/link/attribute.rs
@@ -465,8 +465,8 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
                     ),
                     _ => Self::ProtoInfoUnknown(
                         DefaultNla::parse(buf).context(format!(
-                            "invalid IFLA_PROTINFO for \
-                        {interface_family:?}: {payload:?}"
+                            "invalid IFLA_PROTINFO for {interface_family:?}: \
+                             {payload:?}"
                         ))?,
                     ),
                 }
@@ -614,7 +614,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
             ),
             IFLA_MAP => {
                 let err =
-                    |payload| format!("Invalid IFLA_MAP value {:?}", payload);
+                    |payload| format!("Invalid IFLA_MAP value {payload:?}");
                 Self::Map(
                     super::Map::parse(
                         &MapBuffer::new_checked(payload)
@@ -632,7 +632,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
                     )
                     .as_slice(),
                 ))
-                .context(format!("Invalid IFLA_STATS value {:?}", payload))?,
+                .context(format!("Invalid IFLA_STATS value {payload:?}"))?,
             ),
             IFLA_STATS64 => {
                 let payload = expand_buffer_if_small(
@@ -645,8 +645,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
                         payload.as_slice(),
                     ))
                     .context(format!(
-                        "Invalid IFLA_STATS64 value {:?}",
-                        payload
+                        "Invalid IFLA_STATS64 value {payload:?}"
                     ))?,
                 )
             }

--- a/src/link/buffer_tool.rs
+++ b/src/link/buffer_tool.rs
@@ -9,10 +9,9 @@ pub(crate) fn expand_buffer_if_small(
     match payload.len() {
         l if l > expected_size => {
             log::warn!(
-                "Specified {nla_name} NLA attribute holds \
-            more(most likely new kernel) data which is unknown to \
-            netlink-packet-route crate, expecting \
-            {expected_size}, got {}",
+                "Specified {nla_name} NLA attribute holds more(most likely \
+                 new kernel) data which is unknown to netlink-packet-route \
+                 crate, expecting {expected_size}, got {}",
                 got.len()
             );
         }

--- a/src/link/down_reason.rs
+++ b/src/link/down_reason.rs
@@ -37,7 +37,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
             }
             kind => Self::Other(DefaultNla::parse(buf).context(format!(
                 "unknown NLA type {kind} for IFLA_PROTO_DOWN_REASON: \
-                {payload:?}"
+                 {payload:?}"
             ))?),
         })
     }

--- a/src/link/link_info/bridge.rs
+++ b/src/link/link_info/bridge.rs
@@ -624,8 +624,8 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                 Ok(IpAddr::V4(addr)) => Ipv4Address(addr),
                 Ok(v) => {
                     return Err(DecodeError::from(format!(
-                        "Invalid BRIDGE_QUERIER_IP_ADDRESS, \
-                        expecting IPv4 address, but got {v}"
+                        "Invalid BRIDGE_QUERIER_IP_ADDRESS, expecting IPv4 \
+                         address, but got {v}"
                     )))
                 }
                 Err(e) => {
@@ -638,8 +638,8 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                 Ok(IpAddr::V6(addr)) => Ipv6Address(addr),
                 Ok(v) => {
                     return Err(DecodeError::from(format!(
-                        "Invalid BRIDGE_QUERIER_IPV6_ADDRESS, \
-                        expecting IPv6 address, but got {v}"
+                        "Invalid BRIDGE_QUERIER_IPV6_ADDRESS, expecting IPv6 \
+                         address, but got {v}"
                     )));
                 }
                 Err(e) => {

--- a/src/link/link_info/bridge_port.rs
+++ b/src/link/link_info/bridge_port.rs
@@ -312,9 +312,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
             ),
             IFLA_BRPORT_FAST_LEAVE => InfoBridgePort::FastLeave(
                 parse_u8(payload).with_context(|| {
-                    format!(
-                        "invalid IFLA_BRPORT_FAST_LEAVE {payload:?}"
-                    )
+                    format!("invalid IFLA_BRPORT_FAST_LEAVE {payload:?}")
                 })? > 0,
             ),
             IFLA_BRPORT_LEARNING => InfoBridgePort::Learning(
@@ -338,14 +336,14 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                 })? > 0,
             ),
             IFLA_BRPORT_ROOT_ID => Self::RootId(
-                BridgeId::parse(&BridgeIdBuffer::new(payload)).with_context(|| {
-                    format!("invalid IFLA_BRPORT_ROOT_ID {payload:?}")
-                })?,
+                BridgeId::parse(&BridgeIdBuffer::new(payload)).with_context(
+                    || format!("invalid IFLA_BRPORT_ROOT_ID {payload:?}"),
+                )?,
             ),
             IFLA_BRPORT_BRIDGE_ID => Self::BridgeId(
-                BridgeId::parse(&BridgeIdBuffer::new(payload)).with_context(|| {
-                    format!("invalid IFLA_BRPORT_BRIDGE_ID {payload:?}")
-                })?,
+                BridgeId::parse(&BridgeIdBuffer::new(payload)).with_context(
+                    || format!("invalid IFLA_BRPORT_BRIDGE_ID {payload:?}"),
+                )?,
             ),
             IFLA_BRPORT_DESIGNATED_PORT => InfoBridgePort::DesignatedPort(
                 parse_u16(payload).with_context(|| {
@@ -358,20 +356,21 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                 })?,
             ),
             IFLA_BRPORT_ID => {
-                InfoBridgePort::PortId(parse_u16(payload).with_context(|| {
-                    format!("invalid IFLA_BRPORT_ID {payload:?}")
-                })?)
+                InfoBridgePort::PortId(parse_u16(payload).with_context(
+                    || format!("invalid IFLA_BRPORT_ID {payload:?}"),
+                )?)
             }
             IFLA_BRPORT_NO => {
-                InfoBridgePort::PortNumber(parse_u16(payload).with_context(|| {
-                    format!("invalid IFLA_BRPORT_NO {payload:?}")
-                })?)
+                InfoBridgePort::PortNumber(parse_u16(payload).with_context(
+                    || format!("invalid IFLA_BRPORT_NO {payload:?}"),
+                )?)
             }
             IFLA_BRPORT_TOPOLOGY_CHANGE_ACK => {
                 InfoBridgePort::TopologyChangeAck(
                     parse_u8(payload).with_context(|| {
                         format!(
-                            "invalid IFLA_BRPORT_TOPOLOGY_CHANGE_ACK {payload:?}"
+                            "invalid IFLA_BRPORT_TOPOLOGY_CHANGE_ACK \
+                             {payload:?}"
                         )
                     })? > 0,
                 )
@@ -390,7 +389,8 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                 InfoBridgePort::ForwardDelayTimer(
                     parse_u64(payload).with_context(|| {
                         format!(
-                            "invalid IFLA_BRPORT_FORWARD_DELAY_TIMER {payload:?}"
+                            "invalid IFLA_BRPORT_FORWARD_DELAY_TIMER \
+                             {payload:?}"
                         )
                     })?,
                 )
@@ -464,7 +464,8 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                 InfoBridgePort::MulticastEhtHostsLimit(
                     parse_u32(payload).with_context(|| {
                         format!(
-                            "invalid IFLA_BRPORT_MCAST_EHT_HOSTS_LIMIT {payload:?}"
+                            "invalid IFLA_BRPORT_MCAST_EHT_HOSTS_LIMIT \
+                             {payload:?}"
                         )
                     })?,
                 )
@@ -473,9 +474,10 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                 InfoBridgePort::MulticastEhtHostsCnt(
                     parse_u32(payload).with_context(|| {
                         format!(
-                            "invalid IFLA_BRPORT_MCAST_EHT_HOSTS_CNT {payload:?}"
+                            "invalid IFLA_BRPORT_MCAST_EHT_HOSTS_CNT \
+                             {payload:?}"
                         )
-                    })?
+                    })?,
                 )
             }
             IFLA_BRPORT_LOCKED => InfoBridgePort::Locked(
@@ -498,13 +500,16 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                     format!("invalid IFLA_BRPORT_MCAST_MAX_GROUPS {payload:?}")
                 })?,
             ),
-            IFLA_BRPORT_NEIGH_VLAN_SUPPRESS => InfoBridgePort::NeighVlanSupress(
-                parse_u8(payload).with_context(|| {
-                    format!(
-                        "invalid IFLA_BRPORT_NEIGH_VLAN_SUPPRESS {payload:?}"
-                    )
-                })? > 0,
-            ),
+            IFLA_BRPORT_NEIGH_VLAN_SUPPRESS => {
+                InfoBridgePort::NeighVlanSupress(
+                    parse_u8(payload).with_context(|| {
+                        format!(
+                            "invalid IFLA_BRPORT_NEIGH_VLAN_SUPPRESS \
+                             {payload:?}"
+                        )
+                    })? > 0,
+                )
+            }
             IFLA_BRPORT_BACKUP_NHID => InfoBridgePort::BackupNextHopId(
                 parse_u32(payload).with_context(|| {
                     format!("invalid IFLA_BRPORT_BACKUP_NHID {payload:?}")
@@ -513,7 +518,8 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
             kind => InfoBridgePort::Other(
                 DefaultNla::parse(buf).with_context(|| {
                     format!(
-                        "failed to parse bridge port NLA of type '{kind}' into DefaultNla"
+                        "failed to parse bridge port NLA of type '{kind}' \
+                         into DefaultNla"
                     )
                 })?,
             ),

--- a/src/link/link_info/geneve.rs
+++ b/src/link/link_info/geneve.rs
@@ -152,9 +152,8 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoGeneve {
                     Remote(Ipv4Addr::from(data))
                 } else {
                     return Err(DecodeError::from(format!(
-                        "Invalid IFLA_GENEVE_REMOTE, got unexpected length \
-                        of IPv4 address payload {:?}",
-                        payload
+                        "Invalid IFLA_GENEVE_REMOTE, got unexpected length of \
+                         IPv4 address payload {payload:?}"
                     )));
                 }
             }
@@ -166,8 +165,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoGeneve {
                 } else {
                     return Err(DecodeError::from(format!(
                         "Invalid IFLA_GENEVE_REMOTE6, got unexpected length \
-                        of IPv6 address payload {:?}",
-                        payload
+                         of IPv6 address payload {payload:?}"
                     )));
                 }
             }

--- a/src/link/link_info/hsr.rs
+++ b/src/link/link_info/hsr.rs
@@ -148,7 +148,7 @@ impl std::fmt::Display for HsrProtocol {
         match self {
             Self::Hsr => write!(f, "hsr"),
             Self::Prp => write!(f, "prp"),
-            Self::Other(d) => write!(f, "{}", d),
+            Self::Other(d) => write!(f, "{d}"),
         }
     }
 }

--- a/src/link/link_info/info_port.rs
+++ b/src/link/link_info/info_port.rs
@@ -147,7 +147,8 @@ impl InfoPortData {
         };
 
         Ok(port_data.context(format!(
-            "failed to parse IFLA_INFO_PORT_DATA (IFLA_INFO_PORT_KIND is '{kind}')"
+            "failed to parse IFLA_INFO_PORT_DATA (IFLA_INFO_PORT_KIND is \
+             '{kind}')"
         ))?)
     }
 }

--- a/src/link/link_info/infos.rs
+++ b/src/link/link_info/infos.rs
@@ -117,8 +117,8 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for VecLinkInfo {
                             LinkXstats::parse_with_param(&nla, link_info_kind)?,
                         ));
                     } else {
-                        return Err("IFLA_INFO_XSTATS is not \
-                            preceded by an IFLA_INFO_KIND"
+                        return Err("IFLA_INFO_XSTATS is not preceded by an \
+                                    IFLA_INFO_KIND"
                             .into());
                     }
                 }
@@ -137,7 +137,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for VecLinkInfo {
                         ));
                     } else {
                         return Err("IFLA_INFO_PORT_DATA is not preceded by \
-                            an IFLA_INFO_PORT_KIND"
+                                    an IFLA_INFO_PORT_KIND"
                             .into());
                     }
                     link_info_port_kind = None;
@@ -155,14 +155,13 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for VecLinkInfo {
                         )?));
                     } else {
                         return Err("IFLA_INFO_DATA is not preceded by an \
-                            IFLA_INFO_KIND"
+                                    IFLA_INFO_KIND"
                             .into());
                     }
                 }
                 _kind => nlas.push(LinkInfo::Other(
                     DefaultNla::parse(&nla).context(format!(
-                        "Unknown NLA type for IFLA_INFO_DATA {:?}",
-                        nla
+                        "Unknown NLA type for IFLA_INFO_DATA {nla:?}"
                     ))?,
                 )),
             }

--- a/src/link/link_info/ipvlan.rs
+++ b/src/link/link_info/ipvlan.rs
@@ -148,7 +148,7 @@ impl From<u16> for IpVlanMode {
             IPVLAN_MODE_L3 => Self::L3,
             IPVLAN_MODE_L3S => Self::L3S,
             _ => {
-                log::warn!("Unknown IP VLAN mode {}", d);
+                log::warn!("Unknown IP VLAN mode {d}");
                 Self::Other(d)
             }
         }

--- a/src/link/link_info/mac_vlan.rs
+++ b/src/link/link_info/mac_vlan.rs
@@ -292,7 +292,7 @@ impl From<u32> for MacVlanMode {
             MACVLAN_MODE_PASSTHRU => Self::Passthrough,
             MACVLAN_MODE_SOURCE => Self::Source,
             _ => {
-                log::warn!("Unknown MAC VLAN mode {}", d);
+                log::warn!("Unknown MAC VLAN mode {d}");
                 Self::Other(d)
             }
         }

--- a/src/link/link_info/vxlan.rs
+++ b/src/link/link_info/vxlan.rs
@@ -199,9 +199,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoVxlan {
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();
         Ok(match buf.kind() {
-            IFLA_VXLAN_ID => {
-                Self::Id(parse_u32(payload).context("invalid IFLA_VXLAN_ID value")?)
-            }
+            IFLA_VXLAN_ID => Self::Id(
+                parse_u32(payload).context("invalid IFLA_VXLAN_ID value")?,
+            ),
             IFLA_VXLAN_GROUP => {
                 if payload.len() == 4 {
                     let mut data = [0u8; 4];
@@ -209,9 +209,8 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoVxlan {
                     Self::Group(Ipv4Addr::from(data))
                 } else {
                     return Err(DecodeError::from(format!(
-                        "Invalid IFLA_VXLAN_GROUP, got unexpected length \
-                        of IPv4 address payload {:?}",
-                        payload
+                        "Invalid IFLA_VXLAN_GROUP, got unexpected length of \
+                         IPv4 address payload {payload:?}"
                     )));
                 }
             }
@@ -222,9 +221,8 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoVxlan {
                     Self::Local(Ipv4Addr::from(data))
                 } else {
                     return Err(DecodeError::from(format!(
-                        "Invalid IFLA_VXLAN_LOCAL, got unexpected length \
-                        of IPv4 address payload {:?}",
-                        payload
+                        "Invalid IFLA_VXLAN_LOCAL, got unexpected length of \
+                         IPv4 address payload {payload:?}"
                     )));
                 }
             }
@@ -235,12 +233,11 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoVxlan {
                     Self::Group6(Ipv6Addr::from(data))
                 } else {
                     return Err(DecodeError::from(format!(
-                        "Invalid IFLA_VXLAN_GROUP6, got unexpected length \
-                        of IPv6 address payload {:?}",
-                        payload
+                        "Invalid IFLA_VXLAN_GROUP6, got unexpected length of \
+                         IPv6 address payload {payload:?}"
                     )));
                 }
-            },
+            }
             IFLA_VXLAN_LOCAL6 => {
                 if payload.len() == 16 {
                     let mut data = [0u8; 16];
@@ -248,29 +245,27 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoVxlan {
                     Self::Local6(Ipv6Addr::from(data))
                 } else {
                     return Err(DecodeError::from(format!(
-                        "Invalid IFLA_VXLAN_LOCAL6, got unexpected length \
-                        of IPv6 address payload {:?}",
-                        payload
+                        "Invalid IFLA_VXLAN_LOCAL6, got unexpected length of \
+                         IPv6 address payload {payload:?}"
                     )));
                 }
-            },
+            }
             IFLA_VXLAN_LINK => Self::Link(
                 parse_u32(payload).context("invalid IFLA_VXLAN_LINK value")?,
             ),
-            IFLA_VXLAN_TOS => {
-                Self::Tos(parse_u8(payload)
-                    .context("invalid IFLA_VXLAN_TOS value")?)
-            }
-            IFLA_VXLAN_TTL => {
-                Self::Ttl(parse_u8(payload)
-                    .context("invalid IFLA_VXLAN_TTL value")?)
-            }
+            IFLA_VXLAN_TOS => Self::Tos(
+                parse_u8(payload).context("invalid IFLA_VXLAN_TOS value")?,
+            ),
+            IFLA_VXLAN_TTL => Self::Ttl(
+                parse_u8(payload).context("invalid IFLA_VXLAN_TTL value")?,
+            ),
             IFLA_VXLAN_LABEL => Self::Label(
                 parse_u32(payload).context("invalid IFLA_VXLAN_LABEL value")?,
             ),
             IFLA_VXLAN_LEARNING => Self::Learning(
                 parse_u8(payload)
-                    .context("invalid IFLA_VXLAN_LEARNING value")? > 0,
+                    .context("invalid IFLA_VXLAN_LEARNING value")?
+                    > 0,
             ),
             IFLA_VXLAN_AGEING => Self::Ageing(
                 parse_u32(payload)
@@ -280,21 +275,24 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoVxlan {
                 parse_u32(payload).context("invalid IFLA_VXLAN_LIMIT value")?,
             ),
             IFLA_VXLAN_PROXY => Self::Proxy(
-                parse_u8(payload).context("invalid IFLA_VXLAN_PROXY value")? > 0,
+                parse_u8(payload).context("invalid IFLA_VXLAN_PROXY value")?
+                    > 0,
             ),
-            IFLA_VXLAN_RSC => {
-                Self::Rsc(parse_u8(payload)
-                    .context("invalid IFLA_VXLAN_RSC value")?> 0)
-            }
+            IFLA_VXLAN_RSC => Self::Rsc(
+                parse_u8(payload).context("invalid IFLA_VXLAN_RSC value")? > 0,
+            ),
             IFLA_VXLAN_L2MISS => Self::L2Miss(
-                parse_u8(payload).context("invalid IFLA_VXLAN_L2MISS value")? > 0,
+                parse_u8(payload).context("invalid IFLA_VXLAN_L2MISS value")?
+                    > 0,
             ),
             IFLA_VXLAN_L3MISS => Self::L3Miss(
-                parse_u8(payload).context("invalid IFLA_VXLAN_L3MISS value")? > 0,
+                parse_u8(payload).context("invalid IFLA_VXLAN_L3MISS value")?
+                    > 0,
             ),
             IFLA_VXLAN_COLLECT_METADATA => Self::CollectMetadata(
                 parse_u8(payload)
-                    .context("invalid IFLA_VXLAN_COLLECT_METADATA value")? >0,
+                    .context("invalid IFLA_VXLAN_COLLECT_METADATA value")?
+                    > 0,
             ),
             IFLA_VXLAN_PORT_RANGE => {
                 let err = "invalid IFLA_VXLAN_PORT value";
@@ -311,49 +309,56 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoVxlan {
             ),
             IFLA_VXLAN_UDP_CSUM => Self::UDPCsum(
                 parse_u8(payload)
-                    .context("invalid IFLA_VXLAN_UDP_CSUM value")? > 0,
+                    .context("invalid IFLA_VXLAN_UDP_CSUM value")?
+                    > 0,
             ),
             IFLA_VXLAN_UDP_ZERO_CSUM6_TX => Self::UDPZeroCsumTX(
                 parse_u8(payload)
-                    .context("invalid IFLA_VXLAN_UDP_ZERO_CSUM6_TX value")? > 0,
+                    .context("invalid IFLA_VXLAN_UDP_ZERO_CSUM6_TX value")?
+                    > 0,
             ),
             IFLA_VXLAN_UDP_ZERO_CSUM6_RX => Self::UDPZeroCsumRX(
                 parse_u8(payload)
-                    .context("invalid IFLA_VXLAN_UDP_ZERO_CSUM6_RX value")? > 0,
+                    .context("invalid IFLA_VXLAN_UDP_ZERO_CSUM6_RX value")?
+                    > 0,
             ),
             IFLA_VXLAN_REMCSUM_TX => Self::RemCsumTX(
                 parse_u8(payload)
-                    .context("invalid IFLA_VXLAN_REMCSUM_TX value")? > 0,
+                    .context("invalid IFLA_VXLAN_REMCSUM_TX value")?
+                    > 0,
             ),
             IFLA_VXLAN_REMCSUM_RX => Self::RemCsumRX(
                 parse_u8(payload)
-                    .context("invalid IFLA_VXLAN_REMCSUM_RX value")? > 0,
+                    .context("invalid IFLA_VXLAN_REMCSUM_RX value")?
+                    > 0,
             ),
-            IFLA_VXLAN_DF => {
-                Self::Df(parse_u8(payload).context("invalid IFLA_VXLAN_DF value")?)
-            }
-            IFLA_VXLAN_GBP => {
-                Self::Gbp(true)
-            }
-            IFLA_VXLAN_GPE => {
-                Self::Gpe(true)
-            }
+            IFLA_VXLAN_DF => Self::Df(
+                parse_u8(payload).context("invalid IFLA_VXLAN_DF value")?,
+            ),
+            IFLA_VXLAN_GBP => Self::Gbp(true),
+            IFLA_VXLAN_GPE => Self::Gpe(true),
             IFLA_VXLAN_REMCSUM_NOPARTIAL => Self::RemCsumNoPartial(true),
             IFLA_VXLAN_TTL_INHERIT => Self::TtlInherit(
                 parse_u8(payload)
-                    .context("invalid IFLA_VXLAN_TTL_INHERIT value")? > 0,
+                    .context("invalid IFLA_VXLAN_TTL_INHERIT value")?
+                    > 0,
             ),
             IFLA_VXLAN_VNIFILTER => Self::Vnifilter(
                 parse_u8(payload)
-                    .context("invalid IFLA_VXLAN_VNIFILTER value")? > 0,
+                    .context("invalid IFLA_VXLAN_VNIFILTER value")?
+                    > 0,
             ),
             IFLA_VXLAN_LOCALBYPASS => Self::Localbypass(
                 parse_u8(payload)
-                    .context("invalid IFLA_VXLAN_LOCALBYPASS value")? > 0,
+                    .context("invalid IFLA_VXLAN_LOCALBYPASS value")?
+                    > 0,
             ),
-            unknown_kind => Self::Other(DefaultNla::parse(buf).context(format!(
-                "Failed to parse IFLA_INFO_DATA(vxlan) NLA type: {unknown_kind} as DefaultNla"
-            ))?),
+            unknown_kind => {
+                Self::Other(DefaultNla::parse(buf).context(format!(
+                    "Failed to parse IFLA_INFO_DATA(vxlan) NLA type: \
+                     {unknown_kind} as DefaultNla"
+                ))?)
+            }
         })
     }
 }

--- a/src/link/link_layer_type.rs
+++ b/src/link/link_layer_type.rs
@@ -217,7 +217,7 @@ impl From<u16> for LinkLayerType {
             _ => {
                 log::warn!(
                     "BUG: Got unknown ARPHRD_XXX {d} for LinkLayerType, \
-                    treating it as LinkLayerType::Void"
+                     treating it as LinkLayerType::Void"
                 );
                 Self::Void
             }

--- a/src/link/sriov/vf_list.rs
+++ b/src/link/sriov/vf_list.rs
@@ -36,8 +36,8 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                 )?)?);
             } else {
                 log::warn!(
-                    "BUG: Expecting IFLA_VF_INFO in IFLA_VFINFO_LIST, \
-                    but got {}",
+                    "BUG: Expecting IFLA_VF_INFO in IFLA_VFINFO_LIST, but got \
+                     {}",
                     nla.kind()
                 );
             }

--- a/src/link/sriov/vf_port.rs
+++ b/src/link/sriov/vf_port.rs
@@ -25,8 +25,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                 )?)?);
             } else {
                 log::warn!(
-                    "BUG: Expecting IFLA_VF_PORT in IFLA_VF_PORTS, \
-                    but got {}",
+                    "BUG: Expecting IFLA_VF_PORT in IFLA_VF_PORTS, but got {}",
                     nla.kind()
                 );
             }

--- a/src/neighbour/attribute.rs
+++ b/src/neighbour/attribute.rs
@@ -114,26 +114,21 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
         Ok(match buf.kind() {
             NDA_DST => Self::Destination(
                 NeighbourAddress::parse_with_param(address_family, payload)
-                    .context(format!("invalid NDA_DST value {:?}", payload))?,
+                    .context(format!("invalid NDA_DST value {payload:?}"))?,
             ),
             NDA_LLADDR => Self::LinkLocalAddress(payload.to_vec()),
             NDA_CACHEINFO => Self::CacheInfo(
                 NeighbourCacheInfo::parse(
                     &NeighbourCacheInfoBuffer::new_checked(payload).context(
-                        format!("invalid NDA_CACHEINFO value {:?}", payload),
+                        format!("invalid NDA_CACHEINFO value {payload:?}"),
                     )?,
                 )
-                .context(format!(
-                    "invalid NDA_CACHEINFO value {:?}",
-                    payload
-                ))?,
+                .context(format!("invalid NDA_CACHEINFO value {payload:?}"))?,
             ),
-            NDA_PROBES => {
-                Self::Probes(parse_u32(payload).context(format!(
-                    "invalid NDA_PROBES value {:?}",
-                    payload
-                ))?)
-            }
+            NDA_PROBES => Self::Probes(
+                parse_u32(payload)
+                    .context(format!("invalid NDA_PROBES value {payload:?}"))?,
+            ),
             NDA_VLAN => Self::Vlan(parse_u16(payload)?),
             NDA_PORT => Self::Port(
                 parse_u16_be(payload)
@@ -150,7 +145,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
             NDA_SRC_VNI => Self::SourceVni(parse_u32(payload)?),
             NDA_PROTOCOL => {
                 Self::Protocol(RouteProtocol::parse(payload).context(
-                    format!("invalid NDA_PROTOCOL value {:?}", payload),
+                    format!("invalid NDA_PROTOCOL value {payload:?}"),
                 )?)
             }
             _ => Self::Other(

--- a/src/prefix/attribute.rs
+++ b/src/prefix/attribute.rs
@@ -57,12 +57,15 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                 if let Ok(payload) = TryInto::<[u8; 16]>::try_into(payload) {
                     Ok(Self::Address(Ipv6Addr::from(payload)))
                 } else {
-                    Err(DecodeError::from(format!("Invalid PREFIX_ADDRESS, unexpected payload length: {:?}", payload)))
+                    Err(DecodeError::from(format!(
+                        "Invalid PREFIX_ADDRESS, unexpected payload length: \
+                         {payload:?}"
+                    )))
                 }
             }
             PREFIX_CACHEINFO => Ok(Self::CacheInfo(
                 CacheInfo::parse(&CacheInfoBuffer::new(payload)).context(
-                    format!("Invalid PREFIX_CACHEINFO: {:?}", payload),
+                    format!("Invalid PREFIX_CACHEINFO: {payload:?}"),
                 )?,
             )),
             _ => Ok(Self::Other(DefaultNla::parse(buf)?)),

--- a/src/route/attribute.rs
+++ b/src/route/attribute.rs
@@ -219,15 +219,14 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
             RTA_VIA => Self::Via(
                 RouteVia::parse(
                     &RouteViaBuffer::new_checked(payload).context(format!(
-                        "Invalid RTA_VIA value {:?}",
-                        payload
+                        "Invalid RTA_VIA value {payload:?}"
                     ))?,
                 )
-                .context(format!("Invalid RTA_VIA value {:?}", payload))?,
+                .context(format!("Invalid RTA_VIA value {payload:?}"))?,
             ),
             RTA_NEWDST => Self::NewDestination(
                 VecMplsLabel::parse(payload)
-                    .context(format!("Invalid RTA_NEWDST value {:?}", payload))?
+                    .context(format!("Invalid RTA_NEWDST value {payload:?}"))?
                     .0,
             ),
 
@@ -239,24 +238,22 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
                 if route_type == RouteType::Multicast {
                     Self::MulticastExpires(parse_u64(payload).context(
                         format!(
-                            "invalid RTA_EXPIRES (multicast) value {:?}",
-                            payload
+                            "invalid RTA_EXPIRES (multicast) value {payload:?}"
                         ),
                     )?)
                 } else {
                     Self::Expires(parse_u32(payload).context(format!(
-                        "invalid RTA_EXPIRES value {:?}",
-                        payload
+                        "invalid RTA_EXPIRES value {payload:?}"
                     ))?)
                 }
             }
             RTA_UID => Self::Uid(
                 parse_u32(payload)
-                    .context(format!("invalid RTA_UID value {:?}", payload))?,
+                    .context(format!("invalid RTA_UID value {payload:?}"))?,
             ),
             RTA_TTL_PROPAGATE => Self::TtlPropagate(
                 RouteMplsTtlPropagation::from(parse_u8(payload).context(
-                    format!("invalid RTA_TTL_PROPAGATE {:?}", payload),
+                    format!("invalid RTA_TTL_PROPAGATE {payload:?}"),
                 )?),
             ),
             RTA_ENCAP_TYPE => Self::EncapType(RouteLwEnCapType::from(

--- a/src/route/header.rs
+++ b/src/route/header.rs
@@ -251,8 +251,7 @@ impl Parseable<[u8]> for RouteProtocol {
             Ok(Self::from(buf[0]))
         } else {
             Err(DecodeError::from(format!(
-                "Expecting single u8 for route protocol, but got {:?}",
-                buf
+                "Expecting single u8 for route protocol, but got {buf:?}"
             )))
         }
     }

--- a/src/route/mpls.rs
+++ b/src/route/mpls.rs
@@ -56,8 +56,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
             MPLS_IPTUNNEL_DST => Self::Destination(
                 VecMplsLabel::parse(payload)
                     .context(format!(
-                        "invalid MPLS_IPTUNNEL_DST value {:?}",
-                        payload
+                        "invalid MPLS_IPTUNNEL_DST value {payload:?}"
                     ))?
                     .0,
             ),
@@ -102,8 +101,8 @@ impl MplsLabel {
             ])))
         } else {
             Err(DecodeError::from(format!(
-                "Invalid u8 array length {}, expecting \
-                4 bytes for MPLS label, got {:?}",
+                "Invalid u8 array length {}, expecting 4 bytes for MPLS \
+                 label, got {:?}",
                 payload.len(),
                 payload,
             )))

--- a/src/route/realm.rs
+++ b/src/route/realm.rs
@@ -20,9 +20,8 @@ impl RouteRealm {
             })
         } else {
             Err(DecodeError::from(format!(
-                "Invalid rule port range data, expecting \
-                {RULE_REALM_LEN} u8 array, but got {:?}",
-                buf
+                "Invalid rule port range data, expecting {RULE_REALM_LEN} u8 \
+                 array, but got {buf:?}"
             )))
         }
     }

--- a/src/rule/port_range.rs
+++ b/src/rule/port_range.rs
@@ -20,8 +20,7 @@ impl RulePortRange {
         } else {
             Err(DecodeError::from(format!(
                 "Invalid rule port range data, expecting \
-                {RULE_PORT_RANGE_LEN} u8 array, but got {:?}",
-                buf
+                 {RULE_PORT_RANGE_LEN} u8 array, but got {buf:?}"
             )))
         }
     }

--- a/src/rule/uid_range.rs
+++ b/src/rule/uid_range.rs
@@ -19,9 +19,8 @@ impl RuleUidRange {
             })
         } else {
             Err(DecodeError::from(format!(
-                "Invalid rule port range data, expecting \
-                {RULE_UID_RANGE_LEN} u8 array, but got {:?}",
-                buf
+                "Invalid rule port range data, expecting {RULE_UID_RANGE_LEN} \
+                 u8 array, but got {buf:?}"
             )))
         }
     }

--- a/src/tc/actions/nat.rs
+++ b/src/tc/actions/nat.rs
@@ -156,8 +156,8 @@ impl<T: AsRef<[u8]> + ?Sized> Parseable<TcNatBuffer<&T>> for TcNat {
 fn parse_ipv4(data: &[u8]) -> Result<Ipv4Addr, DecodeError> {
     if data.len() != 4 {
         Err(DecodeError::from(format!(
-            "Invalid length of IPv4 Address, expecting 4 bytes, but got {:?}",
-            data
+            "Invalid length of IPv4 Address, expecting 4 bytes, but got \
+             {data:?}"
         )))
     } else {
         Ok(Ipv4Addr::new(data[0], data[1], data[2], data[3]))

--- a/src/tc/filters/cls_u32.rs
+++ b/src/tc/filters/cls_u32.rs
@@ -201,7 +201,8 @@ impl<T: AsRef<[u8]>> TcU32SelectorBuffer<T> {
         let len = self.buffer.as_ref().len();
         if len < TC_U32_SEL_BUF_LEN {
             return Err(format!(
-                "invalid TcU32SelectorBuffer: length {len} < {TC_U32_SEL_BUF_LEN}"
+                "invalid TcU32SelectorBuffer: length {len} < \
+                 {TC_U32_SEL_BUF_LEN}"
             )
             .into());
         }
@@ -210,8 +211,7 @@ impl<T: AsRef<[u8]>> TcU32SelectorBuffer<T> {
             ((self.nkeys() as usize) * TC_U32_KEY_BUF_LEN) + TC_U32_SEL_BUF_LEN;
         if len < expected_len {
             return Err(format!(
-                "invalid RouteNextHopBuffer: length {} < {}",
-                len, expected_len,
+                "invalid RouteNextHopBuffer: length {len} < {expected_len}",
             )
             .into());
         }


### PR DESCRIPTION
=== Breaking changes
 - `InfoBond::ArpAllTargets` changed to enum. (507ea73)
 - `InfoBond::XmitHashPolicy` changed to enum. (b2572da)
 - `InfoBond::FailOverMac` changed to enum. (3270863)

=== New features
 - tc: Add support of tunnel key. (f5535f3)

=== Bug fixes
 - Fix compile on Andriod. (d44d500)
 - Fix panic of integer underflow in `RouteNextHopBuffer`. (a285aba)