### PR TITLE
bond: Change `InfoBond::UseCarrier` from u8 to bool

### DIFF
--- a/src/link/link_info/bond.rs
+++ b/src/link/link_info/bond.rs
@@ -614,7 +614,9 @@ pub enum InfoBond {
     MiiMon(u32),
     UpDelay(u32),
     DownDelay(u32),
-    UseCarrier(u8),
+    /// Specifies whether or not miimon should use MII or ETHTOOL ioctls vs.
+    /// `netif_carrier_ok()` to determine the link status.
+    UseCarrier(bool),
     ArpInterval(u32),
     ArpIpTarget(Vec<Ipv4Addr>),
     ArpValidate(BondArpValidate),
@@ -696,13 +698,12 @@ impl Nla for InfoBond {
             Self::Mode(value) => buffer[0] = (*value).into(),
             Self::XmitHashPolicy(value) => buffer[0] = (*value).into(),
             Self::PrimaryReselect(value) => buffer[0] = (*value).into(),
-            Self::UseCarrier(value)
-            | Self::NumPeerNotif(value)
+            Self::NumPeerNotif(value)
             | Self::AdSelect(value)
             | Self::MissedMax(value) => buffer[0] = *value,
-            Self::AdLacpActive(value) | Self::TlbDynamicLb(value) => {
-                buffer[0] = (*value).into()
-            }
+            Self::UseCarrier(value)
+            | Self::AdLacpActive(value)
+            | Self::TlbDynamicLb(value) => buffer[0] = (*value).into(),
             Self::AdLacpRate(value) => buffer[0] = (*value).into(),
             Self::AllPortsActive(value) => buffer[0] = (*value).into(),
             Self::FailOverMac(value) => buffer[0] = (*value).into(),
@@ -802,7 +803,8 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoBond {
             ),
             IFLA_BOND_USE_CARRIER => Self::UseCarrier(
                 parse_u8(payload)
-                    .context("invalid IFLA_BOND_USE_CARRIER value")?,
+                    .context("invalid IFLA_BOND_USE_CARRIER value")?
+                    > 0,
             ),
             IFLA_BOND_ARP_INTERVAL => Self::ArpInterval(
                 parse_u32(payload)

--- a/src/link/tests/bond.rs
+++ b/src/link/tests/bond.rs
@@ -65,7 +65,7 @@ fn test_bond_link_info() {
                 InfoBond::UpDelay(0),
                 InfoBond::DownDelay(0),
                 InfoBond::PeerNotifDelay(0),
-                InfoBond::UseCarrier(1),
+                InfoBond::UseCarrier(true),
                 InfoBond::ArpInterval(0),
                 InfoBond::ArpValidate(BondArpValidate::None),
                 InfoBond::ArpAllTargets(BondArpAllTargets::Any),


### PR DESCRIPTION
Both linux kernel code and document confirmed the `use_carrier` is a
boolean.

Unit test case updated.