### PR TITLE
link: Add numeric fallbacks to FromStr for bond enums

### DIFF
--- a/src/link/link_info/bond.rs
+++ b/src/link/link_info/bond.rs
@@ -229,13 +229,13 @@ impl std::str::FromStr for BondMode {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s {
-            "balance-rr" => Self::BalanceRr,
-            "active-backup" => Self::ActiveBackup,
-            "balance-xor" => Self::BalanceXor,
-            "broadcast" => Self::Broadcast,
-            "802.3ad" => Self::Ieee8023Ad,
-            "balance-tlb" => Self::BalanceTlb,
-            "balance-alb" => Self::BalanceAlb,
+            "balance-rr" | "0" => Self::BalanceRr,
+            "active-backup" | "1" => Self::ActiveBackup,
+            "balance-xor" | "2" => Self::BalanceXor,
+            "broadcast" | "3" => Self::Broadcast,
+            "802.3ad" | "4" => Self::Ieee8023Ad,
+            "balance-tlb" | "5" => Self::BalanceTlb,
+            "balance-alb" | "6" => Self::BalanceAlb,
             _ => {
                 return Err(DecodeError::from(format!(
                     "unknown bond mode: {s}"
@@ -312,13 +312,13 @@ impl std::str::FromStr for BondArpValidate {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s {
-            "none" => Self::None,
-            "active" => Self::Active,
-            "backup" => Self::Backup,
-            "all" => Self::All,
-            "filter" => Self::Filter,
-            "filter_active" => Self::FilterActive,
-            "filter_backup" => Self::FilterBackup,
+            "none" | "0" => Self::None,
+            "active" | "1" => Self::Active,
+            "backup" | "2" => Self::Backup,
+            "all" | "3" => Self::All,
+            "filter" | "4" => Self::Filter,
+            "filter_active" | "5" => Self::FilterActive,
+            "filter_backup" | "6" => Self::FilterBackup,
             _ => {
                 return Err(DecodeError::from(format!(
                     "unknown bond arp validate: {s}"
@@ -379,9 +379,9 @@ impl std::str::FromStr for BondPrimaryReselect {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s {
-            "always" => Self::Always,
-            "better" => Self::Better,
-            "failure" => Self::Failure,
+            "always" | "0" => Self::Always,
+            "better" | "1" => Self::Better,
+            "failure" | "2" => Self::Failure,
             _ => {
                 return Err(DecodeError::from(format!(
                     "unknown bond primary reselect: {s}"
@@ -454,12 +454,12 @@ impl std::str::FromStr for BondXmitHashPolicy {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s {
-            "layer2" => Self::Layer2,
-            "layer3+4" => Self::Layer34,
-            "layer2+3" => Self::Layer23,
-            "encap2+3" => Self::Encap23,
-            "encap3+4" => Self::Encap34,
-            "vlan+srcmac" => Self::VlanSrcMac,
+            "layer2" | "0" => Self::Layer2,
+            "layer3+4" | "1" => Self::Layer34,
+            "layer2+3" | "2" => Self::Layer23,
+            "encap2+3" | "3" => Self::Encap23,
+            "encap3+4" | "4" => Self::Encap34,
+            "vlan+srcmac" | "5" => Self::VlanSrcMac,
             _ => {
                 return Err(DecodeError::from(format!(
                     "unknown bond xmit hash policy: {s}"
@@ -516,8 +516,8 @@ impl std::str::FromStr for BondArpAllTargets {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s {
-            "any" => Self::Any,
-            "all" => Self::All,
+            "any" | "0" => Self::Any,
+            "all" | "1" => Self::All,
             _ => {
                 return Err(DecodeError::from(format!(
                     "unknown bond arp all targets: {s}"
@@ -578,9 +578,9 @@ impl std::str::FromStr for BondFailOverMac {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s {
-            "none" => Self::None,
-            "active" => Self::Active,
-            "follow" => Self::Follow,
+            "none" | "0" => Self::None,
+            "active" | "1" => Self::Active,
+            "follow" | "2" => Self::Follow,
             _ => {
                 return Err(DecodeError::from(format!(
                     "unknown bond fail over mac: {s}"
@@ -763,8 +763,8 @@ impl std::str::FromStr for BondLacpRate {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s {
-            "slow" => Self::Slow,
-            "fast" => Self::Fast,
+            "slow" | "0" => Self::Slow,
+            "fast" | "1" => Self::Fast,
             _ => {
                 return Err(DecodeError::from(format!(
                     "unknown bond lacp rate: {s}"
@@ -833,10 +833,10 @@ impl std::str::FromStr for BondAdSelect {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s {
-            "stable" => Self::Stable,
-            "bandwidth" => Self::Bandwidth,
-            "count" => Self::Count,
-            "actor_port_prio" => Self::ActorPortPrio,
+            "stable" | "0" => Self::Stable,
+            "bandwidth" | "1" => Self::Bandwidth,
+            "count" | "2" => Self::Count,
+            "actor_port_prio" | "3" => Self::ActorPortPrio,
             _ => {
                 return Err(DecodeError::from(format!(
                     "unknown bond ad select: {s}"

--- a/src/link/tests/bond.rs
+++ b/src/link/tests/bond.rs
@@ -241,6 +241,13 @@ fn test_bond_mode_from_str() {
     assert_eq!(BondMode::Ieee8023Ad, "802.3ad".parse().unwrap());
     assert_eq!(BondMode::BalanceTlb, "balance-tlb".parse().unwrap());
     assert_eq!(BondMode::BalanceAlb, "balance-alb".parse().unwrap());
+    assert_eq!(BondMode::BalanceRr, "0".parse().unwrap());
+    assert_eq!(BondMode::ActiveBackup, "1".parse().unwrap());
+    assert_eq!(BondMode::BalanceXor, "2".parse().unwrap());
+    assert_eq!(BondMode::Broadcast, "3".parse().unwrap());
+    assert_eq!(BondMode::Ieee8023Ad, "4".parse().unwrap());
+    assert_eq!(BondMode::BalanceTlb, "5".parse().unwrap());
+    assert_eq!(BondMode::BalanceAlb, "6".parse().unwrap());
     assert!(BondMode::from_str("bogus").is_err());
 }
 
@@ -260,6 +267,13 @@ fn test_bond_arp_validate_from_str() {
         BondArpValidate::FilterBackup,
         "filter_backup".parse().unwrap()
     );
+    assert_eq!(BondArpValidate::None, "0".parse().unwrap());
+    assert_eq!(BondArpValidate::Active, "1".parse().unwrap());
+    assert_eq!(BondArpValidate::Backup, "2".parse().unwrap());
+    assert_eq!(BondArpValidate::All, "3".parse().unwrap());
+    assert_eq!(BondArpValidate::Filter, "4".parse().unwrap());
+    assert_eq!(BondArpValidate::FilterActive, "5".parse().unwrap());
+    assert_eq!(BondArpValidate::FilterBackup, "6".parse().unwrap());
     assert!(BondArpValidate::from_str("bogus").is_err());
 }
 
@@ -269,6 +283,9 @@ fn test_bond_primary_reselect_from_str() {
     assert_eq!(BondPrimaryReselect::Always, "always".parse().unwrap());
     assert_eq!(BondPrimaryReselect::Better, "better".parse().unwrap());
     assert_eq!(BondPrimaryReselect::Failure, "failure".parse().unwrap());
+    assert_eq!(BondPrimaryReselect::Always, "0".parse().unwrap());
+    assert_eq!(BondPrimaryReselect::Better, "1".parse().unwrap());
+    assert_eq!(BondPrimaryReselect::Failure, "2".parse().unwrap());
     assert!(BondPrimaryReselect::from_str("bogus").is_err());
 }
 
@@ -284,6 +301,12 @@ fn test_bond_xmit_hash_policy_from_str() {
         BondXmitHashPolicy::VlanSrcMac,
         "vlan+srcmac".parse().unwrap()
     );
+    assert_eq!(BondXmitHashPolicy::Layer2, "0".parse().unwrap());
+    assert_eq!(BondXmitHashPolicy::Layer34, "1".parse().unwrap());
+    assert_eq!(BondXmitHashPolicy::Layer23, "2".parse().unwrap());
+    assert_eq!(BondXmitHashPolicy::Encap23, "3".parse().unwrap());
+    assert_eq!(BondXmitHashPolicy::Encap34, "4".parse().unwrap());
+    assert_eq!(BondXmitHashPolicy::VlanSrcMac, "5".parse().unwrap());
     assert!(BondXmitHashPolicy::from_str("bogus").is_err());
 }
 
@@ -292,6 +315,8 @@ fn test_bond_arp_all_targets_from_str() {
     use std::str::FromStr;
     assert_eq!(BondArpAllTargets::Any, "any".parse().unwrap());
     assert_eq!(BondArpAllTargets::All, "all".parse().unwrap());
+    assert_eq!(BondArpAllTargets::Any, "0".parse().unwrap());
+    assert_eq!(BondArpAllTargets::All, "1".parse().unwrap());
     assert!(BondArpAllTargets::from_str("bogus").is_err());
 }
 
@@ -301,6 +326,9 @@ fn test_bond_fail_over_mac_from_str() {
     assert_eq!(BondFailOverMac::None, "none".parse().unwrap());
     assert_eq!(BondFailOverMac::Active, "active".parse().unwrap());
     assert_eq!(BondFailOverMac::Follow, "follow".parse().unwrap());
+    assert_eq!(BondFailOverMac::None, "0".parse().unwrap());
+    assert_eq!(BondFailOverMac::Active, "1".parse().unwrap());
+    assert_eq!(BondFailOverMac::Follow, "2".parse().unwrap());
     assert!(BondFailOverMac::from_str("bogus").is_err());
 }
 
@@ -314,6 +342,10 @@ fn test_bond_ad_select_from_str() {
         BondAdSelect::ActorPortPrio,
         "actor_port_prio".parse().unwrap()
     );
+    assert_eq!(BondAdSelect::Stable, "0".parse().unwrap());
+    assert_eq!(BondAdSelect::Bandwidth, "1".parse().unwrap());
+    assert_eq!(BondAdSelect::Count, "2".parse().unwrap());
+    assert_eq!(BondAdSelect::ActorPortPrio, "3".parse().unwrap());
     assert!(BondAdSelect::from_str("bogus").is_err());
 }
 
@@ -322,6 +354,8 @@ fn test_bond_lacp_rate_from_str() {
     use std::str::FromStr;
     assert_eq!(BondLacpRate::Slow, "slow".parse().unwrap());
     assert_eq!(BondLacpRate::Fast, "fast".parse().unwrap());
+    assert_eq!(BondLacpRate::Slow, "0".parse().unwrap());
+    assert_eq!(BondLacpRate::Fast, "1".parse().unwrap());
     assert!(BondLacpRate::from_str("bogus").is_err());
 }
 


### PR DESCRIPTION
Introduced support for parsing numeric values in:
 * `BondMode`
 * `BondArpValidate`
 * `BondPrimaryReselect`
 * `BondXmitHashPolicy`
 * `BondArpAllTargets`
 * `BondFailOverMac`
 * `BondAdSelect`
 * `BondLacpRate`
 * `BondAllPortActive`

Unit tests are included.