### PR TITLE
Build error context lazily when using format!()

### DIFF
--- a/src/address/attribute.rs
+++ b/src/address/attribute.rs
@@ -176,10 +176,11 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                     )));
                 }
             }
-            IFA_CACHEINFO => Self::CacheInfo(
-                CacheInfo::parse(payload)
-                    .context(format!("Invalid IFA_CACHEINFO {payload:?}"))?,
-            ),
+            IFA_CACHEINFO => {
+                Self::CacheInfo(CacheInfo::parse(payload).with_context(
+                    || format!("Invalid IFA_CACHEINFO {payload:?}"),
+                )?)
+            }
             IFA_MULTICAST => {
                 if payload.len() == IPV6_ADDR_LEN {
                     let mut data = [0u8; IPV6_ADDR_LEN];
@@ -207,7 +208,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
             ),
             kind => Self::Other(
                 DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {kind}"))?,
+                    .with_context(|| format!("unknown NLA type {kind}"))?,
             ),
         })
     }

--- a/src/link/af_spec/bridge.rs
+++ b/src/link/af_spec/bridge.rs
@@ -78,9 +78,11 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for AfSpecBridge {
             IFLA_BRIDGE_VLAN_TUNNEL_INFO => {
                 let mut nlas = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
+                    let nla = &nla.with_context(|| {
+                        format!(
                         "Invalid IFLA_BRIDGE_VLAN_TUNNEL_INFO for {payload:?}"
-                    ))?;
+                    )
+                    })?;
                     let parsed = BridgeVlanTunnelInfo::parse(nla)?;
                     nlas.push(parsed);
                 }
@@ -88,7 +90,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for AfSpecBridge {
             }
             kind => Self::Other(
                 DefaultNla::parse(buf)
-                    .context(format!("Unknown NLA type {kind}"))?,
+                    .with_context(|| format!("Unknown NLA type {kind}"))?,
             ),
         })
     }
@@ -171,13 +173,13 @@ impl TryFrom<&[u8]> for BridgeVlanInfo {
         if raw.len() == 4 {
             Ok(Self {
                 flags: BridgeVlanInfoFlags::from_bits_retain(
-                    parse_u16(&raw[0..2]).context(format!(
-                        "Invalid IFLA_BRIDGE_VLAN_INFO value: {raw:?}"
-                    ))?,
+                    parse_u16(&raw[0..2]).with_context(|| {
+                        format!("Invalid IFLA_BRIDGE_VLAN_INFO value: {raw:?}")
+                    })?,
                 ),
-                vid: parse_u16(&raw[2..4]).context(format!(
-                    "Invalid IFLA_BRIDGE_VLAN_INFO value: {raw:?}"
-                ))?,
+                vid: parse_u16(&raw[2..4]).with_context(|| {
+                    format!("Invalid IFLA_BRIDGE_VLAN_INFO value: {raw:?}")
+                })?,
             })
         } else {
             Err(DecodeError::from(format!(
@@ -360,20 +362,22 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
         let payload = buf.value();
         Ok(match buf.kind() {
             IFLA_BRIDGE_VLAN_TUNNEL_ID => {
-                Self::Id(parse_u32(payload).context(format!(
-                    "Invalid IFLA_BRIDGE_VLAN_TUNNEL_ID {payload:?}"
-                ))?)
+                Self::Id(parse_u32(payload).with_context(|| {
+                    format!("Invalid IFLA_BRIDGE_VLAN_TUNNEL_ID {payload:?}")
+                })?)
             }
             IFLA_BRIDGE_VLAN_TUNNEL_VID => {
-                Self::Vid(parse_u16(payload).context(format!(
-                    "Invalid IFLA_BRIDGE_VLAN_TUNNEL_VID {payload:?}"
-                ))?)
+                Self::Vid(parse_u16(payload).with_context(|| {
+                    format!("Invalid IFLA_BRIDGE_VLAN_TUNNEL_VID {payload:?}")
+                })?)
             }
             IFLA_BRIDGE_VLAN_TUNNEL_FLAGS => {
                 Self::Flags(BridgeVlanInfoFlags::from_bits_retain(
-                    parse_u16(payload).context(format!(
-                        "Invalid IFLA_BRIDGE_VLAN_TUNNEL_VID {payload:?}"
-                    ))?,
+                    parse_u16(payload).with_context(|| {
+                        format!(
+                            "Invalid IFLA_BRIDGE_VLAN_TUNNEL_VID {payload:?}"
+                        )
+                    })?,
                 ))
             }
             _ => {

--- a/src/link/af_spec/inet.rs
+++ b/src/link/af_spec/inet.rs
@@ -117,9 +117,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for AfSpecInet {
                 )
                 .as_slice(),
             )?),
-            kind => Self::Other(DefaultNla::parse(buf).context(format!(
-                "Unknown NLA type {kind} for IFLA_AF_SPEC(inet)"
-            ))?),
+            kind => Self::Other(DefaultNla::parse(buf).with_context(|| {
+                format!("Unknown NLA type {kind} for IFLA_AF_SPEC(inet)")
+            })?),
         })
     }
 }

--- a/src/link/af_spec/inet6.rs
+++ b/src/link/af_spec/inet6.rs
@@ -106,11 +106,11 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for AfSpecInet6 {
             IFLA_INET6_FLAGS => Self::Flags(Inet6IfaceFlags::from_bits_retain(
                 parse_u32(payload).context("invalid IFLA_INET6_FLAGS value")?,
             )),
-            IFLA_INET6_CACHEINFO => {
-                Self::CacheInfo(Inet6CacheInfo::parse(payload).context(
-                    format!("invalid IFLA_INET6_CACHEINFO value {payload:?}"),
-                )?)
-            }
+            IFLA_INET6_CACHEINFO => Self::CacheInfo(
+                Inet6CacheInfo::parse(payload).with_context(|| {
+                    format!("invalid IFLA_INET6_CACHEINFO value {payload:?}")
+                })?,
+            ),
             IFLA_INET6_CONF => Self::DevConf(
                 Inet6DevConf::parse(
                     expand_buffer_if_small(
@@ -120,9 +120,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for AfSpecInet6 {
                     )
                     .as_slice(),
                 )
-                .context(format!(
-                    "invalid IFLA_INET6_CONF value {payload:?}"
-                ))?,
+                .with_context(|| {
+                    format!("invalid IFLA_INET6_CONF value {payload:?}")
+                })?,
             ),
             IFLA_INET6_STATS => Self::Stats(
                 Inet6Stats::parse(
@@ -133,9 +133,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for AfSpecInet6 {
                     )
                     .as_slice(),
                 )
-                .context(format!(
-                    "invalid IFLA_INET6_STATS value {payload:?}"
-                ))?,
+                .with_context(|| {
+                    format!("invalid IFLA_INET6_STATS value {payload:?}")
+                })?,
             ),
             IFLA_INET6_ICMP6STATS => Self::Icmp6Stats(
                 Icmp6Stats::parse(
@@ -146,9 +146,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for AfSpecInet6 {
                     )
                     .as_slice(),
                 )
-                .context(format!(
-                    "invalid IFLA_INET6_ICMP6STATS value {payload:?}"
-                ))?,
+                .with_context(|| {
+                    format!("invalid IFLA_INET6_ICMP6STATS value {payload:?}")
+                })?,
             ),
             IFLA_INET6_TOKEN => Self::Token(
                 parse_ipv6_addr(payload)
@@ -163,9 +163,11 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for AfSpecInet6 {
                 parse_u32(payload)
                     .context("invalid IFLA_INET6_RA_MTU value")?,
             ),
-            kind => Self::Other(DefaultNla::parse(buf).context(format!(
+            kind => Self::Other(DefaultNla::parse(buf).with_context(|| {
+                format!(
                 "unknown AF_INET6 NLA type {kind} for IFLA_AF_SPEC(AF_UNSPEC)"
-            ))?),
+            )
+            })?),
         })
     }
 }

--- a/src/link/af_spec/mctp.rs
+++ b/src/link/af_spec/mctp.rs
@@ -103,9 +103,11 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for AfSpecMctp {
                     .context("invalid IFLA_MCTP_PHYS_BINDING value")?;
                 Self::PhysBinding(MctpPhysBinding::from(b))
             }
-            kind => Self::Other(DefaultNla::parse(buf).context(format!(
+            kind => Self::Other(DefaultNla::parse(buf).with_context(|| {
+                format!(
                 "unknown AF_MCTP NLA type {kind} for IFLA_AF_SPEC(AF_UNSPEC)"
-            ))?),
+            )
+            })?),
         })
     }
 }

--- a/src/link/af_spec/unspec.rs
+++ b/src/link/af_spec/unspec.rs
@@ -92,12 +92,14 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                         .0,
                     )
                 }
-                kind => AfSpecUnspec::Other(DefaultNla::parse(&nla).context(
-                    format!(
-                        "Unknown AF_XXX type {kind} for \
+                kind => AfSpecUnspec::Other(
+                    DefaultNla::parse(&nla).with_context(|| {
+                        format!(
+                            "Unknown AF_XXX type {kind} for \
                          IFLA_AF_SPEC(AF_UNSPEC)"
-                    ),
-                )?),
+                        )
+                    })?,
+                ),
             })
         }
         Ok(Self(nlas))

