### PR TITLE
link: derive IFLA_MAP size from the target ABI

### DIFF
--- a/src/link/map.rs
+++ b/src/link/map.rs
@@ -2,9 +2,43 @@
 
 use netlink_packet_core::{DecodeError, Emitable, Parseable};
 
-const LINK_MAP_LEN: usize = 32;
+/// Mirror of the kernel's `struct rtnl_link_ifmap`.
+///
+/// Never constructed; it exists so that `size_of` yields the layout the
+/// kernel's C compiler produces for *this* target. `repr(C)` is what makes
+/// that equivalence hold, since it applies the target's C ABI rules.
+#[repr(C)]
+struct RtnlLinkIfmap {
+    mem_start: u64,
+    mem_end: u64,
+    base_addr: u64,
+    irq: u16,
+    dma: u8,
+    port: u8,
+}
 
-buffer!(MapBuffer(LINK_MAP_LEN) {
+/// Bytes the six fields themselves occupy.
+///
+/// Every ABI places them at the same offsets (0, 8, 16, 24, 26, 27); only the
+/// trailing alignment padding differs. This is therefore the shortest payload
+/// that still carries a complete map, and the minimum accepted when parsing.
+const LINK_MAP_FIELDS_LEN: usize = 28;
+
+/// Size of `struct rtnl_link_ifmap` as the running kernel lays it out: 28
+/// where `u64` is 4-byte aligned (the i386 psABI), 32 where it is 8-byte
+/// aligned (x86-64, arm, aarch64 -- the extra 4 bytes being trailing
+/// padding). Used when emitting, so a map we produce is the size the local
+/// kernel expects.
+const LINK_MAP_LEN: usize = std::mem::size_of::<RtnlLinkIfmap>();
+
+const _: () = assert!(
+    LINK_MAP_LEN >= LINK_MAP_FIELDS_LEN,
+    "rtnl_link_ifmap cannot be smaller than its own fields"
+);
+
+// The generated length check is a *minimum*, so declaring the fields' length
+// here accepts both the padded (32-byte) and unpadded (28-byte) forms.
+buffer!(MapBuffer(LINK_MAP_FIELDS_LEN) {
     memory_start: (u64, 0..8),
     memory_end: (u64, 8..16),
     base_address: (u64, 16..24),
@@ -43,6 +77,9 @@ impl Emitable for Map {
     }
 
     fn emit(&self, buffer: &mut [u8]) {
+        // Zero any trailing alignment padding rather than leaving whatever
+        // the caller's buffer happened to hold.
+        buffer[LINK_MAP_FIELDS_LEN..LINK_MAP_LEN].fill(0);
         let mut buffer = MapBuffer::new(buffer);
         buffer.set_memory_start(self.memory_start);
         buffer.set_memory_end(self.memory_end);

--- a/src/link/tests/map.rs
+++ b/src/link/tests/map.rs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+
+use netlink_packet_core::{Emitable, NlaBuffer, ParseableParametrized};
+
+use crate::{
+    link::{LinkAttribute, Map},
+    AddressFamily,
+};
+
+// `struct rtnl_link_ifmap` is three u64 followed by u16 + u8 + u8. Those
+// fields always sit at offsets 0/8/16/24/26/27, but the struct's size follows
+// the target's `u64` alignment: 32 bytes where it is 8 (x86-64, arm, aarch64)
+// and 28 where it is 4 (the i386 psABI). The kernel emits IFLA_MAP at its own
+// native size, so both forms appear on the wire and both must parse.
+
+const IFLA_MAP: u16 = 14;
+
+const EXPECTED: Map = Map {
+    memory_start: 0xdead_beef_0000_1000,
+    memory_end: 0xdead_beef_0000_2000,
+    base_address: 0x0000_0000_0000_c000,
+    irq: 11,
+    dma: 3,
+    port: 1,
+};
+
+/// The 28 bytes the six fields occupy, identical on every ABI.
+const FIELD_BYTES: [u8; 28] = [
+    0x00, 0x10, 0x00, 0x00, 0xef, 0xbe, 0xad, 0xde, // memory_start
+    0x00, 0x20, 0x00, 0x00, 0xef, 0xbe, 0xad, 0xde, // memory_end
+    0x00, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // base_address
+    0x0b, 0x00, // irq 11
+    0x03, // dma 3
+    0x01, // port 1
+];
+
+fn parse(payload: &[u8]) -> LinkAttribute {
+    let mut raw = Vec::new();
+    raw.extend_from_slice(&(payload.len() as u16 + 4).to_ne_bytes());
+    raw.extend_from_slice(&IFLA_MAP.to_ne_bytes());
+    raw.extend_from_slice(payload);
+
+    LinkAttribute::parse_with_param(
+        &NlaBuffer::new_checked(&raw[..]).unwrap(),
+        AddressFamily::Unspec,
+    )
+    .unwrap()
+}
+
+/// The padded 32-byte form a 64-bit or ARM kernel emits.
+#[test]
+fn test_link_map_padded_32_bytes() {
+    let mut payload = FIELD_BYTES.to_vec();
+    payload.extend_from_slice(&[0x00; 4]); // trailing alignment padding
+    assert_eq!(payload.len(), 32);
+    assert_eq!(parse(&payload), LinkAttribute::Map(EXPECTED));
+}
+
+/// The unpadded 28-byte form a 32-bit x86 kernel emits. This previously failed
+/// with "Invalid buffer MapBuffer. Expected at least 32 bytes, received 28
+/// bytes" which, because one bad NLA fails the whole message, dropped every
+/// RTM_GETLINK reply on i586/i686.
+#[test]
+fn test_link_map_unpadded_28_bytes() {
+    assert_eq!(FIELD_BYTES.len(), 28);
+    assert_eq!(parse(&FIELD_BYTES), LinkAttribute::Map(EXPECTED));
+}
+
+/// Both forms decode to the same value: the padding is not significant.
+#[test]
+fn test_link_map_padding_is_not_significant() {
+    let mut padded = FIELD_BYTES.to_vec();
+    padded.extend_from_slice(&[0x00; 4]);
+    assert_eq!(parse(&padded), parse(&FIELD_BYTES));
+}
+
+/// Emitting produces this target's native size, and round-trips.
+#[test]
+fn test_link_map_emit_uses_native_size() {
+    let attr = LinkAttribute::Map(EXPECTED);
+    let mut buf = vec![0u8; attr.buffer_len()];
+    attr.emit(&mut buf);
+
+    // Payload is the NLA header (4) plus the native struct size: 28 on i386,
+    // 32 wherever `u64` is 8-byte aligned.
+    let payload = &buf[4..];
+    assert_eq!(payload.len(), EXPECTED.buffer_len());
+    assert!(matches!(payload.len(), 28 | 32));
+    assert_eq!(&payload[..28], &FIELD_BYTES[..]);
+
+    assert_eq!(parse(payload), LinkAttribute::Map(EXPECTED));
+}

--- a/src/link/tests/mod.rs
+++ b/src/link/tests/mod.rs
@@ -16,6 +16,7 @@ mod loopback;
 mod macsec;
 mod macvlan;
 mod macvtap;
+mod map;
 mod message;
 mod netdevsim;
 mod netkit;


### PR DESCRIPTION
IFLA_MAP carries `struct rtnl_link_ifmap`: three u64 followed by u16 + u8 + u8. Its fields always sit at offsets 0/8/16/24/26/27, but the struct's size follows the target's u64 alignment - 32 bytes where that is 8 (x86-64, armv7, aarch64) and 28 where it is 4 (the i386 psABI). The kernel fills the attribute with its own native sizeof, so a 32-bit x86 kernel emits 28 bytes.

LINK_MAP_LEN was hardcoded to 32, so on i586/i686 every IFLA_MAP was rejected with "Expected at least 32 bytes, received 28 bytes". Since LinkMessage::parse propagates an error from any single NLA, one unparseable IFLA_MAP discards the entire link message - and every link carries one, so an RTM_GETLINK dump yielded zero links on those targets.

Note this is not a 32- vs 64-bit split: 32-bit ARM aligns u64 to 8 under AAPCS and gets the padded 32-byte struct. Only the i386 psABI produces 28, which is why this went unnoticed.

Split the constant in two:

  - Parsing uses the 28 bytes the fields occupy. The generated length check is a minimum, so this accepts both the padded and unpadded forms, and the getters are unchanged since the offsets are ABI-invariant.

  - Emitting takes size_of of a #[repr(C)] mirror of the kernel struct, so the size follows the target's C ABI and matches what the local kernel expects. Trailing padding is now explicitly zeroed.

Add regression tests covering both wire forms and the emit round-trip.