### PR TITLE
address: ip: Handle `IFA_RT_PRIORITY` `IFA_TARGET_NETNSID` and `IFA_PROTO`

### DIFF
--- a/src/address/mod.rs
+++ b/src/address/mod.rs
@@ -12,7 +12,7 @@ mod tests;
 pub use self::{
     addr_flags::{AddressFlags, AddressHeaderFlags},
     addr_scope::AddressScope,
-    attribute::AddressAttribute,
+    attribute::{AddressAttribute, AddressProtocol},
     cache_info::{CacheInfo, CacheInfoBuffer},
     message::{AddressHeader, AddressMessage, AddressMessageBuffer},
 };

--- a/src/address/tests/ipv6.rs
+++ b/src/address/tests/ipv6.rs
@@ -1,13 +1,17 @@
 // SPDX-License-Identifier: MIT
 
-use std::net::{IpAddr, Ipv6Addr};
+use std::{
+    net::{IpAddr, Ipv6Addr},
+    str::FromStr,
+};
 
 use netlink_packet_core::{Emitable, NlaBuffer, Parseable};
 
 use crate::{
     address::{
         AddressAttribute, AddressFlags, AddressHeader, AddressHeaderFlags,
-        AddressMessage, AddressMessageBuffer, AddressScope, CacheInfo,
+        AddressMessage, AddressMessageBuffer, AddressProtocol, AddressScope,
+        CacheInfo,
     },
     AddressFamily,
 };
@@ -66,6 +70,52 @@ fn test_get_loopback_ipv6_addr() {
             AddressAttribute::Flags(
                 AddressFlags::Permanent | AddressFlags::Noprefixroute,
             ),
+        ],
+    };
+
+    assert_eq!(
+        expected,
+        AddressMessage::parse(&AddressMessageBuffer::new(&raw)).unwrap()
+    );
+
+    let mut buf = vec![0; expected.buffer_len()];
+
+    expected.emit(&mut buf);
+
+    assert_eq!(buf, raw);
+}
+
+#[test]
+fn test_get_ipv6_address_ra_protocol() {
+    let raw = vec![
+        0x0a, 0x40, 0x00, 0x00, 0x0f, 0x01, 0x00, 0x00, 0x14, 0x00, 0x01, 0x00,
+        0x20, 0x01, 0x0d, 0xb8, 0x00, 0x0a, 0x00, 0x00, 0xb4, 0x02, 0xdf, 0xff,
+        0xfe, 0x56, 0xc3, 0xce, 0x14, 0x00, 0x06, 0x00, 0x03, 0x07, 0x00, 0x00,
+        0x03, 0x07, 0x00, 0x00, 0x63, 0x4f, 0x34, 0x01, 0x4f, 0x5e, 0x34, 0x01,
+        0x08, 0x00, 0x08, 0x00, 0x00, 0x01, 0x00, 0x00, 0x05, 0x00, 0x0b, 0x00,
+        0x02, 0x00, 0x00, 0x00,
+    ];
+
+    let expected = AddressMessage {
+        header: AddressHeader {
+            family: AddressFamily::Inet6,
+            prefix_len: 64,
+            flags: AddressHeaderFlags::empty(),
+            scope: AddressScope::Universe,
+            index: 271,
+        },
+        attributes: vec![
+            AddressAttribute::Address(
+                IpAddr::from_str("2001:db8:a:0:b402:dfff:fe56:c3ce").unwrap(),
+            ),
+            AddressAttribute::CacheInfo(CacheInfo {
+                ifa_preferred: 1795,
+                ifa_valid: 1795,
+                cstamp: 20205411,
+                tstamp: 20209231,
+            }),
+            AddressAttribute::Flags(AddressFlags::Managetempaddr),
+            AddressAttribute::Protocol(AddressProtocol::RouterAnnouncement),
         ],
     };
 


### PR DESCRIPTION
Adding parsing/emiting code for:
 * `IFA_RT_PRIORITY`
 * `IFA_TARGET_NETNSID`
 * `IFA_PROTO`

The /usr/bin/ip command does not support `IFA_RT_PRIORITY` and
`IFA_TARGET_NETNSID`, no idea how to trigger it. Hence no unit test for
them.

Unit test case included for `IFA_PROTO`.