### PR TITLE
bond: Changing `InfoBond::AdLacpRate` from u8 to enum

### DIFF
--- a/src/link/link_info/mod.rs
+++ b/src/link/link_info/mod.rs
@@ -30,8 +30,8 @@ pub(crate) use self::infos::VecLinkInfo;
 pub use self::{
     bond::{
         BondAdInfo, BondAllPortActive, BondArpAllTargets, BondArpValidate,
-        BondFailOverMac, BondMode, BondPrimaryReselect, BondXmitHashPolicy,
-        InfoBond,
+        BondFailOverMac, BondLacpRate, BondMode, BondPrimaryReselect,
+        BondXmitHashPolicy, InfoBond,
     },
     bond_port::{BondPortState, InfoBondPort, MiiStatus},
     bridge::{BridgeId, BridgeIdBuffer, BridgeQuerierState, InfoBridge},

--- a/src/link/mod.rs
+++ b/src/link/mod.rs
@@ -42,8 +42,8 @@ pub use self::{
     link_flag::LinkFlags,
     link_info::{
         BondAdInfo, BondAllPortActive, BondArpAllTargets, BondArpValidate,
-        BondFailOverMac, BondMode, BondPortState, BondPrimaryReselect,
-        BondXmitHashPolicy, BridgeId, BridgeIdBuffer,
+        BondFailOverMac, BondLacpRate, BondMode, BondPortState,
+        BondPrimaryReselect, BondXmitHashPolicy, BridgeId, BridgeIdBuffer,
         BridgePortMulticastRouter, BridgePortState, BridgeQuerierState,
         GeneveDf, GreEncapFlags, GreEncapType, GreIOFlags, HsrProtocol,
         InfoBond, InfoBondPort, InfoBridge, InfoBridgePort, InfoData,

--- a/src/link/tests/bond.rs
+++ b/src/link/tests/bond.rs
@@ -4,12 +4,12 @@ use netlink_packet_core::{Emitable, Parseable};
 
 use crate::{
     link::{
-        link_flag::LinkFlags, BondAllPortActive, BondArpAllTargets,
-        BondArpValidate, BondFailOverMac, BondMode, BondPortState,
-        BondPrimaryReselect, BondXmitHashPolicy, InfoBond, InfoBondPort,
-        InfoData, InfoKind, InfoPortData, InfoPortKind, LinkAttribute,
-        LinkHeader, LinkInfo, LinkLayerType, LinkMessage, LinkMessageBuffer,
-        LinkMode, Map, MiiStatus, State,
+        BondAllPortActive, BondArpAllTargets, BondArpValidate, BondFailOverMac,
+        BondLacpRate, BondMode, BondPortState, BondPrimaryReselect,
+        BondXmitHashPolicy, InfoBond, InfoBondPort, InfoData, InfoKind,
+        InfoPortData, InfoPortKind, LinkAttribute, LinkFlags, LinkHeader,
+        LinkInfo, LinkLayerType, LinkMessage, LinkMessageBuffer, LinkMode, Map,
+        MiiStatus, State,
     },
     AddressFamily, RouteNetlinkMessage,
 };
@@ -79,7 +79,7 @@ fn test_bond_link_info() {
                 InfoBond::LpInterval(1),
                 InfoBond::PacketsPerPort(1),
                 InfoBond::AdLacpActive(1),
-                InfoBond::AdLacpRate(0),
+                InfoBond::AdLacpRate(BondLacpRate::Slow),
                 InfoBond::AdSelect(0),
                 InfoBond::TlbDynamicLb(1),
                 InfoBond::MissedMax(2),


### PR DESCRIPTION
Changing `InfoBond::AdLacpRate(u8)` to
`InfoBond::AdLacpRate(BondLacpRate)`.

Unit test case updated.