### PR TITLE
link: Add support of `IFLA_DEVLINK_PORT`

### DIFF
--- a/src/link/attribute.rs
+++ b/src/link/attribute.rs
@@ -23,6 +23,7 @@ use super::proto_info::VecLinkProtoInfoBridge;
 use super::{
     af_spec::VecAfSpecUnspec,
     buffer_tool::expand_buffer_if_small,
+    devlink_port::DevlinkPort,
     ext_mask::VecLinkExtentMask,
     link_info::VecLinkInfo,
     proto_info::VecLinkProtoInfoInet6,
@@ -100,7 +101,7 @@ const IFLA_GRO_MAX_SIZE: u16 = 58;
 const IFLA_TSO_MAX_SIZE: u16 = 59;
 const IFLA_TSO_MAX_SEGS: u16 = 60;
 const IFLA_ALLMULTI: u16 = 61;
-// const IFLA_DEVLINK_PORT: u16 = 62;
+const IFLA_DEVLINK_PORT: u16 = 62;
 const IFLA_GSO_IPV4_MAX_SIZE: u16 = 63;
 const IFLA_GRO_IPV4_MAX_SIZE: u16 = 64;
 // const IFLA_DPLL_PIN: u16 = 65;
@@ -181,6 +182,7 @@ pub enum LinkAttribute {
     GsoIpv4MaxSize(u32),
     GroIpv4MaxSize(u32),
     NetnsImmutable(bool),
+    DevlinkPort(Vec<DevlinkPort>),
     Other(DefaultNla),
 }
 
@@ -253,6 +255,7 @@ impl Nla for LinkAttribute {
             Self::PropList(nlas) => nlas.as_slice().buffer_len(),
             Self::AfSpecUnspec(nlas) => nlas.as_slice().buffer_len(),
             Self::AfSpecBridge(nlas) => nlas.as_slice().buffer_len(),
+            Self::DevlinkPort(nlas) => nlas.as_slice().buffer_len(),
             Self::ProtoInfoUnknown(attr) => attr.value_len(),
             Self::Wireless(v) => v.buffer_len(),
             Self::Other(attr) => attr.value_len(),
@@ -335,6 +338,7 @@ impl Nla for LinkAttribute {
             Self::PropList(nlas) => nlas.as_slice().emit(buffer),
             Self::AfSpecUnspec(nlas) => nlas.as_slice().emit(buffer),
             Self::AfSpecBridge(nlas) => nlas.as_slice().emit(buffer),
+            Self::DevlinkPort(nlas) => nlas.as_slice().emit(buffer),
             Self::Wireless(v) => v.emit(buffer),
             Self::ProtoInfoUnknown(attr) | Self::Other(attr) => {
                 attr.emit_value(buffer)
@@ -406,6 +410,7 @@ impl Nla for LinkAttribute {
             Self::GsoIpv4MaxSize(_) => IFLA_GSO_IPV4_MAX_SIZE,
             Self::GroIpv4MaxSize(_) => IFLA_GRO_IPV4_MAX_SIZE,
             Self::NetnsImmutable(_) => IFLA_NETNS_IMMUTABLE,
+            Self::DevlinkPort(_) => IFLA_DEVLINK_PORT | NLA_F_NESTED,
             Self::Other(attr) => attr.kind(),
         }
     }
@@ -766,6 +771,16 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
                     .context("invalid IFLA_NETNS_IMMUTABLE value")?
                     != 0,
             ),
+            IFLA_DEVLINK_PORT => {
+                let err = "invalid IFLA_DEVLINK_PORT value";
+                let mut nlas = vec![];
+                for nla in NlasIterator::new(payload) {
+                    let nla = &nla.context(err)?;
+                    let parsed = DevlinkPort::parse(nla).context(err)?;
+                    nlas.push(parsed);
+                }
+                Self::DevlinkPort(nlas)
+            }
             kind => Self::Other(
                 DefaultNla::parse(buf)
                     .context(format!("unknown NLA type {kind}"))?,

--- a/src/link/devlink_port.rs
+++ b/src/link/devlink_port.rs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+
+use netlink_packet_core::{
+    emit_u32, parse_string, parse_u32, DecodeError, DefaultNla, ErrorContext,
+    Nla, NlaBuffer, Parseable,
+};
+
+const DEVLINK_ATTR_BUS_NAME: u16 = 1;
+const DEVLINK_ATTR_DEV_NAME: u16 = 2;
+const DEVLINK_ATTR_PORT_INDEX: u16 = 3;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
+pub enum DevlinkPort {
+    BusName(String),
+    DevName(String),
+    PortIndex(u32),
+    Other(DefaultNla),
+}
+
+impl Nla for DevlinkPort {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::BusName(s) | Self::DevName(s) => s.len() + 1,
+            Self::PortIndex(_) => 4,
+            Self::Other(nla) => nla.value_len(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::BusName(s) | Self::DevName(s) => {
+                buffer[..s.len()].copy_from_slice(s.as_bytes());
+                buffer[s.len()] = 0;
+            }
+            Self::PortIndex(v) => emit_u32(buffer, *v).unwrap(),
+            Self::Other(nla) => nla.emit_value(buffer),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::BusName(_) => DEVLINK_ATTR_BUS_NAME,
+            Self::DevName(_) => DEVLINK_ATTR_DEV_NAME,
+            Self::PortIndex(_) => DEVLINK_ATTR_PORT_INDEX,
+            Self::Other(nla) => nla.kind(),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for DevlinkPort {
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            DEVLINK_ATTR_BUS_NAME => Self::BusName(
+                parse_string(payload)
+                    .context("invalid DEVLINK_ATTR_BUS_NAME value")?,
+            ),
+            DEVLINK_ATTR_DEV_NAME => Self::DevName(
+                parse_string(payload)
+                    .context("invalid DEVLINK_ATTR_DEV_NAME value")?,
+            ),
+            DEVLINK_ATTR_PORT_INDEX => Self::PortIndex(
+                parse_u32(payload)
+                    .context("invalid DEVLINK_ATTR_PORT_INDEX value")?,
+            ),
+            _ => Self::Other(DefaultNla::parse(buf).context(format!(
+                "unknown DEVLINK_ATTR type {}",
+                buf.kind()
+            ))?),
+        })
+    }
+}

--- a/src/link/mod.rs
+++ b/src/link/mod.rs
@@ -3,6 +3,7 @@
 mod af_spec;
 mod attribute;
 mod buffer_tool;
+mod devlink_port;
 mod down_reason;
 mod event;
 pub(crate) mod ext_mask;
@@ -36,6 +37,7 @@ pub use self::{
         MctpPhysBinding,
     },
     attribute::LinkAttribute,
+    devlink_port::DevlinkPort,
     down_reason::LinkProtocolDownReason,
     event::LinkEvent,
     ext_mask::LinkExtentMask,

--- a/src/link/tests/bridge.rs
+++ b/src/link/tests/bridge.rs
@@ -420,7 +420,7 @@ fn test_parse_link_bridge_no_extention_mask() {
                     }),
                 ]),
             ]),
