### PR TITLE
prefix: export PrefixAttribute and CacheInfo

### DIFF
--- a/src/prefix/mod.rs
+++ b/src/prefix/mod.rs
@@ -7,5 +7,7 @@ mod message;
 #[cfg(test)]
 mod tests;
 
+pub use attribute::PrefixAttribute;
+pub use cache_info::CacheInfo;
 pub use header::PrefixMessageBuffer;
 pub use message::PrefixMessage;


### PR DESCRIPTION
These types are required for applications to utilise RTM_NEWPREFIX support.