### PR TITLE
New release 0.24.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,17 @@
 # Changelog
+## [0.24.0] - 2025-05-21
+### Breaking changes
+ - Changed `InfoBond::PrimaryReselect` from u8 to enum. (7be1634)
+
+### New features
+ - ICMP6: Add support of ICMP6_MIB_RATELIMITHOST. (3497a69)
+ - Support Seg6 encapsulation type. (1a33cd3)
+ - impl `From<IpAddr>` for `RouteVia`. (7ef6bf6)
+
+### Bug fixes
+ - Fix parsing error on empty IFLA_AF_SPEC. (5e54549)
+ - Fix panic of integer underflow in `RouteNextHopBuffer`. (a285aba)
+
 ## [0.23.0] - 2025-04-30
 ### Breaking changes
  - `InfoBond::ArpAllTargets` changed to enum. (507ea73)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-packet-route"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 
 homepage = "https://github.com/rust-netlink/netlink-packet-route"

--- a/tools/make_release.sh
+++ b/tools/make_release.sh
@@ -56,7 +56,7 @@ git reset --hard upstream/$MAIN_BRANCH_NAME
 
 echo "Checking 'cargo publish --dry-run'"
 cargo set-version $NEXT_VERSION
-cargo publish --dry-run
+cargo publish --dry-run --allow-dirty
 
 echo "# Changelog" > $TMP_CHANGELOG_FILE
 echo "## [$NEXT_VERSION] - $(date +%F)" >> $TMP_CHANGELOG_FILE


### PR DESCRIPTION
=== Breaking changes
 - Changed `InfoBond::PrimaryReselect` from u8 to enum. (7be1634)

=== New features
 - ICMP6: Add support of `ICMP6_MIB_RATELIMITHOST`. (3497a69)
 - Support Seg6 encapsulation type. (1a33cd3)
 - impl `From<IpAddr>` for `RouteVia`. (7ef6bf6)

=== Bug fixes
 - Fix parsing error on empty `IFLA_AF_SPEC`. (5e54549)
 - Fix panic of integer underflow in `RouteNextHopBuffer`. (a285aba)