### PR TITLE
link: use 802.1Q for VlanProtocol::Ieee8021Q display

### DIFF
--- a/src/link/tests/bridge.rs
+++ b/src/link/tests/bridge.rs
@@ -1358,7 +1358,7 @@ fn test_bridge_port_state_from_str() {
 
 #[test]
 fn test_vlan_protocol_display() {
-    assert_eq!("802.1q", VlanProtocol::Ieee8021Q.to_string());
+    assert_eq!("802.1Q", VlanProtocol::Ieee8021Q.to_string());
     assert_eq!("802.1ad", VlanProtocol::Ieee8021Ad.to_string());
 }
 

--- a/src/link/vlan_protocol.rs
+++ b/src/link/vlan_protocol.rs
@@ -47,7 +47,7 @@ impl std::fmt::Display for VlanProtocol {
             f,
             "{}",
             match self {
-                VlanProtocol::Ieee8021Q => "802.1q",
+                VlanProtocol::Ieee8021Q => "802.1Q",
                 VlanProtocol::Ieee8021Ad => "802.1ad",
             }
         )


### PR DESCRIPTION
Align the Display output of `VlanProtocol::Ieee8021Q` with iproute2, which uses "802.1Q" instead of "802.1q".