--- a/src/link/attribute.rs
+++ b/src/link/attribute.rs
@@ -431,15 +431,14 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
         let payload = buf.value();
         Ok(match buf.kind() {
             IFLA_VFINFO_LIST => {
-                let err =
-                    |payload| format!("invalid IFLA_VFINFO_LIST {payload:?}");
+                let err = || format!("invalid IFLA_VFINFO_LIST {payload:?}");
                 if !payload.is_empty() {
                     Self::VfInfoList(
                         VecLinkVfInfo::parse(
                             &NlaBuffer::new_checked(payload)
-                                .with_context(|| err(payload))?,
+                                .with_context(err)?,
                         )
-                        .with_context(|| err(payload))?
+                        .with_context(err)?
                         .0,
                     )
                 } else {
@@ -449,26 +448,22 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
                 }
             }
             IFLA_VF_PORTS => {
-                let err =
-                    |payload| format!("invalid IFLA_VF_PORTS {payload:?}");
+                let err = || format!("invalid IFLA_VF_PORTS {payload:?}");
                 Self::VfPorts(
                     VecLinkVfPort::parse(
-                        &NlaBuffer::new_checked(payload)
-                            .with_context(|| err(payload))?,
+                        &NlaBuffer::new_checked(payload).with_context(err)?,
                     )
-                    .with_context(|| err(payload))?
+                    .with_context(err)?
                     .0,
                 )
             }
             IFLA_PORT_SELF => {
-                let err =
-                    |payload| format!("invalid IFLA_PORT_SELF {payload:?}");
+                let err = || format!("invalid IFLA_PORT_SELF {payload:?}");
                 Self::PortSelf(
                     LinkVfPort::parse(
-                        &NlaBuffer::new_checked(payload)
-                            .with_context(|| err(payload))?,
+                        &NlaBuffer::new_checked(payload).with_context(err)?,
                     )
-                    .with_context(|| err(payload))?,
+                    .with_context(err)?,
                 )
             }
             IFLA_PHYS_PORT_ID => {
@@ -482,16 +477,16 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
                 )?)
             }
             IFLA_PROTINFO => {
-                let err = |payload| {
+                let err = || {
                     format!("invalid IFLA_PROTINFO for AF_INET6 {payload:?}")
                 };
                 match interface_family {
                     AddressFamily::Inet6 => Self::ProtoInfoInet6(
                         VecLinkProtoInfoInet6::parse(
                             &NlaBuffer::new_checked(payload)
-                                .with_context(|| err(payload))?,
+                                .with_context(err)?,
                         )
-                        .with_context(|| err(payload))?
+                        .with_context(err)?
                         .0,
                     ),
                     #[cfg(any(
@@ -663,11 +658,8 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
                     .into(),
             ),
             IFLA_MAP => {
-                let err =
-                    |payload| format!("Invalid IFLA_MAP value {payload:?}");
-                Self::Map(
-                    super::Map::parse(payload).with_context(|| err(payload))?,
-                )
+                let err = || format!("Invalid IFLA_MAP value {payload:?}");
+                Self::Map(super::Map::parse(payload).with_context(err)?)
             }
             IFLA_STATS => Self::Stats(
                 super::Stats::parse(

--- a/src/link/attribute.rs
+++ b/src/link/attribute.rs
@@ -658,8 +658,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
                     .into(),
             ),
             IFLA_MAP => {
-                let err = || format!("Invalid IFLA_MAP value {payload:?}");
-                Self::Map(super::Map::parse(payload).with_context(err)?)
+                Self::Map(super::Map::parse(payload).with_context(|| {
+                    format!("Invalid IFLA_MAP value {payload:?}")
+                })?)
             }
             IFLA_STATS => Self::Stats(
                 super::Stats::parse(

--- a/src/link/attribute.rs
+++ b/src/link/attribute.rs
@@ -437,9 +437,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
                     Self::VfInfoList(
                         VecLinkVfInfo::parse(
                             &NlaBuffer::new_checked(payload)
-                                .context(err(payload))?,
+                                .with_context(|| err(payload))?,
                         )
-                        .context(err(payload))?
+                        .with_context(|| err(payload))?
                         .0,
                     )
                 } else {
@@ -454,9 +454,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
                 Self::VfPorts(
                     VecLinkVfPort::parse(
                         &NlaBuffer::new_checked(payload)
-                            .context(err(payload))?,
+                            .with_context(|| err(payload))?,
                     )
-                    .context(err(payload))?
+                    .with_context(|| err(payload))?
                     .0,
                 )
             }
@@ -466,19 +466,19 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
                 Self::PortSelf(
                     LinkVfPort::parse(
                         &NlaBuffer::new_checked(payload)
-                            .context(err(payload))?,
+                            .with_context(|| err(payload))?,
                     )
-                    .context(err(payload))?,
+                    .with_context(|| err(payload))?,
                 )
             }
             IFLA_PHYS_PORT_ID => {
-                Self::PhysPortId(LinkPhysId::parse(payload).context(
-                    format!("invalid IFLA_PHYS_PORT_ID value {payload:?}"),
+                Self::PhysPortId(LinkPhysId::parse(payload).with_context(
+                    || format!("invalid IFLA_PHYS_PORT_ID value {payload:?}"),
                 )?)
             }
             IFLA_PHYS_SWITCH_ID => {
-                Self::PhysSwitchId(LinkPhysId::parse(payload).context(
-                    format!("invalid IFLA_PHYS_SWITCH_ID value {payload:?}"),
+                Self::PhysSwitchId(LinkPhysId::parse(payload).with_context(
+                    || format!("invalid IFLA_PHYS_SWITCH_ID value {payload:?}"),
                 )?)
             }
             IFLA_PROTINFO => {
@@ -489,9 +489,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
                     AddressFamily::Inet6 => Self::ProtoInfoInet6(
                         VecLinkProtoInfoInet6::parse(
                             &NlaBuffer::new_checked(payload)
-                                .context(err(payload))?,
+                                .with_context(|| err(payload))?,
                         )
-                        .context(err(payload))?
+                        .with_context(|| err(payload))?
                         .0,
                     ),
                     #[cfg(any(
@@ -503,23 +503,28 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
                         VecLinkProtoInfoBridge::parse(&NlaBuffer::new_checked(
                             payload,
                         )?)
-                        .context(format!(
+                        .with_context(|| {
+                            format!(
                             "invalid IFLA_PROTINFO for AF_INET6 {payload:?}"
-                        ))?
+                        )
+                        })?
                         .0,
                     ),
                     _ => Self::ProtoInfoUnknown(
-                        DefaultNla::parse(buf).context(format!(
+                        DefaultNla::parse(buf).with_context(|| {
+                            format!(
                             "invalid IFLA_PROTINFO for {interface_family:?}: \
                              {payload:?}"
-                        ))?,
+                        )
+                        })?,
                     ),
                 }
             }
-            IFLA_EVENT => Self::Event(
-                LinkEvent::parse(payload)
-                    .context(format!("invalid IFLA_EVENT {payload:?}"))?,
-            ),
+            IFLA_EVENT => {
+                Self::Event(LinkEvent::parse(payload).with_context(|| {
+                    format!("invalid IFLA_EVENT {payload:?}")
+                })?)
+            }
             IFLA_NEW_NETNSID => Self::NewNetnsId(
                 parse_i32(payload).context("invalid IFLA_NEW_NETNSID value")?,
             ),
@@ -660,7 +665,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
             IFLA_MAP => {
                 let err =
                     |payload| format!("Invalid IFLA_MAP value {payload:?}");
-                Self::Map(super::Map::parse(payload).context(err(payload))?)
+                Self::Map(
+                    super::Map::parse(payload).with_context(|| err(payload))?,
+                )
             }
             IFLA_STATS => Self::Stats(
                 super::Stats::parse(
@@ -671,7 +678,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
                     )
                     .as_slice(),
                 )
-                .context(format!("Invalid IFLA_STATS value {payload:?}"))?,
+                .with_context(|| {
+                    format!("Invalid IFLA_STATS value {payload:?}")
+                })?,
             ),
             IFLA_STATS64 => {
                 let payload = expand_buffer_if_small(
@@ -680,8 +689,8 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
                     "IFLA_STATS64",
                 );
                 Self::Stats64(
-                    super::Stats64::parse(payload.as_slice()).context(
-                        format!("Invalid IFLA_STATS64 value {payload:?}"),
+                    super::Stats64::parse(payload.as_slice()).with_context(
+                        || format!("Invalid IFLA_STATS64 value {payload:?}"),
                     )?,
                 )
             }
@@ -789,7 +798,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
             }
             kind => Self::Other(
                 DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {kind}"))?,
+                    .with_context(|| format!("unknown NLA type {kind}"))?,
             ),
         })
     }

--- a/src/link/devlink_port.rs
+++ b/src/link/devlink_port.rs
@@ -64,10 +64,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for DevlinkPort {
                 parse_u32(payload)
                     .context("invalid DEVLINK_ATTR_PORT_INDEX value")?,
             ),
-            _ => Self::Other(DefaultNla::parse(buf).context(format!(
-                "unknown DEVLINK_ATTR type {}",
-                buf.kind()
-            ))?),
+            _ => Self::Other(DefaultNla::parse(buf).with_context(|| {
+                format!("unknown DEVLINK_ATTR type {}", buf.kind())
+            })?),
         })
     }
 }

--- a/src/link/down_reason.rs
+++ b/src/link/down_reason.rs
@@ -23,19 +23,21 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
         let payload = buf.value();
         Ok(match buf.kind() {
             IFLA_PROTO_DOWN_REASON_MASK => {
-                Self::Mask(parse_u32(payload).context(format!(
-                    "invalid IFLA_PROTO_DOWN_REASON_MASK {payload:?}"
-                ))?)
+                Self::Mask(parse_u32(payload).with_context(|| {
+                    format!("invalid IFLA_PROTO_DOWN_REASON_MASK {payload:?}")
+                })?)
             }
             IFLA_PROTO_DOWN_REASON_VALUE => {
-                Self::Value(parse_u32(payload).context(format!(
-                    "invalid IFLA_PROTO_DOWN_REASON_VALUE {payload:?}"
-                ))?)
+                Self::Value(parse_u32(payload).with_context(|| {
+                    format!("invalid IFLA_PROTO_DOWN_REASON_VALUE {payload:?}")
+                })?)
             }
-            kind => Self::Other(DefaultNla::parse(buf).context(format!(
-                "unknown NLA type {kind} for IFLA_PROTO_DOWN_REASON: \
+            kind => Self::Other(DefaultNla::parse(buf).with_context(|| {
+                format!(
+                    "unknown NLA type {kind} for IFLA_PROTO_DOWN_REASON: \
                  {payload:?}"
-            ))?),
+                )
+            })?),
         })
     }
 }

--- a/src/link/dpll_pin.rs
+++ b/src/link/dpll_pin.rs
@@ -48,12 +48,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for DpllPin {
             DPLL_A_PIN_ID => Self::PinId(
                 parse_u32(payload).context("invalid DPLL_A_PIN_ID value")?,
             ),
-            _ => {
-                Self::Other(DefaultNla::parse(buf).context(format!(
-                    "unknown DPLL_A_PIN type {}",
-                    buf.kind()
-                ))?)
-            }
+            _ => Self::Other(DefaultNla::parse(buf).with_context(|| {
+                format!("unknown DPLL_A_PIN type {}", buf.kind())
+            })?),
         })
     }
 }

--- a/src/link/link_info/amt.rs
+++ b/src/link/link_info/amt.rs
@@ -168,10 +168,11 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoAmt {
                 parse_u32(payload)
                     .context("invalid IFLA_AMT_MAX_TUNNELS value")?,
             ),
-            kind => Self::Other(
-                DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {kind} for amt"))?,
-            ),
+            kind => {
+                Self::Other(DefaultNla::parse(buf).with_context(|| {
+                    format!("unknown NLA type {kind} for amt")
+                })?)
+            }
         })
     }
 }

--- a/src/link/link_info/bareudp.rs
+++ b/src/link/link_info/bareudp.rs
@@ -72,9 +72,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoBareUdp {
                 Self::SrcPortMin(u16::from_ne_bytes(bytes))
             }
             IFLA_BAREUDP_MULTIPROTO_MODE => Self::MultiprotoMode,
-            kind => Self::Other(DefaultNla::parse(buf).context(format!(
-                "unknown NLA type {kind} for IFLA_INFO_DATA(bareudp)"
-            ))?),
+            kind => Self::Other(DefaultNla::parse(buf).with_context(|| {
+                format!("unknown NLA type {kind} for IFLA_INFO_DATA(bareudp)")
+            })?),
         })
     }
 }

--- a/src/link/link_info/batadv.rs
+++ b/src/link/link_info/batadv.rs
@@ -49,9 +49,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoBatAdv {
                 parse_string(payload)
                     .context("invalid IFLA_BATADV_ALGO_NAME value")?,
             ),
-            kind => Self::Other(DefaultNla::parse(buf).context(format!(
-                "unknown NLA type {kind} for IFLA_INFO_DATA(batadv)"
-            ))?),
+            kind => Self::Other(DefaultNla::parse(buf).with_context(|| {
+                format!("unknown NLA type {kind} for IFLA_INFO_DATA(batadv)")
+            })?),
         })
     }
 }

--- a/src/link/link_info/bond.rs
+++ b/src/link/link_info/bond.rs
@@ -155,10 +155,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for BondAdInfo {
                 parse_mac(payload)
                     .context("invalid IFLA_BOND_AD_INFO_PARTNER_MAC value")?,
             ),
-            _ => Self::Other(DefaultNla::parse(buf).context(format!(
-                "invalid NLA for {}: {payload:?}",
-                buf.kind()
-            ))?),
+            _ => Self::Other(DefaultNla::parse(buf).with_context(|| {
+                format!("invalid NLA for {}: {payload:?}", buf.kind())
+            })?),
         })
     }
 }
@@ -1195,10 +1194,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoBond {
                     .context("invalid IFLA_BOND_BROADCAST_NEIGH value")?
                     > 0,
             ),
-            _ => Self::Other(DefaultNla::parse(buf).context(format!(
-                "invalid NLA for {}: {payload:?}",
-                buf.kind()
-            ))?),
+            _ => Self::Other(DefaultNla::parse(buf).with_context(|| {
+                format!("invalid NLA for {}: {payload:?}", buf.kind())
+            })?),
         })
     }
 }

--- a/src/link/link_info/bond_port.rs
+++ b/src/link/link_info/bond_port.rs
@@ -381,7 +381,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoBondPort {
             ),
             kind => Self::Other(
                 DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {kind}"))?,
+                    .with_context(|| format!("unknown NLA type {kind}"))?,
             ),
         })
     }

--- a/src/link/link_info/bridge.rs
+++ b/src/link/link_info/bridge.rs
@@ -744,7 +744,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
 
             kind => Self::Other(
                 DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {kind}"))?,
+                    .with_context(|| format!("unknown NLA type {kind}"))?,
             ),
         })
     }

