### PR TITLE
bond: Changed `InfoBond::AdLacpActive` from u8 to bool

### DIFF
--- a/src/link/link_info/bond.rs
+++ b/src/link/link_info/bond.rs
@@ -643,7 +643,8 @@ pub enum InfoBond {
     /// [BondMode::BalanceTlb] mode.
     TlbDynamicLb(bool),
     PeerNotifDelay(u32),
-    AdLacpActive(u8),
+    /// Whether to send LACPDU frames periodically
+    AdLacpActive(bool),
     MissedMax(u8),
     NsIp6Target(Vec<Ipv6Addr>),
     Other(DefaultNla),
@@ -697,10 +698,11 @@ impl Nla for InfoBond {
             Self::PrimaryReselect(value) => buffer[0] = (*value).into(),
             Self::UseCarrier(value)
             | Self::NumPeerNotif(value)
-            | Self::AdLacpActive(value)
             | Self::AdSelect(value)
             | Self::MissedMax(value) => buffer[0] = *value,
-            Self::TlbDynamicLb(value) => buffer[0] = (*value).into(),
+            Self::AdLacpActive(value) | Self::TlbDynamicLb(value) => {
+                buffer[0] = (*value).into()
+            }
             Self::AdLacpRate(value) => buffer[0] = (*value).into(),
             Self::AllPortsActive(value) => buffer[0] = (*value).into(),
             Self::FailOverMac(value) => buffer[0] = (*value).into(),
@@ -913,7 +915,8 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoBond {
             ),
             IFLA_BOND_AD_LACP_ACTIVE => Self::AdLacpActive(
                 parse_u8(payload)
-                    .context("invalid IFLA_BOND_AD_LACP_ACTIVE value")?,
+                    .context("invalid IFLA_BOND_AD_LACP_ACTIVE value")?
+                    > 0,
             ),
             IFLA_BOND_MISSED_MAX => Self::MissedMax(
                 parse_u8(payload)

--- a/src/link/tests/bond.rs
+++ b/src/link/tests/bond.rs
@@ -78,7 +78,7 @@ fn test_bond_link_info() {
                 InfoBond::MinLinks(0),
                 InfoBond::LpInterval(1),
                 InfoBond::PacketsPerPort(1),
-                InfoBond::AdLacpActive(1),
+                InfoBond::AdLacpActive(true),
                 InfoBond::AdLacpRate(BondLacpRate::Slow),
                 InfoBond::AdSelect(0),
                 InfoBond::TlbDynamicLb(true),


### PR DESCRIPTION
Both linux kernel code and document confirmed `lacp_active` is a
boolean.

Unit test case updated.