### PR TITLE
neighbour: Support `NDA_FLAGS_EXT`

### DIFF
--- a/src/neighbour/flags.rs
+++ b/src/neighbour/flags.rs
@@ -25,3 +25,18 @@ bitflags! {
         const _ = !0;
     }
 }
+
+const NTF_EXT_MANAGED: u32 = 1 << 0;
+const NTF_EXT_LOCKED: u32 = 1 << 1;
+const NTF_EXT_EXT_VALIDATED: u32 = 1 << 2;
+
+bitflags! {
+    #[derive(Clone, Eq, PartialEq, Debug, Copy, Default)]
+    #[non_exhaustive]
+    pub struct NeighbourExtFlags: u32 {
+        const Managed = NTF_EXT_MANAGED;
+        const Locked = NTF_EXT_LOCKED;
+        const ExtValidated = NTF_EXT_EXT_VALIDATED;
+        const _ = !0;
+    }
+}

--- a/src/neighbour/mod.rs
+++ b/src/neighbour/mod.rs
@@ -15,7 +15,7 @@ pub use self::{
     address::NeighbourAddress,
     attribute::NeighbourAttribute,
     cache_info::{NeighbourCacheInfo, NeighbourCacheInfoBuffer},
-    flags::NeighbourFlags,
+    flags::{NeighbourExtFlags, NeighbourFlags},
     header::{NeighbourHeader, NeighbourMessageBuffer},
     message::NeighbourMessage,
     state::NeighbourState,


### PR DESCRIPTION
Support parsing the packet of command like:

```
ip neigh replace dev wlan0 172.17.2.1 managed
ip neigh show dev wlan0 to 172.17.2.1
```

Unit tests included using the nlmon tcpdump of above commands.