### PR TITLE
link: add Display + FromStr impls for netkit enums

### DIFF
--- a/src/link/link_info/netkit.rs
+++ b/src/link/link_info/netkit.rs
@@ -38,6 +38,28 @@ impl From<u32> for NetkitMode {
     }
 }
 
+impl std::fmt::Display for NetkitMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::L2 => f.write_str("l2"),
+            Self::L3 => f.write_str("l3"),
+            Self::Other(v) => write!(f, "{v}"),
+        }
+    }
+}
+
+impl std::str::FromStr for NetkitMode {
+    type Err = DecodeError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "l2" => Ok(Self::L2),
+            "l3" => Ok(Self::L3),
+            _ => Err(DecodeError::from(format!("unknown netkit mode: {s}"))),
+        }
+    }
+}
+
 const NETKIT_PASS: u32 = 0;
 const NETKIT_DROP: u32 = 2;
 const NETKIT_REDIRECT: u32 = 7;
@@ -78,6 +100,30 @@ impl From<u32> for NetkitPolicy {
     }
 }
 
+impl std::fmt::Display for NetkitPolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pass => f.write_str("forward"),
+            Self::Drop => f.write_str("blackhole"),
+            Self::Redirect => f.write_str("redirect"),
+            Self::Other(v) => write!(f, "{v}"),
+        }
+    }
+}
+
+impl std::str::FromStr for NetkitPolicy {
+    type Err = DecodeError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "forward" => Ok(Self::Pass),
+            "blackhole" => Ok(Self::Drop),
+            "redirect" => Ok(Self::Redirect),
+            _ => Err(DecodeError::from(format!("unknown netkit policy: {s}"))),
+        }
+    }
+}
+
 const NETKIT_SCRUB_NONE: u32 = 0;
 const NETKIT_SCRUB_DEFAULT: u32 = 1;
 
@@ -102,6 +148,27 @@ impl From<u32> for NetkitScrub {
         match value {
             NETKIT_SCRUB_NONE => NetkitScrub::None,
             _ => NetkitScrub::Default,
+        }
+    }
+}
+
+impl std::fmt::Display for NetkitScrub {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => f.write_str("none"),
+            Self::Default => f.write_str("default"),
+        }
+    }
+}
+
+impl std::str::FromStr for NetkitScrub {
+    type Err = DecodeError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "none" => Ok(Self::None),
+            "default" => Ok(Self::Default),
+            _ => Err(DecodeError::from(format!("unknown netkit scrub: {s}"))),
         }
     }
 }

--- a/src/link/tests/netkit.rs
+++ b/src/link/tests/netkit.rs
@@ -6,7 +6,7 @@ use crate::{
     link::{
         InfoData, InfoKind, InfoNetkit, LinkAttribute, LinkHeader, LinkInfo,
         LinkLayerType, LinkMessage, LinkMessageBuffer, NetkitMode,
-        NetkitPolicy,
+        NetkitPolicy, NetkitScrub,
     },
     AddressFamily,
 };
@@ -84,4 +84,52 @@ fn test_create_netkit() {
     expected.emit(&mut buf);
 
     assert_eq!(buf, raw);
+}
+
+#[test]
+fn test_netkit_mode_display() {
+    assert_eq!("l2", NetkitMode::L2.to_string());
+    assert_eq!("l3", NetkitMode::L3.to_string());
+    assert_eq!("255", NetkitMode::Other(255).to_string());
+}
+
+#[test]
+fn test_netkit_mode_from_str() {
+    use std::str::FromStr;
+    assert_eq!(NetkitMode::L2, "l2".parse().unwrap());
+    assert_eq!(NetkitMode::L3, "l3".parse().unwrap());
+    assert!(NetkitMode::from_str("42").is_err());
+    assert!(NetkitMode::from_str("bogus").is_err());
+}
+
+#[test]
+fn test_netkit_policy_display() {
+    assert_eq!("forward", NetkitPolicy::Pass.to_string());
+    assert_eq!("blackhole", NetkitPolicy::Drop.to_string());
+    assert_eq!("redirect", NetkitPolicy::Redirect.to_string());
+    assert_eq!("255", NetkitPolicy::Other(255).to_string());
+}
+
+#[test]
+fn test_netkit_policy_from_str() {
+    use std::str::FromStr;
+    assert_eq!(NetkitPolicy::Pass, "forward".parse().unwrap());
+    assert_eq!(NetkitPolicy::Drop, "blackhole".parse().unwrap());
+    assert_eq!(NetkitPolicy::Redirect, "redirect".parse().unwrap());
+    assert!(NetkitPolicy::from_str("42").is_err());
+    assert!(NetkitPolicy::from_str("bogus").is_err());
+}
+
+#[test]
+fn test_netkit_scrub_display() {
+    assert_eq!("none", NetkitScrub::None.to_string());
+    assert_eq!("default", NetkitScrub::Default.to_string());
+}
+
+#[test]
+fn test_netkit_scrub_from_str() {
+    use std::str::FromStr;
+    assert_eq!(NetkitScrub::None, "none".parse().unwrap());
+    assert_eq!(NetkitScrub::Default, "default".parse().unwrap());
+    assert!(NetkitScrub::from_str("bogus").is_err());
 }


### PR DESCRIPTION
Add Display and FromStr implementations for NetkitMode, NetkitPolicy,
and NetkitScrub, matching the strings used by iproute2.