### PR TITLE
New release 0.25.1

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -14,17 +14,14 @@ jobs:
   build_on_msrv:
     strategy:
       fail-fast: true
-      matrix:
-        include:
-          - msrv: "1.77"
 
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v5
 
-    - name: Install Rust ${{ matrix.msrv }}
-      run: rustup install ${{ matrix.msrv }}
+    - name: Install Rust 1.77
+      run: rustup install 1.77
 
     - name: Build test
-      run: cargo +${{ matrix.msrv }} build --ignore-rust-version
+      run: cargo +1.77 build --ignore-rust-version

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,14 @@
 # Changelog
+## [0.25.1] - 2025-08-29
+### Breaking changes
+ - Set minimum supported rust version to 1.77. (6bd5418)
+
+### New features
+ - N/A
+
+### Bug fixes
+ - Fix compiling error on rust 1.77. (6bd5418)
+
 ## [0.25.0] - 2025-08-27
 ### Breaking changes
  - Drop the dependency on `netlink-packet-utils`. (e09acbd)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-packet-route"
-version = "0.25.0"
+version = "0.25.1"
 edition = "2021"
 rust-version = "1.77"
 homepage = "https://github.com/rust-netlink/netlink-packet-route"


### PR DESCRIPTION
=== Breaking changes
 - Set minimum supported rust version to 1.77. (6bd5418)

=== New features
 - N/A

=== Bug fixes
 - Fix compiling error on rust 1.77. (6bd5418)