--- a/src/link/link_info/bridge_port.rs
+++ b/src/link/link_info/bridge_port.rs
@@ -285,93 +285,94 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
         Ok(match buf.kind() {
             IFLA_BRPORT_STATE => InfoBridgePort::State(
                 parse_u8(payload)
-                    .context({
+                    .with_context(|| {
                         format!("invalid IFLA_BRPORT_STATE {payload:?}")
                     })?
                     .into(),
             ),
             IFLA_BRPORT_PRIORITY => {
-                InfoBridgePort::Priority(parse_u16(payload).context({
-                    format!("invalid IFLA_BRPORT_PRIORITY {payload:?}")
-                })?)
+                InfoBridgePort::Priority(parse_u16(payload).with_context(
+                    || format!("invalid IFLA_BRPORT_PRIORITY {payload:?}"),
+                )?)
             }
             IFLA_BRPORT_COST => {
-                InfoBridgePort::Cost(parse_u32(payload).context({
+                InfoBridgePort::Cost(parse_u32(payload).with_context(|| {
                     format!("invalid IFLA_BRPORT_COST {payload:?}")
                 })?)
             }
             IFLA_BRPORT_MODE => InfoBridgePort::HairpinMode(
-                parse_u8(payload).context({
+                parse_u8(payload).with_context(|| {
                     format!("invalid IFLA_BRPORT_MODE {payload:?}")
                 })? > 0,
             ),
             IFLA_BRPORT_GUARD => InfoBridgePort::Guard(
-                parse_u8(payload).context({
+                parse_u8(payload).with_context(|| {
                     format!("invalid IFLA_BRPORT_GUARD {payload:?}")
                 })? > 0,
             ),
             IFLA_BRPORT_PROTECT => InfoBridgePort::Protect(
-                parse_u8(payload).context({
+                parse_u8(payload).with_context(|| {
                     format!("invalid IFLA_BRPORT_PROTECT {payload:?}")
                 })? > 0,
             ),
             IFLA_BRPORT_FAST_LEAVE => InfoBridgePort::FastLeave(
-                parse_u8(payload).context({
+                parse_u8(payload).with_context(|| {
                     format!("invalid IFLA_BRPORT_FAST_LEAVE {payload:?}")
                 })? > 0,
             ),
             IFLA_BRPORT_LEARNING => InfoBridgePort::Learning(
-                parse_u8(payload).context({
+                parse_u8(payload).with_context(|| {
                     format!("invalid IFLA_BRPORT_LEARNING {payload:?}")
                 })? > 0,
             ),
             IFLA_BRPORT_UNICAST_FLOOD => InfoBridgePort::UnicastFlood(
-                parse_u8(payload).context({
+                parse_u8(payload).with_context(|| {
                     format!("invalid IFLA_BRPORT_UNICAST_FLOOD {payload:?}")
                 })? > 0,
             ),
             IFLA_BRPORT_PROXYARP => InfoBridgePort::ProxyARP(
-                parse_u8(payload).context({
+                parse_u8(payload).with_context(|| {
                     format!("invalid IFLA_BRPORT_PROXYARP {payload:?}")
                 })? > 0,
             ),
             IFLA_BRPORT_PROXYARP_WIFI => InfoBridgePort::ProxyARPWifi(
-                parse_u8(payload).context({
+                parse_u8(payload).with_context(|| {
                     format!("invalid IFLA_BRPORT_PROXYARP_WIFI {payload:?}")
                 })? > 0,
             ),
             IFLA_BRPORT_ROOT_ID => {
-                Self::RootId(BridgeId::parse(payload).context(format!(
-                    "invalid IFLA_BRPORT_ROOT_ID {payload:?}"
-                ))?)
+                Self::RootId(BridgeId::parse(payload).with_context(|| {
+                    format!("invalid IFLA_BRPORT_ROOT_ID {payload:?}")
+                })?)
             }
             IFLA_BRPORT_BRIDGE_ID => {
-                Self::BridgeId(BridgeId::parse(payload).context(format!(
-                    "invalid IFLA_BRPORT_BRIDGE_ID {payload:?}"
-                ))?)
+                Self::BridgeId(BridgeId::parse(payload).with_context(|| {
+                    format!("invalid IFLA_BRPORT_BRIDGE_ID {payload:?}")
+                })?)
             }
-            IFLA_BRPORT_DESIGNATED_PORT => {
-                InfoBridgePort::DesignatedPort(parse_u16(payload).context({
+            IFLA_BRPORT_DESIGNATED_PORT => InfoBridgePort::DesignatedPort(
+                parse_u16(payload).with_context(|| {
                     format!("invalid IFLA_BRPORT_DESIGNATED_PORT {payload:?}")
-                })?)
-            }
-            IFLA_BRPORT_DESIGNATED_COST => {
-                InfoBridgePort::DesignatedCost(parse_u16(payload).context({
-                    format!("invalid IFLA_BRPORT_DESIGNATED_COST {payload:?}")
-                })?)
-            }
-            IFLA_BRPORT_ID => {
-                InfoBridgePort::PortId(parse_u16(payload).context({
-                    format!("invalid IFLA_BRPORT_ID {payload:?}")
-                })?)
-            }
-            IFLA_BRPORT_NO => InfoBridgePort::PortNumber(
-                parse_u16(payload)
-                    .context(format!("invalid IFLA_BRPORT_NO {payload:?}"))?,
+                })?,
             ),
+            IFLA_BRPORT_DESIGNATED_COST => InfoBridgePort::DesignatedCost(
+                parse_u16(payload).with_context(|| {
+                    format!("invalid IFLA_BRPORT_DESIGNATED_COST {payload:?}")
+                })?,
+            ),
+            IFLA_BRPORT_ID => {
+                InfoBridgePort::PortId(parse_u16(payload).with_context(
+                    || format!("invalid IFLA_BRPORT_ID {payload:?}"),
+                )?)
+            }
+            IFLA_BRPORT_NO => {
+                InfoBridgePort::PortNumber(parse_u16(payload).with_context(
+                    || format!("invalid IFLA_BRPORT_NO {payload:?}"),
+                )?)
+            }
             IFLA_BRPORT_TOPOLOGY_CHANGE_ACK => {
                 InfoBridgePort::TopologyChangeAck(
-                    parse_u8(payload).context({
+                    parse_u8(payload).with_context(|| {
                         format!(
                             "invalid IFLA_BRPORT_TOPOLOGY_CHANGE_ACK \
                              {payload:?}"
@@ -380,34 +381,34 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                 )
             }
             IFLA_BRPORT_CONFIG_PENDING => InfoBridgePort::ConfigPending(
-                parse_u8(payload).context({
+                parse_u8(payload).with_context(|| {
                     format!("invalid IFLA_BRPORT_CONFIG_PENDING {payload:?}")
                 })? > 0,
             ),
             IFLA_BRPORT_MESSAGE_AGE_TIMER => InfoBridgePort::MessageAgeTimer(
-                parse_u64(payload).context({
+                parse_u64(payload).with_context(|| {
                     format!("invalid IFLA_BRPORT_MESSAGE_AGE_TIMER {payload:?}")
                 })?,
             ),
             IFLA_BRPORT_FORWARD_DELAY_TIMER => {
-                InfoBridgePort::ForwardDelayTimer(parse_u64(payload).context(
-                    {
+                InfoBridgePort::ForwardDelayTimer(
+                    parse_u64(payload).with_context(|| {
                         format!(
                             "invalid IFLA_BRPORT_FORWARD_DELAY_TIMER \
                              {payload:?}"
                         )
-                    },
-                )?)
+                    })?,
+                )
             }
             IFLA_BRPORT_HOLD_TIMER => {
-                InfoBridgePort::HoldTimer(parse_u64(payload).context({
-                    format!("invalid IFLA_BRPORT_HOLD_TIMER {payload:?}")
-                })?)
+                InfoBridgePort::HoldTimer(parse_u64(payload).with_context(
+                    || format!("invalid IFLA_BRPORT_HOLD_TIMER {payload:?}"),
+                )?)
             }
             IFLA_BRPORT_FLUSH => InfoBridgePort::Flush,
             IFLA_BRPORT_MULTICAST_ROUTER => InfoBridgePort::MulticastRouter(
                 parse_u8(payload)
-                    .context({
+                    .with_context(|| {
                         format!(
                             "invalid IFLA_BRPORT_MULTICAST_ROUTER {payload:?}"
                         )
@@ -415,58 +416,58 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                     .into(),
             ),
             IFLA_BRPORT_MCAST_FLOOD => InfoBridgePort::MulticastFlood(
-                parse_u8(payload).context({
+                parse_u8(payload).with_context(|| {
                     format!("invalid IFLA_BRPORT_MCAST_FLOOD {payload:?}")
                 })? > 0,
             ),
             IFLA_BRPORT_MCAST_TO_UCAST => InfoBridgePort::MulticastToUnicast(
-                parse_u8(payload).context({
+                parse_u8(payload).with_context(|| {
                     format!("invalid IFLA_BRPORT_MCAST_TO_UCAST {payload:?}")
                 })? > 0,
             ),
             IFLA_BRPORT_VLAN_TUNNEL => InfoBridgePort::VlanTunnel(
-                parse_u8(payload).context({
+                parse_u8(payload).with_context(|| {
                     format!("invalid IFLA_BRPORT_VLAN_TUNNEL {payload:?}")
                 })? > 0,
             ),
             IFLA_BRPORT_BCAST_FLOOD => InfoBridgePort::BroadcastFlood(
-                parse_u8(payload).context({
+                parse_u8(payload).with_context(|| {
                     format!("invalid IFLA_BRPORT_BCAST_FLOOD {payload:?}")
                 })? > 0,
             ),
-            IFLA_BRPORT_GROUP_FWD_MASK => {
-                InfoBridgePort::GroupFwdMask(parse_u16(payload).context({
+            IFLA_BRPORT_GROUP_FWD_MASK => InfoBridgePort::GroupFwdMask(
+                parse_u16(payload).with_context(|| {
                     format!("invalid IFLA_BRPORT_GROUP_FWD_MASK {payload:?}")
-                })?)
-            }
+                })?,
+            ),
             IFLA_BRPORT_NEIGH_SUPPRESS => InfoBridgePort::NeighSupress(
-                parse_u8(payload).context({
+                parse_u8(payload).with_context(|| {
                     format!("invalid IFLA_BRPORT_NEIGH_SUPPRESS {payload:?}")
                 })? > 0,
             ),
             IFLA_BRPORT_ISOLATED => InfoBridgePort::Isolated(
-                parse_u8(payload).context({
+                parse_u8(payload).with_context(|| {
                     format!("invalid IFLA_BRPORT_ISOLATED {payload:?}")
                 })? > 0,
             ),
             IFLA_BRPORT_BACKUP_PORT => {
-                InfoBridgePort::BackupPort(parse_u32(payload).context(
-                    format!("invalid IFLA_BRPORT_BACKUP_PORT {payload:?}"),
+                InfoBridgePort::BackupPort(parse_u32(payload).with_context(
+                    || format!("invalid IFLA_BRPORT_BACKUP_PORT {payload:?}"),
                 )?)
             }
             IFLA_BRPORT_MRP_RING_OPEN => InfoBridgePort::MrpRingOpen(
-                parse_u8(payload).context({
+                parse_u8(payload).with_context(|| {
                     format!("invalid IFLA_BRPORT_MRP_RING_OPEN {payload:?}")
                 })? > 0,
             ),
             IFLA_BRPORT_MRP_IN_OPEN => InfoBridgePort::MrpInOpen(
-                parse_u8(payload).context({
+                parse_u8(payload).with_context(|| {
                     format!("invalid IFLA_BRPORT_MRP_IN_OPEN {payload:?}")
                 })? > 0,
             ),
             IFLA_BRPORT_MCAST_EHT_HOSTS_LIMIT => {
                 InfoBridgePort::MulticastEhtHostsLimit(
-                    parse_u32(payload).context({
+                    parse_u32(payload).with_context(|| {
                         format!(
                             "invalid IFLA_BRPORT_MCAST_EHT_HOSTS_LIMIT \
                              {payload:?}"
@@ -476,7 +477,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
             }
             IFLA_BRPORT_MCAST_EHT_HOSTS_CNT => {
                 InfoBridgePort::MulticastEhtHostsCnt(
-                    parse_u32(payload).context({
+                    parse_u32(payload).with_context(|| {
                         format!(
                             "invalid IFLA_BRPORT_MCAST_EHT_HOSTS_CNT \
                              {payload:?}"
@@ -485,28 +486,28 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                 )
             }
             IFLA_BRPORT_LOCKED => InfoBridgePort::Locked(
-                parse_u8(payload).context({
+                parse_u8(payload).with_context(|| {
                     format!("invalid IFLA_BRPORT_LOCKED {payload:?}")
                 })? > 0,
             ),
             IFLA_BRPORT_MAB => InfoBridgePort::Mab(
-                parse_u8(payload).context({
+                parse_u8(payload).with_context(|| {
                     format!("invalid IFLA_BRPORT_MAB {payload:?}")
                 })? > 0,
             ),
             IFLA_BRPORT_MCAST_N_GROUPS => InfoBridgePort::MulticastNGroups(
-                parse_u32(payload).context({
+                parse_u32(payload).with_context(|| {
                     format!("invalid IFLA_BRPORT_MCAST_N_GROUPS {payload:?}")
                 })?,
             ),
             IFLA_BRPORT_MCAST_MAX_GROUPS => InfoBridgePort::MulticastMaxGroups(
-                parse_u32(payload).context({
+                parse_u32(payload).with_context(|| {
                     format!("invalid IFLA_BRPORT_MCAST_MAX_GROUPS {payload:?}")
                 })?,
             ),
             IFLA_BRPORT_NEIGH_VLAN_SUPPRESS => {
                 InfoBridgePort::NeighVlanSuppress(
-                    parse_u8(payload).context({
+                    parse_u8(payload).with_context(|| {
                         format!(
                             "invalid IFLA_BRPORT_NEIGH_VLAN_SUPPRESS \
                              {payload:?}"
@@ -514,24 +515,26 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                     })? > 0,
                 )
             }
-            IFLA_BRPORT_BACKUP_NHID => {
-                InfoBridgePort::BackupNextHopId(parse_u32(payload).context(
-                    format!("invalid IFLA_BRPORT_BACKUP_NHID {payload:?}"),
-                )?)
-            }
+            IFLA_BRPORT_BACKUP_NHID => InfoBridgePort::BackupNextHopId(
+                parse_u32(payload).with_context(|| {
+                    format!("invalid IFLA_BRPORT_BACKUP_NHID {payload:?}")
+                })?,
+            ),
             IFLA_BRPORT_NEIGH_FORWARD_GRAT => InfoBridgePort::NeighForwardGrat(
-                parse_u8(payload).context({
+                parse_u8(payload).with_context(|| {
                     format!(
                         "invalid IFLA_BRPORT_NEIGH_FORWARD_GRAT {payload:?}"
                     )
                 })? > 0,
             ),
-            kind => InfoBridgePort::Other(DefaultNla::parse(buf).context({
-                format!(
+            kind => InfoBridgePort::Other(
+                DefaultNla::parse(buf).with_context(|| {
+                    format!(
                     "failed to parse bridge port NLA of type '{kind}' into \
                      DefaultNla"
                 )
-            })?),
+                })?,
+            ),
         })
     }
 }

--- a/src/link/link_info/can.rs
+++ b/src/link/link_info/can.rs
@@ -541,9 +541,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoCan {
                 CanCtrlMode::parse(payload)
                     .context("invalid IFLA_CAN_CTRLMODE_EXT")?,
             ),
-            kind => Self::Other(DefaultNla::parse(buf).context(format!(
-                "unknown NLA type {kind} for IFLA_INFO_DATA(can)"
-            ))?),
+            kind => Self::Other(DefaultNla::parse(buf).with_context(|| {
+                format!("unknown NLA type {kind} for IFLA_INFO_DATA(can)")
+            })?),
         })
     }
 }

--- a/src/link/link_info/dsa.rs
+++ b/src/link/link_info/dsa.rs
@@ -50,9 +50,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoDsa {
                 parse_u32(payload).context("invalid IFLA_DSA_CONDUIT value")?,
             ),
             unknown_kind => {
-                Self::Other(DefaultNla::parse(buf).context(format!(
-                    "unknown NLA type {unknown_kind} for dsa"
-                ))?)
+                Self::Other(DefaultNla::parse(buf).with_context(|| {
+                    format!("unknown NLA type {unknown_kind} for dsa")
+                })?)
             }
         })
     }

--- a/src/link/link_info/geneve.rs
+++ b/src/link/link_info/geneve.rs
@@ -279,7 +279,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoGeneve {
             IFLA_GENEVE_INNER_PROTO_INHERIT => Self::InnerProtoInherit,
             kind => Self::Other(
                 DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {kind}"))?,
+                    .with_context(|| format!("unknown NLA type {kind}"))?,
             ),
         })
     }

--- a/src/link/link_info/gre/info_gre.rs
+++ b/src/link/link_info/gre/info_gre.rs
@@ -207,10 +207,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoGre {
                 parse_u16(payload)
                     .context("invalid IFLA_GRE_ERSPAN_HWID value")?,
             ),
-            kind => Self::Other(
-                DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {kind} for ip6gre"))?,
-            ),
+            kind => Self::Other(DefaultNla::parse(buf).with_context(|| {
+                format!("unknown NLA type {kind} for ip6gre")
+            })?),
         })
     }
 }

--- a/src/link/link_info/gre/info_gre6.rs
+++ b/src/link/link_info/gre/info_gre6.rs
@@ -212,10 +212,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoGre6 {
                 parse_u16(payload)
                     .context("invalid IFLA_GRE_ERSPAN_HWID value")?,
             ),
-            kind => Self::Other(
-                DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {kind} for ip6gre"))?,
-            ),
+            kind => Self::Other(DefaultNla::parse(buf).with_context(|| {
+                format!("unknown NLA type {kind} for ip6gre")
+            })?),
         })
     }
 }

--- a/src/link/link_info/gtp.rs
+++ b/src/link/link_info/gtp.rs
@@ -164,9 +164,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoGtp {
                 }
             }
             unknown_kind => {
-                Self::Other(DefaultNla::parse(buf).context(format!(
-                    "unknown NLA type {unknown_kind} for gtp"
-                ))?)
+                Self::Other(DefaultNla::parse(buf).with_context(|| {
+                    format!("unknown NLA type {unknown_kind} for gtp")
+                })?)
             }
         })
     }

--- a/src/link/link_info/hsr.rs
+++ b/src/link/link_info/hsr.rs
@@ -108,7 +108,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoHsr {
             ),
             kind => Self::Other(
                 DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {kind}"))?,
+                    .with_context(|| format!("unknown NLA type {kind}"))?,
             ),
         })
     }

--- a/src/link/link_info/info_data.rs
+++ b/src/link/link_info/info_data.rs
@@ -153,9 +153,9 @@ impl InfoData {
             InfoKind::Can => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                     let parsed = InfoCan::parse(nla)?;
                     v.push(parsed);
                 }
@@ -164,9 +164,9 @@ impl InfoData {
             InfoKind::Bridge => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                     let parsed = InfoBridge::parse(nla)?;
                     v.push(parsed);
                 }
@@ -175,9 +175,9 @@ impl InfoData {
             InfoKind::Vlan => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                     let parsed = InfoVlan::parse(nla)?;
                     v.push(parsed);
                 }
@@ -186,27 +186,28 @@ impl InfoData {
             InfoKind::Tun => {
                 let mut nlas = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                     let parsed = InfoTun::parse(nla)?;
                     nlas.push(parsed);
                 }
                 InfoData::Tun(nlas)
             }
             InfoKind::Veth => {
-                let nla_buf = NlaBuffer::new_checked(&payload).context(
-                    format!("invalid IFLA_INFO_DATA for {kind} {payload:?}"),
-                )?;
+                let nla_buf =
+                    NlaBuffer::new_checked(&payload).with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                 let parsed = InfoVeth::parse(&nla_buf)?;
                 InfoData::Veth(parsed)
             }
             InfoKind::Vxlan => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                     let parsed = InfoVxlan::parse(nla)?;
                     v.push(parsed);
                 }
@@ -215,9 +216,9 @@ impl InfoData {
             InfoKind::Bond => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                     let parsed = InfoBond::parse(nla)?;
                     v.push(parsed);
                 }
@@ -226,9 +227,9 @@ impl InfoData {
             InfoKind::IpVlan => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                     let parsed = InfoIpVlan::parse(nla)?;
                     v.push(parsed);
                 }
@@ -237,9 +238,9 @@ impl InfoData {
             InfoKind::IpVtap => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                     let parsed = InfoIpVtap::parse(nla)?;
                     v.push(parsed);
                 }
@@ -248,9 +249,9 @@ impl InfoData {
             InfoKind::MacVlan => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                     let parsed = InfoMacVlan::parse(nla)?;
                     v.push(parsed);
                 }
@@ -259,9 +260,9 @@ impl InfoData {
             InfoKind::MacVtap => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                     let parsed = InfoMacVtap::parse(nla)?;
                     v.push(parsed);
                 }
@@ -270,9 +271,9 @@ impl InfoData {
             InfoKind::GreTap => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                     let parsed = InfoGre::parse(nla)?;
                     v.push(parsed);
                 }
@@ -281,9 +282,9 @@ impl InfoData {
             InfoKind::GreTap6 => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                     let parsed = InfoGre6::parse(nla)?;
                     v.push(parsed);
                 }
@@ -292,9 +293,9 @@ impl InfoData {
             InfoKind::GreTun => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                     let parsed = InfoGre::parse(nla)?;
                     v.push(parsed);
                 }
@@ -303,9 +304,9 @@ impl InfoData {
             InfoKind::GreTun6 => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                     let parsed = InfoGre6::parse(nla)?;
                     v.push(parsed);
                 }
@@ -314,9 +315,9 @@ impl InfoData {
             InfoKind::Vti | InfoKind::Vti6 => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                     let parsed = InfoVti::parse(nla)?;
                     v.push(parsed);
                 }
@@ -325,9 +326,9 @@ impl InfoData {
             InfoKind::Vrf => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                     let parsed = InfoVrf::parse(nla)?;
                     v.push(parsed);
                 }
@@ -336,9 +337,9 @@ impl InfoData {
             InfoKind::Gtp => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                     let parsed = InfoGtp::parse(nla)?;
                     v.push(parsed);
                 }
@@ -347,9 +348,9 @@ impl InfoData {
             InfoKind::Ipoib => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                     let parsed = InfoIpoib::parse(nla)?;
                     v.push(parsed);
                 }
@@ -358,9 +359,9 @@ impl InfoData {
             InfoKind::Xfrm => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                     let parsed = InfoXfrm::parse(nla)?;
                     v.push(parsed);
                 }
@@ -369,9 +370,9 @@ impl InfoData {
             InfoKind::MacSec => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                     let parsed = InfoMacSec::parse(nla)?;
                     v.push(parsed);
                 }
@@ -380,9 +381,9 @@ impl InfoData {
             InfoKind::Hsr => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                     let parsed = InfoHsr::parse(nla)?;
                     v.push(parsed);
                 }
@@ -391,9 +392,9 @@ impl InfoData {
             InfoKind::IpIp | InfoKind::Ip6Tnl | InfoKind::SitTun => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                     let parsed =
                         InfoIpTunnel::parse_with_param(nla, kind.clone())?;
                     v.push(parsed);
@@ -403,9 +404,9 @@ impl InfoData {
             InfoKind::Geneve => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                     let parsed = InfoGeneve::parse(nla)?;
                     v.push(parsed);
                 }
@@ -414,27 +415,28 @@ impl InfoData {
             InfoKind::Netkit => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                     let parsed = InfoNetkit::parse(nla)?;
                     v.push(parsed);
                 }
                 InfoData::Netkit(v)
             }
             InfoKind::Vxcan => {
-                let nla_buf = NlaBuffer::new_checked(&payload).context(
-                    format!("invalid IFLA_INFO_DATA for {kind} {payload:?}"),
-                )?;
+                let nla_buf =
+                    NlaBuffer::new_checked(&payload).with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                 let parsed = InfoVxcan::parse(&nla_buf)?;
                 InfoData::Vxcan(parsed)
             }
             InfoKind::Amt => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                     let parsed = InfoAmt::parse(nla)?;
                     v.push(parsed);
                 }
@@ -443,9 +445,9 @@ impl InfoData {
             InfoKind::Wwan => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                     let parsed = InfoWwan::parse(nla)?;
                     v.push(parsed);
                 }
@@ -454,9 +456,9 @@ impl InfoData {
             InfoKind::RmNet => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                     let parsed = InfoRmNet::parse(nla)?;
                     v.push(parsed);
                 }
@@ -465,9 +467,9 @@ impl InfoData {
             InfoKind::BatAdv => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                     let parsed = InfoBatAdv::parse(nla)?;
                     v.push(parsed);
                 }
@@ -476,9 +478,9 @@ impl InfoData {
             InfoKind::BareUdp => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                     let parsed = InfoBareUdp::parse(nla)?;
                     v.push(parsed);
                 }
@@ -487,9 +489,9 @@ impl InfoData {
             InfoKind::Dsa => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                     let parsed = InfoDsa::parse(nla)?;
                     v.push(parsed);
                 }
@@ -498,9 +500,9 @@ impl InfoData {
             InfoKind::ErSpan => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                     let parsed = InfoGre::parse(nla)?;
                     v.push(parsed);
                 }
@@ -509,9 +511,9 @@ impl InfoData {
             InfoKind::Ip6ErSpan => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                     let parsed = InfoGre6::parse(nla)?;
                     v.push(parsed);
                 }
@@ -520,9 +522,9 @@ impl InfoData {
             InfoKind::Wireguard => {
                 let mut v = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_INFO_DATA for {kind} {payload:?}"
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!("invalid IFLA_INFO_DATA for {kind} {payload:?}")
+                    })?;
                     let parsed = InfoWireguard::parse(nla)?;
                     v.push(parsed);
                 }

--- a/src/link/link_info/info_port.rs
+++ b/src/link/link_info/info_port.rs
@@ -157,9 +157,11 @@ impl InfoPortData {
             InfoPortKind::Other(_) => Ok(InfoPortData::Other(payload.to_vec())),
         };
 
-        port_data.context(format!(
-            "failed to parse IFLA_INFO_PORT_DATA (IFLA_INFO_PORT_KIND is \
+        port_data.with_context(|| {
+            format!(
+                "failed to parse IFLA_INFO_PORT_DATA (IFLA_INFO_PORT_KIND is \
              '{kind}')"
-        ))
+            )
+        })
     }
 }

--- a/src/link/link_info/infos.rs
+++ b/src/link/link_info/infos.rs
@@ -176,9 +176,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for VecLinkInfo {
                     }
                 }
                 _kind => nlas.push(LinkInfo::Other(
-                    DefaultNla::parse(&nla).context(format!(
-                        "Unknown NLA type for IFLA_INFO_DATA {nla:?}"
-                    ))?,
+                    DefaultNla::parse(&nla).with_context(|| {
+                        format!("Unknown NLA type for IFLA_INFO_DATA {nla:?}")
+                    })?,
                 )),
             }
         }

--- a/src/link/link_info/ipoib.rs
+++ b/src/link/link_info/ipoib.rs
@@ -61,9 +61,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoIpoib {
                 parse_u16(payload)
                     .context("invalid IFLA_IPOIB_UMCAST value")?,
             ),
-            kind => Self::Other(DefaultNla::parse(buf).context(format!(
-                "unknown NLA type {kind} for IFLA_INFO_DATA(ipoib)"
-            ))?),
+            kind => Self::Other(DefaultNla::parse(buf).with_context(|| {
+                format!("unknown NLA type {kind} for IFLA_INFO_DATA(ipoib)")
+            })?),
         })
     }
 }

--- a/src/link/link_info/iptunnel.rs
+++ b/src/link/link_info/iptunnel.rs
@@ -283,7 +283,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
             ),
             kind => Self::Other(
                 DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {kind}"))?,
+                    .with_context(|| format!("unknown NLA type {kind}"))?,
             ),
         })
     }

--- a/src/link/link_info/ipvlan.rs
+++ b/src/link/link_info/ipvlan.rs
@@ -54,9 +54,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoIpVlan {
                 parse_u16(payload)
                     .context("failed to parse IFLA_IPVLAN_FLAGS")?,
             )),
-            kind => Self::Other(DefaultNla::parse(buf).context(format!(
-                "unknown NLA type {kind} for IFLA_INFO_DATA(ipvlan)"
-            ))?),
+            kind => Self::Other(DefaultNla::parse(buf).with_context(|| {
+                format!("unknown NLA type {kind} for IFLA_INFO_DATA(ipvlan)")
+            })?),
         })
     }
 }
@@ -107,9 +107,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoIpVtap {
                 parse_u16(payload)
                     .context("failed to parse IFLA_IPVLAN_FLAGS")?,
             )),
-            kind => Self::Other(DefaultNla::parse(buf).context(format!(
-                "unknown NLA type {kind} for IFLA_INFO_DATA(ipvlan)"
-            ))?),
+            kind => Self::Other(DefaultNla::parse(buf).with_context(|| {
+                format!("unknown NLA type {kind} for IFLA_INFO_DATA(ipvlan)")
+            })?),
         })
     }
 }

--- a/src/link/link_info/mac_vlan.rs
+++ b/src/link/link_info/mac_vlan.rs
@@ -129,9 +129,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoMacVlan {
                 parse_i32(payload)
                     .context("invalid IFLA_MACVLAN_BC_CUTOFF value")?,
             ),
-            kind => Self::Other(DefaultNla::parse(buf).context(format!(
-                "unknown NLA type {kind} for IFLA_INFO_DATA(mac_vlan)"
-            ))?),
+            kind => Self::Other(DefaultNla::parse(buf).with_context(|| {
+                format!("unknown NLA type {kind} for IFLA_INFO_DATA(mac_vlan)")
+            })?),
         })
     }
 }
@@ -248,9 +248,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoMacVtap {
                 parse_i32(payload)
                     .context("invalid IFLA_MACVLAN_BC_CUTOFF value")?,
             ),
-            kind => Self::Other(DefaultNla::parse(buf).context(format!(
-                "unknown NLA type {kind} for IFLA_INFO_DATA(mac_vtap)"
-            ))?),
+            kind => Self::Other(DefaultNla::parse(buf).with_context(|| {
+                format!("unknown NLA type {kind} for IFLA_INFO_DATA(mac_vtap)")
+            })?),
         })
     }
 }

--- a/src/link/link_info/macsec.rs
+++ b/src/link/link_info/macsec.rs
@@ -278,7 +278,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoMacSec {
             ),
             kind => Self::Other(
                 DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {kind}"))?,
+                    .with_context(|| format!("unknown NLA type {kind}"))?,
             ),
         })
     }

--- a/src/link/link_info/netkit.rs
+++ b/src/link/link_info/netkit.rs
@@ -271,10 +271,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoNetkit {
             }
             IFLA_NETKIT_HEADROOM => Self::Headroom(parse_u16(payload)?),
             IFLA_NETKIT_TAILROOM => Self::Tailroom(parse_u16(payload)?),
-            kind => Self::Other(
-                DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {kind} for netkit"))?,
-            ),
+            kind => Self::Other(DefaultNla::parse(buf).with_context(|| {
+                format!("unknown NLA type {kind} for netkit")
+            })?),
         })
     }
 }

--- a/src/link/link_info/tun.rs
+++ b/src/link/link_info/tun.rs
@@ -34,9 +34,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoTun {
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         #[allow(clippy::match_single_binding)]
         Ok(match buf.kind() {
-            kind => Self::Other(DefaultNla::parse(buf).context(format!(
-                "unknown NLA type {kind} for IFLA_INFO_DATA(vrf)"
-            ))?),
+            kind => Self::Other(DefaultNla::parse(buf).with_context(|| {
+                format!("unknown NLA type {kind} for IFLA_INFO_DATA(vrf)")
+            })?),
         })
     }
 }

--- a/src/link/link_info/veth.rs
+++ b/src/link/link_info/veth.rs
@@ -51,7 +51,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoVeth {
             }
             kind => Self::Other(
                 DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {kind}"))?,
+                    .with_context(|| format!("unknown NLA type {kind}"))?,
             ),
         })
     }

--- a/src/link/link_info/vlan.rs
+++ b/src/link/link_info/vlan.rs
@@ -145,9 +145,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                         .context("expected u32 to value")?,
                 )
             }
-            kind => Self::Other(DefaultNla::parse(buf).context(format!(
-                "unknown NLA type {kind} for VLAN QoS mapping"
-            ))?),
+            kind => Self::Other(DefaultNla::parse(buf).with_context(|| {
+                format!("unknown NLA type {kind} for VLAN QoS mapping")
+            })?),
         })
     }
 }
