### PR TITLE
link: Add initial support of IFLA_DPLL_PIN

### DIFF
--- a/src/link/attribute.rs
+++ b/src/link/attribute.rs
@@ -24,6 +24,7 @@ use super::{
     af_spec::VecAfSpecUnspec,
     buffer_tool::expand_buffer_if_small,
     devlink_port::DevlinkPort,
+    dpll_pin::DpllPin,
     ext_mask::VecLinkExtentMask,
     link_info::VecLinkInfo,
     proto_info::VecLinkProtoInfoInet6,
@@ -104,7 +105,7 @@ const IFLA_ALLMULTI: u16 = 61;
 const IFLA_DEVLINK_PORT: u16 = 62;
 const IFLA_GSO_IPV4_MAX_SIZE: u16 = 63;
 const IFLA_GRO_IPV4_MAX_SIZE: u16 = 64;
-// const IFLA_DPLL_PIN: u16 = 65;
+const IFLA_DPLL_PIN: u16 = 65;
 // const IFLA_MAX_PACING_OFFLOAD_HORIZON: u16 = 66;
 const IFLA_NETNS_IMMUTABLE: u16 = 67;
 // const IFLA_HEADROOM: u16 = 68;
@@ -183,6 +184,7 @@ pub enum LinkAttribute {
     GroIpv4MaxSize(u32),
     NetnsImmutable(bool),
     DevlinkPort(Vec<DevlinkPort>),
+    DpllPin(Vec<DpllPin>),
     Other(DefaultNla),
 }
 
@@ -256,6 +258,7 @@ impl Nla for LinkAttribute {
             Self::AfSpecUnspec(nlas) => nlas.as_slice().buffer_len(),
             Self::AfSpecBridge(nlas) => nlas.as_slice().buffer_len(),
             Self::DevlinkPort(nlas) => nlas.as_slice().buffer_len(),
+            Self::DpllPin(nlas) => nlas.as_slice().buffer_len(),
             Self::ProtoInfoUnknown(attr) => attr.value_len(),
             Self::Wireless(v) => v.buffer_len(),
             Self::Other(attr) => attr.value_len(),
@@ -339,6 +342,7 @@ impl Nla for LinkAttribute {
             Self::AfSpecUnspec(nlas) => nlas.as_slice().emit(buffer),
             Self::AfSpecBridge(nlas) => nlas.as_slice().emit(buffer),
             Self::DevlinkPort(nlas) => nlas.as_slice().emit(buffer),
+            Self::DpllPin(nlas) => nlas.as_slice().emit(buffer),
             Self::Wireless(v) => v.emit(buffer),
             Self::ProtoInfoUnknown(attr) | Self::Other(attr) => {
                 attr.emit_value(buffer)
@@ -411,6 +415,7 @@ impl Nla for LinkAttribute {
             Self::GroIpv4MaxSize(_) => IFLA_GRO_IPV4_MAX_SIZE,
             Self::NetnsImmutable(_) => IFLA_NETNS_IMMUTABLE,
             Self::DevlinkPort(_) => IFLA_DEVLINK_PORT | NLA_F_NESTED,
+            Self::DpllPin(_) => IFLA_DPLL_PIN | NLA_F_NESTED,
             Self::Other(attr) => attr.kind(),
         }
     }
@@ -780,6 +785,16 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
                     nlas.push(parsed);
                 }
                 Self::DevlinkPort(nlas)
+            }
+            IFLA_DPLL_PIN => {
+                let err = "invalid IFLA_DPLL_PIN value";
+                let mut nlas = vec![];
+                for nla in NlasIterator::new(payload) {
+                    let nla = &nla.context(err)?;
+                    let parsed = DpllPin::parse(nla).context(err)?;
+                    nlas.push(parsed);
+                }
+                Self::DpllPin(nlas)
             }
             kind => Self::Other(
                 DefaultNla::parse(buf)

--- a/src/link/dpll_pin.rs
+++ b/src/link/dpll_pin.rs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+
+// TODO: If you have hardware to simulate DPLL pins, please add unit tests for
+// this module.
+
+use netlink_packet_core::{
+    emit_u32, parse_u32, DecodeError, DefaultNla, ErrorContext, Nla, NlaBuffer,
+    Parseable,
+};
+
+const DPLL_A_PIN_ID: u16 = 1;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
+pub enum DpllPin {
+    /// The unique pin identifier within the DPLL subsystem.
+    PinId(u32),
+    Other(DefaultNla),
+}
+
+impl Nla for DpllPin {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::PinId(_) => 4,
+            Self::Other(nla) => nla.value_len(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::PinId(v) => emit_u32(buffer, *v).unwrap(),
+            Self::Other(nla) => nla.emit_value(buffer),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::PinId(_) => DPLL_A_PIN_ID,
+            Self::Other(nla) => nla.kind(),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for DpllPin {
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            DPLL_A_PIN_ID => Self::PinId(
+                parse_u32(payload).context("invalid DPLL_A_PIN_ID value")?,
+            ),
+            _ => {
+                Self::Other(DefaultNla::parse(buf).context(format!(
+                    "unknown DPLL_A_PIN type {}",
+                    buf.kind()
+                ))?)
+            }
+        })
+    }
+}

--- a/src/link/mod.rs
+++ b/src/link/mod.rs
@@ -5,6 +5,7 @@ mod attribute;
 mod buffer_tool;
 mod devlink_port;
 mod down_reason;
+mod dpll_pin;
 mod event;
 pub(crate) mod ext_mask;
 mod header;
@@ -39,6 +40,7 @@ pub use self::{
     attribute::LinkAttribute,
     devlink_port::DevlinkPort,
     down_reason::LinkProtocolDownReason,
+    dpll_pin::DpllPin,
     event::LinkEvent,
     ext_mask::LinkExtentMask,
     header::{LinkHeader, LinkMessageBuffer},

--- a/src/link/tests/bridge.rs
+++ b/src/link/tests/bridge.rs
@@ -1218,7 +1218,7 @@ fn test_bridge_netns_immutable() {
                 port: 0,
             }),
             LinkAttribute::DevlinkPort(vec![]),
-            LinkAttribute::Other(DefaultNla::new(32833, vec![])),
+            LinkAttribute::DpllPin(vec![]),
         ],
     };
 

