### PR TITLE
bond: add FromStr/Display for BondAllPortActive

### DIFF
--- a/src/link/link_info/bond.rs
+++ b/src/link/link_info/bond.rs
@@ -688,6 +688,34 @@ impl From<BondAllPortActive> for u8 {
     }
 }
 
+impl std::fmt::Display for BondAllPortActive {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BondAllPortActive::Dropped => f.write_str("dropped"),
+            BondAllPortActive::Delivered => f.write_str("delivered"),
+            BondAllPortActive::Other(v) => write!(f, "{v}"),
+        }
+    }
+}
+
+impl std::str::FromStr for BondAllPortActive {
+    type Err = DecodeError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "dropped" => Self::Dropped,
+            "delivered" => Self::Delivered,
+            "0" => Self::Dropped,
+            "1" => Self::Delivered,
+            _ => {
+                return Err(DecodeError::from(format!(
+                    "unknown bond all ports active: {s}"
+                )))
+            }
+        })
+    }
+}
+
 const AD_LACP_SLOW: u8 = 0;
 const AD_LACP_FAST: u8 = 1;
 

--- a/src/link/tests/bond.rs
+++ b/src/link/tests/bond.rs
@@ -324,3 +324,20 @@ fn test_bond_lacp_rate_from_str() {
     assert_eq!(BondLacpRate::Fast, "fast".parse().unwrap());
     assert!(BondLacpRate::from_str("bogus").is_err());
 }
+
+#[test]
+fn test_bond_all_ports_active_from_str() {
+    use std::str::FromStr;
+    assert_eq!(BondAllPortActive::Dropped, "dropped".parse().unwrap());
+    assert_eq!(BondAllPortActive::Delivered, "delivered".parse().unwrap());
+    assert_eq!(BondAllPortActive::Dropped, "0".parse().unwrap());
+    assert_eq!(BondAllPortActive::Delivered, "1".parse().unwrap());
+    assert!(BondAllPortActive::from_str("bogus").is_err());
+}
+
+#[test]
+fn test_bond_all_ports_active_display() {
+    assert_eq!("dropped", BondAllPortActive::Dropped.to_string());
+    assert_eq!("delivered", BondAllPortActive::Delivered.to_string());
+    assert_eq!("255", BondAllPortActive::Other(255).to_string());
+}


### PR DESCRIPTION
Introduced support for parsing and displaying BondAllPortActive.
FromStr accepts "dropped", "delivered", "0", and "1".