@@ -194,10 +194,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoVlan {
                     .context("invalid IFLA_VLAN_PROTOCOL value")?
                     .into(),
             ),
-            _ => Self::Other(DefaultNla::parse(buf).context(format!(
-                "invalid NLA for {}: {payload:?}",
-                buf.kind()
-            ))?),
+            _ => Self::Other(DefaultNla::parse(buf).with_context(|| {
+                format!("invalid NLA for {}: {payload:?}", buf.kind())
+            })?),
         })
     }
 }

--- a/src/link/link_info/vrf.rs
+++ b/src/link/link_info/vrf.rs
@@ -44,9 +44,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoVrf {
             IFLA_VRF_TABLE => Self::TableId(
                 parse_u32(payload).context("invalid IFLA_VRF_TABLE value")?,
             ),
-            kind => Self::Other(DefaultNla::parse(buf).context(format!(
-                "unknown NLA type {kind} for IFLA_INFO_DATA(vrf)"
-            ))?),
+            kind => Self::Other(DefaultNla::parse(buf).with_context(|| {
+                format!("unknown NLA type {kind} for IFLA_INFO_DATA(vrf)")
+            })?),
         })
     }
 }

--- a/src/link/link_info/vti.rs
+++ b/src/link/link_info/vti.rs
@@ -97,10 +97,11 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoVti {
             IFLA_VTI_FWMARK => Self::FwMark(
                 parse_u32(payload).context("invalid IFLA_VTI_FWMARK value")?,
             ),
-            kind => Self::Other(
-                DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {kind} for vti"))?,
-            ),
+            kind => {
+                Self::Other(DefaultNla::parse(buf).with_context(|| {
+                    format!("unknown NLA type {kind} for vti")
+                })?)
+            }
         })
     }
 }

