### PR TITLE
neighbour: Refer to the correct set of constants for neighbour cache entry type

### DIFF
--- a/src/neighbour/header.rs
+++ b/src/neighbour/header.rs
@@ -51,7 +51,7 @@ pub struct NeighbourHeader {
     /// of the `NTF_*` constants
     pub flags: NeighbourFlags,
     /// Neighbour cache entry type. It should be set to one of the
-    /// `NDA_*` constants.
+    /// `RTN_*` constants.
     pub kind: RouteType,
 }
 


### PR DESCRIPTION
The doc comment for `NeighbourHeader::kind` refers to the `NDA_*` constants whereas the relevant set of constants is `RTN_*` (see e.g. [here](https://github.com/torvalds/linux/blob/44331bd6a6107a33f8082521b227ffa4ec063a40/net/core/neighbour.c#L2744)).