--- a/src/link/tests/dpll_pin.rs
+++ b/src/link/tests/dpll_pin.rs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+
+use netlink_packet_core::{Emitable, NlaBuffer, Parseable};
+
+use crate::link::dpll_pin::DpllPin;
+
+// A nested IFLA_DPLL_PIN containing a single DPLL_A_PIN_ID = 42
+//   8 bytes total: 4-byte NLA header + 4-byte u32 value
+static DPLL_PIN_ID: [u8; 8] = [
+    0x08, 0x00, // length = 8
+    0x01, 0x00, // type = 1 = DPLL_A_PIN_ID
+    0x2a, 0x00, 0x00, 0x00, // value = 42 (little-endian)
+];
+
+#[test]
+fn parse_dpll_pin_id() {
+    let nla = NlaBuffer::new_checked(&DPLL_PIN_ID[..]).unwrap();
+    let parsed = DpllPin::parse(&nla).unwrap();
+    assert_eq!(parsed, DpllPin::PinId(42));
+}
+
+#[test]
+fn emit_dpll_pin_id() {
+    let nla = DpllPin::PinId(42);
+    assert_eq!(nla.buffer_len(), 8);
+
+    let mut buf = vec![0u8; 8];
+    nla.emit(&mut buf);
+    assert_eq!(&buf[..], &DPLL_PIN_ID[..]);
+}
+
+#[test]
+fn parse_unknown_dpll_pin_attr() {
+    // An NLA with type=99 (unknown), value = [0xde, 0xad]
+    let raw: [u8; 8] = [
+        0x06, 0x00, // length = 6
+        0x63, 0x00, // type = 99 (unknown)
+        0xde, 0xad, // value bytes
+        0x00, 0x00, // padding
+    ];
+    let nla = NlaBuffer::new_checked(&raw[..]).unwrap();
+    let parsed = DpllPin::parse(&nla).unwrap();
+    assert!(matches!(parsed, DpllPin::Other(_)));
+}

--- a/src/link/tests/mod.rs
+++ b/src/link/tests/mod.rs
@@ -7,6 +7,8 @@ mod bond;
 #[cfg(test)]
 mod bridge;
 #[cfg(test)]
+mod dpll_pin;
+#[cfg(test)]
 mod geneve;
 #[cfg(test)]
 mod gre;


### PR DESCRIPTION
It require real hardware to test capture, hence no real unit test case.