--- a/src/link/link_info/vxcan.rs
+++ b/src/link/link_info/vxcan.rs
@@ -51,7 +51,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoVxcan {
             }
             kind => Self::Other(
                 DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {kind}"))?,
+                    .with_context(|| format!("unknown NLA type {kind}"))?,
             ),
         })
     }

--- a/src/link/link_info/vxlan.rs
+++ b/src/link/link_info/vxlan.rs
@@ -454,10 +454,12 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoVxlan {
                     > 0,
             ),
             unknown_kind => {
-                Self::Other(DefaultNla::parse(buf).context(format!(
-                    "Failed to parse IFLA_INFO_DATA(vxlan) NLA type: \
+                Self::Other(DefaultNla::parse(buf).with_context(|| {
+                    format!(
+                        "Failed to parse IFLA_INFO_DATA(vxlan) NLA type: \
                      {unknown_kind} as DefaultNla"
-                ))?)
+                    )
+                })?)
             }
         })
     }

--- a/src/link/link_info/wireguard.rs
+++ b/src/link/link_info/wireguard.rs
@@ -36,9 +36,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         #[allow(clippy::match_single_binding)]
         Ok(match buf.kind() {
-            kind => Self::Other(DefaultNla::parse(buf).context(format!(
-                "unknown NLA type {kind} for IFLA_INFO_DATA(wireguard)"
-            ))?),
+            kind => Self::Other(DefaultNla::parse(buf).with_context(|| {
+                format!("unknown NLA type {kind} for IFLA_INFO_DATA(wireguard)")
+            })?),
         })
     }
 }

--- a/src/link/link_info/xfrm.rs
+++ b/src/link/link_info/xfrm.rs
@@ -52,9 +52,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoXfrm {
             IFLA_XFRM_IF_ID => Self::IfId(
                 parse_u32(payload).context("invalid IFLA_XFRM_IF_ID value")?,
             ),
-            kind => Self::Other(DefaultNla::parse(buf).context(format!(
-                "unknown NLA type {kind} for IFLA_INFO_DATA(xfrm)"
-            ))?),
+            kind => Self::Other(DefaultNla::parse(buf).with_context(|| {
+                format!("unknown NLA type {kind} for IFLA_INFO_DATA(xfrm)")
+            })?),
         })
     }
 }

--- a/src/link/prop_list.rs
+++ b/src/link/prop_list.rs
@@ -50,7 +50,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Prop {
             ),
             kind => Prop::Other(
                 DefaultNla::parse(buf)
-                    .context(format!("Unknown NLA type {kind}"))?,
+                    .with_context(|| format!("Unknown NLA type {kind}"))?,
             ),
         })
     }

--- a/src/link/proto_info/bridge.rs
+++ b/src/link/proto_info/bridge.rs
@@ -22,10 +22,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let mut nlas = vec![];
         for nla in NlasIterator::new(buf.into_inner()) {
-            let nla = nla.context(format!(
-                "invalid bridge IFLA_PROTINFO {:?}",
-                buf.value()
-            ))?;
+            let nla = nla.with_context(|| {
+                format!("invalid bridge IFLA_PROTINFO {:?}", buf.value())
+            })?;
             nlas.push(LinkProtoInfoBridge::parse(&nla)?);
         }
         Ok(Self(nlas))
@@ -67,10 +66,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                     .context("invalid IFLA_BRPORT_NEIGH_FORWARD_GRAT value")?
                     > 0,
             ),
-            _ => Self::Other(DefaultNla::parse(buf).context(format!(
-                "invalid bridge IFLA_PROTINFO {:?}",
-                buf.value()
-            ))?),
+            _ => Self::Other(DefaultNla::parse(buf).with_context(|| {
+                format!("invalid bridge IFLA_PROTINFO {:?}", buf.value())
+            })?),
         })
     }
 }

--- a/src/link/proto_info/inet6.rs
+++ b/src/link/proto_info/inet6.rs
@@ -19,10 +19,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let mut nlas = vec![];
         for nla in NlasIterator::new(buf.into_inner()) {
-            let nla = nla.context(format!(
-                "invalid inet6 IFLA_PROTINFO {:?}",
-                buf.value()
-            ))?;
+            let nla = nla.with_context(|| {
+                format!("invalid inet6 IFLA_PROTINFO {:?}", buf.value())
+            })?;
             nlas.push(LinkProtoInfoInet6::parse(&nla)?);
         }
         Ok(Self(nlas))
@@ -53,9 +52,8 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     for LinkProtoInfoInet6
 {
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
-        Ok(Self::Other(DefaultNla::parse(buf).context(format!(
-            "invalid inet6 IFLA_PROTINFO {:?}",
-            buf.value()
-        ))?))
+        Ok(Self::Other(DefaultNla::parse(buf).with_context(|| {
+            format!("invalid inet6 IFLA_PROTINFO {:?}", buf.value())
+        })?))
     }
 }

--- a/src/link/sriov/stats.rs
+++ b/src/link/sriov/stats.rs
@@ -71,48 +71,56 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for VfStats {
         let payload = buf.value();
         Ok(match buf.kind() {
             IFLA_VF_STATS_RX_PACKETS => {
-                Self::RxPackets(parse_u64(payload).context(format!(
-                    "invalid IFLA_VF_STATS_RX_PACKETS value {payload:?}"
-                ))?)
+                Self::RxPackets(parse_u64(payload).with_context(|| {
+                    format!(
+                        "invalid IFLA_VF_STATS_RX_PACKETS value {payload:?}"
+                    )
+                })?)
             }
             IFLA_VF_STATS_TX_PACKETS => {
-                Self::TxPackets(parse_u64(payload).context(format!(
-                    "invalid IFLA_VF_STATS_TX_PACKETS value {payload:?}"
-                ))?)
+                Self::TxPackets(parse_u64(payload).with_context(|| {
+                    format!(
+                        "invalid IFLA_VF_STATS_TX_PACKETS value {payload:?}"
+                    )
+                })?)
             }
             IFLA_VF_STATS_RX_BYTES => {
-                Self::RxBytes(parse_u64(payload).context(format!(
-                    "invalid IFLA_VF_STATS_RX_BYTES value {payload:?}"
-                ))?)
+                Self::RxBytes(parse_u64(payload).with_context(|| {
+                    format!("invalid IFLA_VF_STATS_RX_BYTES value {payload:?}")
+                })?)
             }
             IFLA_VF_STATS_TX_BYTES => {
-                Self::TxBytes(parse_u64(payload).context(format!(
-                    "invalid IFLA_VF_STATS_TX_BYTES value {payload:?}"
-                ))?)
+                Self::TxBytes(parse_u64(payload).with_context(|| {
+                    format!("invalid IFLA_VF_STATS_TX_BYTES value {payload:?}")
+                })?)
             }
             IFLA_VF_STATS_BROADCAST => {
-                Self::Broadcast(parse_u64(payload).context(format!(
-                    "invalid IFLA_VF_STATS_BROADCAST value {payload:?}"
-                ))?)
+                Self::Broadcast(parse_u64(payload).with_context(|| {
+                    format!("invalid IFLA_VF_STATS_BROADCAST value {payload:?}")
+                })?)
             }
             IFLA_VF_STATS_MULTICAST => {
-                Self::Multicast(parse_u64(payload).context(format!(
-                    "invalid IFLA_VF_STATS_MULTICAST value {payload:?}"
-                ))?)
+                Self::Multicast(parse_u64(payload).with_context(|| {
+                    format!("invalid IFLA_VF_STATS_MULTICAST value {payload:?}")
+                })?)
             }
             IFLA_VF_STATS_RX_DROPPED => {
-                Self::RxDropped(parse_u64(payload).context(format!(
-                    "invalid IFLA_VF_STATS_RX_DROPPED value {payload:?}"
-                ))?)
+                Self::RxDropped(parse_u64(payload).with_context(|| {
+                    format!(
+                        "invalid IFLA_VF_STATS_RX_DROPPED value {payload:?}"
+                    )
+                })?)
             }
             IFLA_VF_STATS_TX_DROPPED => {
-                Self::TxDropped(parse_u64(payload).context(format!(
-                    "invalid IFLA_VF_STATS_TX_DROPPED value {payload:?}"
-                ))?)
+                Self::TxDropped(parse_u64(payload).with_context(|| {
+                    format!(
+                        "invalid IFLA_VF_STATS_TX_DROPPED value {payload:?}"
+                    )
+                })?)
             }
-            kind => Self::Other(DefaultNla::parse(buf).context(format!(
-                "failed to parse {kind} as DefaultNla: {payload:?}"
-            ))?),
+            kind => Self::Other(DefaultNla::parse(buf).with_context(|| {
+                format!("failed to parse {kind} as DefaultNla: {payload:?}")
+            })?),
         })
     }
 }