-            LinkAttribute::Other(DefaultNla::new(32830, vec![])),
+            LinkAttribute::DevlinkPort(vec![]),
         ],
     };
 
@@ -1217,7 +1217,7 @@ fn test_bridge_netns_immutable() {
                 dma: 0,
                 port: 0,
             }),
-            LinkAttribute::Other(DefaultNla::new(32830, vec![])),
+            LinkAttribute::DevlinkPort(vec![]),
             LinkAttribute::Other(DefaultNla::new(32833, vec![])),
         ],
     };

--- a/src/link/tests/macvtap.rs
+++ b/src/link/tests/macvtap.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{DefaultNla, Emitable, Parseable};
+use netlink_packet_core::{Emitable, Parseable};
 
 use crate::{
     link::{
@@ -330,8 +330,7 @@ fn test_macvtap_link_info() {
                     }),
                 ]),
             ]),
-            // TODO: Need to parse NLA_F_NESTED|IFLA_DEVLINK_PORT
-            LinkAttribute::Other(DefaultNla::new(32830, Vec::new())),
+            LinkAttribute::DevlinkPort(vec![]),
         ],
     };
 

--- a/src/link/tests/statistics.rs
+++ b/src/link/tests/statistics.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{DefaultNla, Emitable, Parseable};
+use netlink_packet_core::{Emitable, Parseable};
 
 use crate::{
     link::{
@@ -720,10 +720,7 @@ fn test_parsing_link_statistics() {
             LinkAttribute::PropList(vec![Prop::AltIfName("wlp0s20f3".into())]),
             LinkAttribute::ParentDevName("0000:00:14.3".into()),
             LinkAttribute::ParentDevBusName("pci".into()),
-            LinkAttribute::Other(DefaultNla::new(
-                32830, // NLA_F_NESTED|IFLA_DEVLINK_PORT
-                vec![],
-            )),
+            LinkAttribute::DevlinkPort(vec![]),
         ],
     };
 

--- a/src/link/tests/vxlan.rs
+++ b/src/link/tests/vxlan.rs
@@ -369,7 +369,7 @@ fn test_parsing_link_vxlan() {
                     }),
                 ]),
             ]),
-            LinkAttribute::Other(DefaultNla::new(32830, vec![])),
+            LinkAttribute::DevlinkPort(vec![]),
         ],
     };
 


### PR DESCRIPTION
Besides empty devlink_port data in current unit test, I got no real
hardware support so, hence no real unit test for this feature.