--- a/src/link/sriov/vf_list.rs
+++ b/src/link/sriov/vf_list.rs
@@ -22,10 +22,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let mut nlas = vec![];
         for nla in NlasIterator::new(buf.into_inner()) {
-            let nla = &nla.context(format!(
-                "invalid IFLA_VFINFO_LIST value: {:?}",
-                buf.value()
-            ))?;
+            let nla = &nla.with_context(|| {
+                format!("invalid IFLA_VFINFO_LIST value: {:?}", buf.value())
+            })?;
             if nla.kind() == IFLA_VF_INFO {
                 nlas.push(LinkVfInfo::parse(&NlaBuffer::new_checked(
                     nla.value(),
@@ -63,10 +62,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for LinkVfInfo {
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let mut nlas = vec![];
         for nla in NlasIterator::new(buf.into_inner()) {
-            let nla = &nla.context(format!(
-                "invalid IFLA_VF_INFO value {:?}",
-                buf.value()
-            ))?;
+            let nla = &nla.with_context(|| {
+                format!("invalid IFLA_VF_INFO value {:?}", buf.value())
+            })?;
             nlas.push(VfInfo::parse(nla)?);
         }
         Ok(Self(nlas))
@@ -169,62 +167,70 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for VfInfo {
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();
         Ok(match buf.kind() {
-            IFLA_VF_MAC => Self::Mac(
-                VfInfoMac::parse(payload)
-                    .context(format!("invalid IFLA_VF_MAC {payload:?}"))?,
-            ),
-            IFLA_VF_VLAN => Self::Vlan(
-                VfInfoVlan::parse(payload)
-                    .context(format!("invalid IFLA_VF_VLAN {payload:?}"))?,
-            ),
+            IFLA_VF_MAC => {
+                Self::Mac(VfInfoMac::parse(payload).with_context(|| {
+                    format!("invalid IFLA_VF_MAC {payload:?}")
+                })?)
+            }
+            IFLA_VF_VLAN => {
+                Self::Vlan(VfInfoVlan::parse(payload).with_context(|| {
+                    format!("invalid IFLA_VF_VLAN {payload:?}")
+                })?)
+            }
             IFLA_VF_BROADCAST => {
-                Self::Broadcast(VfInfoBroadcast::parse(payload).context(
-                    format!("invalid IFLA_VF_BROADCAST {payload:?}"),
+                Self::Broadcast(VfInfoBroadcast::parse(payload).with_context(
+                    || format!("invalid IFLA_VF_BROADCAST {payload:?}"),
                 )?)
             }
-            IFLA_VF_RATE => Self::Rate(
-                VfInfoRate::parse(payload)
-                    .context(format!("invalid IFLA_VF_RATE {payload:?}"))?,
-            ),
-            IFLA_VF_TX_RATE => Self::TxRate(
-                VfInfoTxRate::parse(payload)
-                    .context(format!("invalid IFLA_VF_TX_RATE {payload:?}"))?,
-            ),
+            IFLA_VF_RATE => {
+                Self::Rate(VfInfoRate::parse(payload).with_context(|| {
+                    format!("invalid IFLA_VF_RATE {payload:?}")
+                })?)
+            }
+            IFLA_VF_TX_RATE => {
+                Self::TxRate(VfInfoTxRate::parse(payload).with_context(
+                    || format!("invalid IFLA_VF_TX_RATE {payload:?}"),
+                )?)
+            }
             IFLA_VF_SPOOFCHK => Self::SpoofCheck(
-                VfInfoSpoofCheck::parse(payload)
-                    .context(format!("invalid IFLA_VF_SPOOFCHK {payload:?}"))?,
+                VfInfoSpoofCheck::parse(payload).with_context(|| {
+                    format!("invalid IFLA_VF_SPOOFCHK {payload:?}")
+                })?,
             ),
             IFLA_VF_LINK_STATE => {
-                Self::LinkState(VfInfoLinkState::parse(payload).context(
-                    format!("invalid IFLA_VF_LINK_STATE {payload:?}"),
+                Self::LinkState(VfInfoLinkState::parse(payload).with_context(
+                    || format!("invalid IFLA_VF_LINK_STATE {payload:?}"),
                 )?)
             }
-            IFLA_VF_RSS_QUERY_EN => {
-                Self::RssQueryEn(VfInfoRssQueryEn::parse(payload).context(
-                    format!("invalid IFLA_VF_RSS_QUERY_EN {payload:?}"),
-                )?)
-            }
-            IFLA_VF_TRUST => Self::Trust(
-                VfInfoTrust::parse(payload)
-                    .context(format!("invalid IFLA_VF_TRUST {payload:?}"))?,
+            IFLA_VF_RSS_QUERY_EN => Self::RssQueryEn(
+                VfInfoRssQueryEn::parse(payload).with_context(|| {
+                    format!("invalid IFLA_VF_RSS_QUERY_EN {payload:?}")
+                })?,
             ),
+            IFLA_VF_TRUST => {
+                Self::Trust(VfInfoTrust::parse(payload).with_context(|| {
+                    format!("invalid IFLA_VF_TRUST {payload:?}")
+                })?)
+            }
             IFLA_VF_IB_NODE_GUID => {
-                Self::IbNodeGuid(VfInfoGuid::parse(payload).context(
-                    format!("invalid IFLA_VF_IB_NODE_GUID {payload:?}"),
+                Self::IbNodeGuid(VfInfoGuid::parse(payload).with_context(
+                    || format!("invalid IFLA_VF_IB_NODE_GUID {payload:?}"),
                 )?)
             }
             IFLA_VF_IB_PORT_GUID => {
-                Self::IbPortGuid(VfInfoGuid::parse(payload).context(
-                    format!("invalid IFLA_VF_IB_PORT_GUID {payload:?}"),
+                Self::IbPortGuid(VfInfoGuid::parse(payload).with_context(
+                    || format!("invalid IFLA_VF_IB_PORT_GUID {payload:?}"),
                 )?)
             }
             IFLA_VF_VLAN_LIST => {
                 let mut nlas: Vec<VfVlan> = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_VF_VLAN_LIST value: {:?}",
-                        buf.value()
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!(
+                            "invalid IFLA_VF_VLAN_LIST value: {:?}",
+                            buf.value()
+                        )
+                    })?;
 
                     nlas.push(VfVlan::parse(nla)?);
                 }
@@ -233,18 +239,20 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for VfInfo {
             IFLA_VF_STATS => {
                 let mut nlas: Vec<VfStats> = Vec::new();
                 for nla in NlasIterator::new(payload) {
-                    let nla = &nla.context(format!(
-                        "invalid IFLA_VF_STATS value: {:?}",
-                        buf.value()
-                    ))?;
+                    let nla = &nla.with_context(|| {
+                        format!(
+                            "invalid IFLA_VF_STATS value: {:?}",
+                            buf.value()
+                        )
+                    })?;
 
                     nlas.push(VfStats::parse(nla)?);
                 }
                 Self::Stats(nlas)
             }
-            kind => Self::Other(DefaultNla::parse(buf).context(format!(
-                "failed to parse {kind} as DefaultNla: {payload:?}"
-            ))?),
+            kind => Self::Other(DefaultNla::parse(buf).with_context(|| {
+                format!("failed to parse {kind} as DefaultNla: {payload:?}")
+            })?),
         })
     }
 }

--- a/src/link/sriov/vf_port.rs
+++ b/src/link/sriov/vf_port.rs
@@ -14,10 +14,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let mut nlas = vec![];
         for nla in NlasIterator::new(buf.into_inner()) {
-            let nla = &nla.context(format!(
-                "invalid IFLA_VF_PORTS value: {:?}",
-                buf.value()
-            ))?;
+            let nla = &nla.with_context(|| {
+                format!("invalid IFLA_VF_PORTS value: {:?}", buf.value())
+            })?;
             if nla.kind() == IFLA_VF_PORT {
                 nlas.push(LinkVfPort::parse(&NlaBuffer::new_checked(
                     nla.value(),
@@ -56,10 +55,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for LinkVfPort {
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let mut nlas = vec![];
         for nla in NlasIterator::new(buf.into_inner()) {
-            let nla = &nla.context(format!(
-                "invalid IFLA_VF_PORT value {:?}",
-                buf.value()
-            ))?;
+            let nla = &nla.with_context(|| {
+                format!("invalid IFLA_VF_PORT value {:?}", buf.value())
+            })?;
             nlas.push(VfPort::parse(nla)?);
         }
         Ok(Self(nlas))
@@ -115,9 +113,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for VfPort {
         let payload = buf.value();
         #[allow(clippy::match_single_binding)]
         Ok(match buf.kind() {
-            kind => Self::Other(DefaultNla::parse(buf).context(format!(
-                "failed to parse {kind} as DefaultNla: {payload:?}"
-            ))?),
+            kind => Self::Other(DefaultNla::parse(buf).with_context(|| {
+                format!("failed to parse {kind} as DefaultNla: {payload:?}")
+            })?),
         })
     }
 }

--- a/src/link/sriov/vf_vlan.rs
+++ b/src/link/sriov/vf_vlan.rs
@@ -44,13 +44,13 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for VfVlan {
         let payload = buf.value();
         Ok(match buf.kind() {
             IFLA_VF_VLAN_INFO => {
-                Self::Info(VfVlanInfo::parse(payload).context(format!(
-                    "invalid IFLA_VF_VLAN_INFO {payload:?}"
-                ))?)
+                Self::Info(VfVlanInfo::parse(payload).with_context(|| {
+                    format!("invalid IFLA_VF_VLAN_INFO {payload:?}")
+                })?)
             }
-            kind => Self::Other(DefaultNla::parse(buf).context(format!(
-                "failed to parse {kind} as DefaultNla: {payload:?}"
-            ))?),
+            kind => Self::Other(DefaultNla::parse(buf).with_context(|| {
+                format!("failed to parse {kind} as DefaultNla: {payload:?}")
+            })?),
         })
     }
 }

--- a/src/link/xdp.rs
+++ b/src/link/xdp.rs
@@ -110,10 +110,11 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for LinkXdp {
             IFLA_XDP_EXPECTED_FD => Self::ExpectedFd(
                 parse_u32(payload).context("invalid IFLA_XDP_PROG_ID value")?,
             ),
-            _ => Self::Other(
-                DefaultNla::parse(nla)
-                    .context(format!("unknown NLA type {}", nla.kind()))?,
-            ),
+            _ => {
+                Self::Other(DefaultNla::parse(nla).with_context(|| {
+                    format!("unknown NLA type {}", nla.kind())
+                })?)
+            }
         })
     }
 }

--- a/src/neighbour/attribute.rs
+++ b/src/neighbour/attribute.rs
@@ -117,42 +117,50 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
         Ok(match buf.kind() {
             NDA_DST => Self::Destination(
                 NeighbourAddress::parse_with_param(address_family, payload)
-                    .context(format!("invalid NDA_DST value {payload:?}"))?,
+                    .with_context(|| {
+                        format!("invalid NDA_DST value {payload:?}")
+                    })?,
             ),
             NDA_LLADDR => Self::LinkLayerAddress(payload.to_vec()),
-            NDA_CACHEINFO => {
-                Self::CacheInfo(NeighbourCacheInfo::parse(payload).context(
-                    format!("invalid NDA_CACHEINFO value {payload:?}"),
-                )?)
+            NDA_CACHEINFO => Self::CacheInfo(
+                NeighbourCacheInfo::parse(payload).with_context(|| {
+                    format!("invalid NDA_CACHEINFO value {payload:?}")
+                })?,
+            ),
+            NDA_PROBES => {
+                Self::Probes(parse_u32(payload).with_context(|| {
+                    format!("invalid NDA_PROBES value {payload:?}")
+                })?)
             }
-            NDA_PROBES => Self::Probes(
-                parse_u32(payload)
-                    .context(format!("invalid NDA_PROBES value {payload:?}"))?,
-            ),
             NDA_VLAN => Self::Vlan(parse_u16(payload)?),
-            NDA_PORT => Self::Port(
-                parse_u16_be(payload)
-                    .context(format!("invalid NDA_PORT value {payload:?}"))?,
-            ),
+            NDA_PORT => {
+                Self::Port(parse_u16_be(payload).with_context(|| {
+                    format!("invalid NDA_PORT value {payload:?}")
+                })?)
+            }
             NDA_VNI => Self::Vni(parse_u32(payload)?),
             NDA_IFINDEX => Self::IfIndex(parse_u32(payload)?),
-            NDA_CONTROLLER => Self::Controller(parse_u32(payload).context(
-                format!("invalid NDA_CONTROLLER value {payload:?}"),
-            )?),
-            NDA_LINK_NETNSID => Self::LinkNetNsId(parse_u32(payload).context(
-                format!("invalid NDA_LINK_NETNSID value {payload:?}"),
-            )?),
+            NDA_CONTROLLER => {
+                Self::Controller(parse_u32(payload).with_context(|| {
+                    format!("invalid NDA_CONTROLLER value {payload:?}")
+                })?)
+            }
+            NDA_LINK_NETNSID => {
+                Self::LinkNetNsId(parse_u32(payload).with_context(|| {
+                    format!("invalid NDA_LINK_NETNSID value {payload:?}")
+                })?)
+            }
             NDA_SRC_VNI => Self::SourceVni(parse_u32(payload)?),
             NDA_PROTOCOL => {
-                Self::Protocol(RouteProtocol::parse(payload).context(
-                    format!("invalid NDA_PROTOCOL value {payload:?}"),
+                Self::Protocol(RouteProtocol::parse(payload).with_context(
+                    || format!("invalid NDA_PROTOCOL value {payload:?}"),
                 )?)
             }
             NDA_FLAGS_EXT => {
                 Self::ExtFlags(NeighbourExtFlags::from_bits_retain(
-                    parse_u32(payload).context(format!(
-                        "invalid NDA_FLAGS_EXT value {payload:?}"
-                    ))?,
+                    parse_u32(payload).with_context(|| {
+                        format!("invalid NDA_FLAGS_EXT value {payload:?}")
+                    })?,
                 ))
             }
             _ => Self::Other(

--- a/src/neighbour_table/attribute.rs
+++ b/src/neighbour_table/attribute.rs
@@ -92,21 +92,23 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                 parse_string(payload).context("invalid NDTA_NAME value")?,
             ),
             NDTA_CONFIG => Self::Config(
-                NeighbourTableConfig::parse(payload)
-                    .context(format!("invalid NDTA_CONFIG {payload:?}"))?,
+                NeighbourTableConfig::parse(payload).with_context(|| {
+                    format!("invalid NDTA_CONFIG {payload:?}")
+                })?,
             ),
-            NDTA_STATS => Self::Stats(
-                NeighbourTableStats::parse(payload)
-                    .context(format!("invalid NDTA_STATS {payload:?}"))?,
-            ),
+            NDTA_STATS => {
+                Self::Stats(NeighbourTableStats::parse(payload).with_context(
+                    || format!("invalid NDTA_STATS {payload:?}"),
+                )?)
+            }
             NDTA_PARMS => {
                 let err = |payload| format!("invalid NDTA_PARMS {payload:?}");
                 Self::Parms(
                     VecNeighbourTableParameter::parse(
                         &NlaBuffer::new_checked(payload)
-                            .context(err(payload))?,
+                            .with_context(|| err(payload))?,
                     )
-                    .context(err(payload))?
+                    .with_context(|| err(payload))?
                     .0,
                 )
             }
@@ -124,7 +126,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
             ),
             kind => Self::Other(
                 DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {kind}"))?,
+                    .with_context(|| format!("unknown NLA type {kind}"))?,
             ),
         })
     }

--- a/src/neighbour_table/attribute.rs
+++ b/src/neighbour_table/attribute.rs
@@ -102,13 +102,12 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                 )?)
             }
             NDTA_PARMS => {
-                let err = |payload| format!("invalid NDTA_PARMS {payload:?}");
+                let err = || format!("invalid NDTA_PARMS {payload:?}");
                 Self::Parms(
                     VecNeighbourTableParameter::parse(
-                        &NlaBuffer::new_checked(payload)
-                            .with_context(|| err(payload))?,
+                        &NlaBuffer::new_checked(payload).with_context(err)?,
                     )
-                    .with_context(|| err(payload))?
+                    .with_context(err)?
                     .0,
                 )
             }

--- a/src/neighbour_table/param.rs
+++ b/src/neighbour_table/param.rs
@@ -134,88 +134,102 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
         let payload = buf.value();
         Ok(match buf.kind() {
             NDTPA_IFINDEX => {
-                Self::Ifindex(parse_u32(payload).context(format!(
-                    "invalid NDTPA_IFINDEX value {payload:?}"
-                ))?)
+                Self::Ifindex(parse_u32(payload).with_context(|| {
+                    format!("invalid NDTPA_IFINDEX value {payload:?}")
+                })?)
             }
             NDTPA_REFCNT => {
-                Self::ReferenceCount(parse_u32(payload).context(format!(
-                    "invalid NDTPA_REFCNT value {payload:?}"
-                ))?)
+                Self::ReferenceCount(parse_u32(payload).with_context(|| {
+                    format!("invalid NDTPA_REFCNT value {payload:?}")
+                })?)
             }
             NDTPA_REACHABLE_TIME => {
-                Self::ReachableTime(parse_u64(payload).context(format!(
-                    "invalid NDTPA_REACHABLE_TIME value {payload:?}"
-                ))?)
+                Self::ReachableTime(parse_u64(payload).with_context(|| {
+                    format!("invalid NDTPA_REACHABLE_TIME value {payload:?}")
+                })?)
             }
-            NDTPA_BASE_REACHABLE_TIME => {
-                Self::BaseReachableTime(parse_u64(payload).context(format!(
-                    "invalid NDTPA_BASE_REACHABLE_TIME value {payload:?}"
-                ))?)
-            }
+            NDTPA_BASE_REACHABLE_TIME => Self::BaseReachableTime(
+                parse_u64(payload).with_context(|| {
+                    format!(
+                        "invalid NDTPA_BASE_REACHABLE_TIME value {payload:?}"
+                    )
+                })?,
+            ),
             NDTPA_RETRANS_TIME => {
-                Self::RetransTime(parse_u64(payload).context(format!(
-                    "invalid NDTPA_RETRANS_TIME value {payload:?}"
-                ))?)
+                Self::RetransTime(parse_u64(payload).with_context(|| {
+                    format!("invalid NDTPA_RETRANS_TIME value {payload:?}")
+                })?)
             }
             NDTPA_GC_STALETIME => {
-                Self::GcStaletime(parse_u64(payload).context(format!(
-                    "invalid NDTPA_GC_STALE_TIME value {payload:?}"
-                ))?)
+                Self::GcStaletime(parse_u64(payload).with_context(|| {
+                    format!("invalid NDTPA_GC_STALE_TIME value {payload:?}")
+                })?)
             }
             NDTPA_DELAY_PROBE_TIME => {
-                Self::DelayProbeTime(parse_u64(payload).context(format!(
-                    "invalid NDTPA_DELAY_PROBE_TIME value {payload:?}"
-                ))?)
+                Self::DelayProbeTime(parse_u64(payload).with_context(|| {
+                    format!("invalid NDTPA_DELAY_PROBE_TIME value {payload:?}")
+                })?)
             }
-            NDTPA_QUEUE_LEN => Self::QueueLen(parse_u32(payload).context(
-                format!("invalid NDTPA_QUEUE_LEN value {payload:?}"),
-            )?),
-            NDTPA_APP_PROBES => Self::AppProbes(parse_u32(payload).context(
-                format!("invalid NDTPA_APP_PROBES value {payload:?}"),
-            )?),
+            NDTPA_QUEUE_LEN => {
+                Self::QueueLen(parse_u32(payload).with_context(|| {
+                    format!("invalid NDTPA_QUEUE_LEN value {payload:?}")
+                })?)
+            }
+            NDTPA_APP_PROBES => {
+                Self::AppProbes(parse_u32(payload).with_context(|| {
+                    format!("invalid NDTPA_APP_PROBES value {payload:?}")
+                })?)
+            }
             NDTPA_UCAST_PROBES => {
-                Self::UcastProbes(parse_u32(payload).context(format!(
-                    "invalid NDTPA_UCAST_PROBES value {payload:?}"
-                ))?)
+                Self::UcastProbes(parse_u32(payload).with_context(|| {
+                    format!("invalid NDTPA_UCAST_PROBES value {payload:?}")
+                })?)
             }
             NDTPA_MCAST_PROBES => {
-                Self::McastProbes(parse_u32(payload).context(format!(
-                    "invalid NDTPA_MCAST_PROBES value {payload:?}"
-                ))?)
+                Self::McastProbes(parse_u32(payload).with_context(|| {
+                    format!("invalid NDTPA_MCAST_PROBES value {payload:?}")
+                })?)
             }
             NDTPA_ANYCAST_DELAY => {
-                Self::AnycastDelay(parse_u64(payload).context(format!(
-                    "invalid NDTPA_ANYCAST_DELAY value {payload:?}"
-                ))?)
+                Self::AnycastDelay(parse_u64(payload).with_context(|| {
+                    format!("invalid NDTPA_ANYCAST_DELAY value {payload:?}")
+                })?)
             }
-            NDTPA_PROXY_DELAY => Self::ProxyDelay(parse_u64(payload).context(
-                format!("invalid NDTPA_PROXY_DELAY value {payload:?}"),
-            )?),
-            NDTPA_PROXY_QLEN => Self::ProxyQlen(parse_u32(payload).context(
-                format!("invalid NDTPA_PROXY_QLEN value {payload:?}"),
-            )?),
-            NDTPA_LOCKTIME => Self::Locktime(parse_u64(payload).context(
-                format!("invalid NDTPA_LOCKTIME value {payload:?}"),
-            )?),
+            NDTPA_PROXY_DELAY => {
+                Self::ProxyDelay(parse_u64(payload).with_context(|| {
+                    format!("invalid NDTPA_PROXY_DELAY value {payload:?}")
+                })?)
+            }
+            NDTPA_PROXY_QLEN => {
+                Self::ProxyQlen(parse_u32(payload).with_context(|| {
+                    format!("invalid NDTPA_PROXY_QLEN value {payload:?}")
+                })?)
+            }
+            NDTPA_LOCKTIME => {
+                Self::Locktime(parse_u64(payload).with_context(|| {
+                    format!("invalid NDTPA_LOCKTIME value {payload:?}")
+                })?)
+            }
             NDTPA_QUEUE_LENBYTES => {
-                Self::QueueLenbytes(parse_u32(payload).context(format!(
-                    "invalid NDTPA_QUEUE_LENBYTES value {payload:?}"
-                ))?)
+                Self::QueueLenbytes(parse_u32(payload).with_context(|| {
+                    format!("invalid NDTPA_QUEUE_LENBYTES value {payload:?}")
+                })?)
             }
             NDTPA_MCAST_REPROBES => {
-                Self::McastReprobes(parse_u32(payload).context(format!(
-                    "invalid NDTPA_MCAST_PROBES value {payload:?}"
-                ))?)
+                Self::McastReprobes(parse_u32(payload).with_context(|| {
+                    format!("invalid NDTPA_MCAST_PROBES value {payload:?}")
+                })?)
             }
             NDTPA_INTERVAL_PROBE_TIME_MS => Self::IntervalProbeTimeMs(
-                parse_u64(payload).context(format!(
+                parse_u64(payload).with_context(|| {
+                    format!(
                     "invalid NDTPA_INTERVAL_PROBE_TIME_MS value {payload:?}"
-                ))?,
+                )
+                })?,
             ),
-            _ => Self::Other(DefaultNla::parse(buf).context(format!(
-                "invalid NDTA_PARMS attribute {payload:?}"
-            ))?),
+            _ => Self::Other(DefaultNla::parse(buf).with_context(|| {
+                format!("invalid NDTA_PARMS attribute {payload:?}")
+            })?),
         })
     }
 }

--- a/src/nsid/attribute.rs
+++ b/src/nsid/attribute.rs
@@ -80,7 +80,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
             ),
             kind => Self::Other(
                 DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {kind}"))?,
+                    .with_context(|| format!("unknown NLA type {kind}"))?,
             ),
         })
     }

--- a/src/prefix/attribute.rs
+++ b/src/prefix/attribute.rs
@@ -62,8 +62,8 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                 }
             }
             PREFIX_CACHEINFO => {
-                Ok(Self::CacheInfo(CacheInfo::parse(payload).context(
-                    format!("Invalid PREFIX_CACHEINFO: {payload:?}"),
+                Ok(Self::CacheInfo(CacheInfo::parse(payload).with_context(
+                    || format!("Invalid PREFIX_CACHEINFO: {payload:?}"),
                 )?))
             }
             _ => Ok(Self::Other(DefaultNla::parse(buf)?)),

--- a/src/route/attribute.rs
+++ b/src/route/attribute.rs
@@ -241,13 +241,16 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
             RTA_PREFSRC => {
                 Self::PrefSource(RouteAddress::parse(address_family, payload)?)
             }
-            RTA_VIA => Self::Via(
-                RouteVia::parse(payload)
-                    .context(format!("Invalid RTA_VIA value {payload:?}"))?,
-            ),
+            RTA_VIA => {
+                Self::Via(RouteVia::parse(payload).with_context(|| {
+                    format!("Invalid RTA_VIA value {payload:?}")
+                })?)
+            }
             RTA_NEWDST => Self::NewDestination(
                 VecMplsLabel::parse(payload)
-                    .context(format!("Invalid RTA_NEWDST value {payload:?}"))?
+                    .with_context(|| {
+                        format!("Invalid RTA_NEWDST value {payload:?}")
+                    })?
                     .0,
             ),
 
@@ -257,24 +260,25 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
             ),
             RTA_EXPIRES => {
                 if route_type == RouteType::Multicast {
-                    Self::MulticastExpires(parse_u64(payload).context(
-                        format!(
+                    Self::MulticastExpires(parse_u64(payload).with_context(
+                        || {
+                            format!(
                             "invalid RTA_EXPIRES (multicast) value {payload:?}"
-                        ),
+                        )
+                        },
                     )?)
                 } else {
-                    Self::Expires(parse_u32(payload).context(format!(
-                        "invalid RTA_EXPIRES value {payload:?}"
-                    ))?)
+                    Self::Expires(parse_u32(payload).with_context(|| {
+                        format!("invalid RTA_EXPIRES value {payload:?}")
+                    })?)
                 }
             }
-            RTA_UID => Self::Uid(
-                parse_u32(payload)
-                    .context(format!("invalid RTA_UID value {payload:?}"))?,
-            ),
+            RTA_UID => Self::Uid(parse_u32(payload).with_context(|| {
+                format!("invalid RTA_UID value {payload:?}")
+            })?),
             RTA_TTL_PROPAGATE => Self::TtlPropagate(
-                RouteMplsTtlPropagation::from(parse_u8(payload).context(
-                    format!("invalid RTA_TTL_PROPAGATE {payload:?}"),
+                RouteMplsTtlPropagation::from(parse_u8(payload).with_context(
+                    || format!("invalid RTA_TTL_PROPAGATE {payload:?}"),
                 )?),
             ),
             RTA_ENCAP_TYPE => Self::EncapType(RouteLwEnCapType::from(

--- a/src/route/lwtunnel.rs
+++ b/src/route/lwtunnel.rs
@@ -329,11 +329,14 @@ where
     ) -> Result<Self, DecodeError> {
         let mut ret = Vec::new();
         for nla in NlasIterator::new(buf.value()) {
-            let nla =
-                nla.context(format!("Invalid RTA_ENCAP for kind: {kind}"))?;
-            ret.push(RouteLwTunnelEncap::parse_with_param(&nla, kind).context(
-                format!("Failed to parse RTA_ENCAP for kind: {kind}",),
-            )?)
+            let nla = nla.with_context(|| {
+                format!("Invalid RTA_ENCAP for kind: {kind}")
+            })?;
+            ret.push(
+                RouteLwTunnelEncap::parse_with_param(&nla, kind).with_context(
+                    || format!("Failed to parse RTA_ENCAP for kind: {kind}",),
+                )?,
+            )
         }
         Ok(Self(ret))
     }

--- a/src/route/mpls.rs
+++ b/src/route/mpls.rs
@@ -52,9 +52,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
         Ok(match buf.kind() {
             MPLS_IPTUNNEL_DST => Self::Destination(
                 VecMplsLabel::parse(payload)
-                    .context(format!(
-                        "invalid MPLS_IPTUNNEL_DST value {payload:?}"
-                    ))?
+                    .with_context(|| {
+                        format!("invalid MPLS_IPTUNNEL_DST value {payload:?}")
+                    })?
                     .0,
             ),
             MPLS_IPTUNNEL_TTL => Self::Ttl(

--- a/src/rule/attribute.rs
+++ b/src/rule/attribute.rs
@@ -153,14 +153,14 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
         let payload = buf.value();
 
         Ok(match buf.kind() {
-            FRA_DST => Self::Destination(
-                parse_ip_addr(payload)
-                    .context(format!("Invalid FRA_DST value {payload:?}"))?,
-            ),
-            FRA_SRC => Self::Source(
-                parse_ip_addr(payload)
-                    .context(format!("Invalid FRA_SRC value {payload:?}"))?,
-            ),
+            FRA_DST => Self::Destination(parse_ip_addr(payload).with_context(
+                || format!("Invalid FRA_DST value {payload:?}"),
+            )?),
+            FRA_SRC => {
+                Self::Source(parse_ip_addr(payload).with_context(|| {
+                    format!("Invalid FRA_SRC value {payload:?}")
+                })?)
+            }
             FRA_IIFNAME => Self::Iifname(
                 parse_string(payload).context("invalid FRA_IIFNAME value")?,
             ),

--- a/src/stats/attribute.rs
+++ b/src/stats/attribute.rs
@@ -101,10 +101,11 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
             IFLA_STATS_AF_SPEC => Self::AfSpec(
                 AfSpecStats::parse(payload).context("invalid AF_SPEC stats")?,
             ),
-            kind => Self::Other(
-                DefaultNla::parse(buf)
-                    .context(format!("unknown IFLA_STATS type {kind}"))?,
-            ),
+            kind => {
+                Self::Other(DefaultNla::parse(buf).with_context(|| {
+                    format!("unknown IFLA_STATS type {kind}")
+                })?)
+            }
         })
     }
 }

--- a/src/stats/bond.rs
+++ b/src/stats/bond.rs
@@ -143,10 +143,11 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Bond3adStats {
                 parse_u64(payload)
                     .context("invalid BOND_3AD_STAT_MARKER_UNKNOWN_RX value")?,
             ),
-            _ => Self::Other(
-                DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {}", buf.kind()))?,
-            ),
+            _ => {
+                Self::Other(DefaultNla::parse(buf).with_context(|| {
+                    format!("unknown NLA type {}", buf.kind())
+                })?)
+            }
         })
     }
 }

--- a/src/tc/attribute.rs
+++ b/src/tc/attribute.rs
@@ -115,7 +115,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> ParseableParametrized<NlaBuffer<&'a T>, &str>
             ),
             TCA_OPTIONS => TcAttribute::Options(
                 VecTcOption::parse_with_param(buf, kind)
-                    .context(format!("Invalid TCA_OPTIONS for kind: {kind}"))?
+                    .with_context(|| {
+                        format!("Invalid TCA_OPTIONS for kind: {kind}")
+                    })?
                     .0,
             ),
             TCA_STATS => TcAttribute::Stats(
@@ -131,9 +133,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> ParseableParametrized<NlaBuffer<&'a T>, &str>
                 let mut nlas = vec![];
                 for nla in NlasIterator::new(payload) {
                     let nla = nla.context("invalid TCA_STATS2")?;
-                    nlas.push(TcStats2::parse_with_param(&nla, kind).context(
-                        format!("failed to parse TCA_STATS2 for kind {kind}"),
-                    )?);
+                    nlas.push(TcStats2::parse_with_param(&nla, kind).with_context(|| format!("failed to parse TCA_STATS2 for kind {kind}"),)?);
                 }
                 TcAttribute::Stats2(nlas)
             }

--- a/src/tc/attribute.rs
+++ b/src/tc/attribute.rs
@@ -133,7 +133,13 @@ impl<'a, T: AsRef<[u8]> + ?Sized> ParseableParametrized<NlaBuffer<&'a T>, &str>
                 let mut nlas = vec![];
                 for nla in NlasIterator::new(payload) {
                     let nla = nla.context("invalid TCA_STATS2")?;
-                    nlas.push(TcStats2::parse_with_param(&nla, kind).with_context(|| format!("failed to parse TCA_STATS2 for kind {kind}"),)?);
+                    let stats = TcStats2::parse_with_param(&nla, kind)
+                        .with_context(|| {
+                            format!(
+                                "failed to parse TCA_STATS2 for kind {kind}"
+                            )
+                        })?;
+                    nlas.push(stats);
                 }
                 TcAttribute::Stats2(nlas)
             }

--- a/src/tc/filters/flower/core.rs
+++ b/src/tc/filters/flower/core.rs
@@ -129,9 +129,12 @@ fn parse_bytes_16(payload: &[u8]) -> Result<[u8; 16], DecodeError> {
 }
 
 macro_rules! nla_err {
-    // Match rule that takes an argument expression
+    // `$message` is only ever stringified, so the whole message is a
+    // compile-time constant. Build it with `concat!` rather than allocating a
+    // `String`: `context` takes the message by value, so it would otherwise be
+    // formatted on every successful parse and thrown away.
     ($message:expr) => {
-        format!("failed to parse {} value", stringify!($message))
+        concat!("failed to parse ", stringify!($message), " value")
     };
 }
 

--- a/src/tc/filters/flower/core.rs
+++ b/src/tc/filters/flower/core.rs
@@ -129,11 +129,8 @@ fn parse_bytes_16(payload: &[u8]) -> Result<[u8; 16], DecodeError> {
 }
 
 macro_rules! nla_err {
-    // `$message` is only ever stringified, so the whole message is a
-    // compile-time constant. Build it with `concat!` rather than allocating a
-    // `String`: `context` takes the message by value, so it would otherwise be
-    // formatted on every successful parse and thrown away.
-    ($message:expr) => {
+    // Shorthand for an NLA parse error message; expands to a &'static str
+    ($message:ident) => {
         concat!("failed to parse ", stringify!($message), " value")
     };
 }

--- a/src/tc/filters/flower/mpls.rs
+++ b/src/tc/filters/flower/mpls.rs
@@ -6,9 +6,12 @@ use netlink_packet_core::{
 };
 
 macro_rules! nla_err {
-    // Match rule that takes an argument expression
+    // `$message` is only ever stringified, so the whole message is a
+    // compile-time constant. Build it with `concat!` rather than allocating a
+    // `String`: `context` takes the message by value, so it would otherwise be
+    // formatted on every successful parse and thrown away.
     ($message:expr) => {
-        &format!("failed to parse {} value", stringify!($message))
+        concat!("failed to parse ", stringify!($message), " value")
     };
 }
 

--- a/src/tc/filters/flower/mpls.rs
+++ b/src/tc/filters/flower/mpls.rs
@@ -6,11 +6,8 @@ use netlink_packet_core::{
 };
 
 macro_rules! nla_err {
-    // `$message` is only ever stringified, so the whole message is a
-    // compile-time constant. Build it with `concat!` rather than allocating a
-    // `String`: `context` takes the message by value, so it would otherwise be
-    // formatted on every successful parse and thrown away.
-    ($message:expr) => {
+    // Shorthand for an NLA parse error message; expands to a &'static str
+    ($message:ident) => {
         concat!("failed to parse ", stringify!($message), " value")
     };
 }

--- a/src/tc/options.rs
+++ b/src/tc/options.rs
@@ -126,14 +126,16 @@ where
             | TcFilterBpf::KIND => {
                 let mut nlas = vec![];
                 for nla in NlasIterator::new(buf.value()) {
-                    let nla = nla.context(format!(
-                        "Invalid TCA_OPTIONS for kind: {kind}",
-                    ))?;
+                    let nla = nla.with_context(|| {
+                        format!("Invalid TCA_OPTIONS for kind: {kind}",)
+                    })?;
                     nlas.push(
-                        TcOption::parse_with_param(&nla, kind).context(
-                            format!(
+                        TcOption::parse_with_param(&nla, kind).with_context(
+                            || {
+                                format!(
                                 "Failed to parse TCA_OPTIONS for kind: {kind}",
-                            ),
+                            )
+                            },
                         )?,
                     )
                 }


### PR DESCRIPTION
Rebased on `main` (0.33.0); uses `ErrorContext::with_context` from netlink-packet-core 0.9.0.

I used a script to convert most of the usage, then did a review and found a few other spots:

* `nla_err!` macro did `format!()`, but since the argument is only stringified, we can convert it to use `concat!()` making the macro produce a `&'static str`. Changed the argument from `expr` to `ident` since it only ever takes a bare name.
* modified some shared error messages `let err = |payload| format!()` to capture `payload` and then passed as `with_context(err)`

6x performance increase parsing a captured 61-interface link dump (`NetlinkMessage::<RouteNetlinkMessage>::deserialize` per message): 1.47ms -> 246µs. Behaviour is unchanged: `cargo test` passes and the parsed output is identical to 0.33.0 on the same captures.

I looked at doing `.context(format_args!(...))` instead of `with_context()`, but `format_args!` had ~12% worse performance (279µs vs 246µs).

Related to: https://github.com/rust-netlink/netlink-packet-route/issues/297

_AI was used to assist with the changes, I have written the PR comments, and reviewed all of the changes manually_