### PR TITLE
route: Add ipproto, sport, dport, flowlabel, nhid support

### DIFF
--- a/src/route/attribute.rs
+++ b/src/route/attribute.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 
 use netlink_packet_core::{
-    emit_u32, emit_u64, parse_u16, parse_u32, parse_u64, parse_u8, DecodeError,
-    DefaultNla, Emitable, ErrorContext, Nla, NlaBuffer, Parseable,
-    ParseableParametrized,
+    emit_u32, emit_u64, parse_u16, parse_u16_be, parse_u32, parse_u64,
+    parse_u8, DecodeError, DefaultNla, Emitable, ErrorContext, Nla, NlaBuffer,
+    Parseable, ParseableParametrized,
 };
 
 use super::{
@@ -40,11 +40,11 @@ const RTA_ENCAP: u16 = 22;
 const RTA_EXPIRES: u16 = 23;
 const RTA_UID: u16 = 25;
 const RTA_TTL_PROPAGATE: u16 = 26;
-// TODO
-// const RTA_IP_PROTO:u16 = 27;
-// const RTA_SPORT:u16 = 28;
-// const RTA_DPORT:u16 = 29;
-// const RTA_NH_ID:u16 = 30;
+const RTA_IP_PROTO: u16 = 27;
+const RTA_SPORT: u16 = 28;
+const RTA_DPORT: u16 = 29;
+const RTA_NH_ID: u16 = 30;
+const RTA_FLOWLABEL: u16 = 31;
 
 /// Netlink attributes for `RTM_NEWROUTE`, `RTM_DELROUTE`,
 /// `RTM_GETROUTE` netlink messages.
@@ -81,6 +81,11 @@ pub enum RouteAttribute {
     Realm(RouteRealm),
     Table(u32),
     Mark(u32),
+    IpProto(u8),
+    Sport(u16),
+    Dport(u16),
+    Flowlabel(u32),
+    NhId(u32),
     Other(DefaultNla),
 }
 
@@ -112,6 +117,9 @@ impl Nla for RouteAttribute {
             | Self::Table(_)
             | Self::Mark(_) => 4,
             Self::MulticastExpires(_) => 8,
+            Self::IpProto(_) => 1,
+            Self::Sport(_) | Self::Dport(_) => 2,
+            Self::Flowlabel(_) | Self::NhId(_) => 4,
             Self::Other(attr) => attr.value_len(),
         }
     }
@@ -149,6 +157,13 @@ impl Nla for RouteAttribute {
             | Self::Mark(value) => emit_u32(buffer, *value).unwrap(),
             Self::Realm(v) => v.emit(buffer),
             Self::MulticastExpires(value) => emit_u64(buffer, *value).unwrap(),
+            Self::IpProto(value) => buffer[0] = *value,
+            Self::Sport(value) | Self::Dport(value) => {
+                buffer[..2].copy_from_slice(&value.to_be_bytes())
+            }
+            Self::Flowlabel(value) | Self::NhId(value) => {
+                emit_u32(buffer, *value).unwrap()
+            }
             Self::Other(attr) => attr.emit_value(buffer),
         }
     }
@@ -178,6 +193,11 @@ impl Nla for RouteAttribute {
             Self::MulticastExpires(_) => RTA_EXPIRES,
             Self::Uid(_) => RTA_UID,
             Self::TtlPropagate(_) => RTA_TTL_PROPAGATE,
+            Self::IpProto(_) => RTA_IP_PROTO,
+            Self::Sport(_) => RTA_SPORT,
+            Self::Dport(_) => RTA_DPORT,
+            Self::Flowlabel(_) => RTA_FLOWLABEL,
+            Self::NhId(_) => RTA_NH_ID,
             Self::Other(ref attr) => attr.kind(),
         }
     }
@@ -322,6 +342,21 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
                 }
                 Self::MultiPath(next_hops)
             }
+            RTA_IP_PROTO => Self::IpProto(
+                parse_u8(payload).context("invalid RTA_IP_PROTO value")?,
+            ),
+            RTA_SPORT => Self::Sport(
+                parse_u16_be(payload).context("invalid RTA_SPORT value")?,
+            ),
+            RTA_DPORT => Self::Dport(
+                parse_u16_be(payload).context("invalid RTA_DPORT value")?,
+            ),
+            RTA_FLOWLABEL => Self::Flowlabel(
+                parse_u32(payload).context("invalid RTA_FLOWLABEL value")?,
+            ),
+            RTA_NH_ID => Self::NhId(
+                parse_u32(payload).context("invalid RTA_NH_ID value")?,
+            ),
             _ => Self::Other(
                 DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?,
             ),

--- a/src/route/tests/metrics.rs
+++ b/src/route/tests/metrics.rs
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: MIT
+
+use std::net::Ipv4Addr;
+
+use netlink_packet_core::{Emitable, Parseable};
+
+use crate::{
+    route::{
+        flags::RouteFlags, RouteAttribute, RouteHeader, RouteMessage,
+        RouteMessageBuffer, RouteMetric, RouteProtocol, RouteScope, RouteType,
+    },
+    AddressFamily,
+};
+
+// wireshark capture(netlink message header removed) of nlmon against command:
+//   ip route add 10.103.0.0/16 via 10.0.0.254 dev test-dummy mtu 1500
+//       window 65535 rtt 100ms hoplimit 64
+#[test]
+fn test_route_metrics_mtu_window_rtt_hoplimit() {
+    let raw = vec![
+        // rtmsg: family=AF_INET(2), dst_len=16, src_len=0, tos=0,
+        //        table=main(254), proto=boot(3), scope=global(0),
+        //        type=unicast(1), flags=0
+        0x02, 0x10, 0x00, 0x00, 0xfe, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+        // RTA_TABLE(0x0f)=254
+        0x08, 0x00, 0x0f, 0x00, 0xfe, 0x00, 0x00, 0x00,
+        // RTA_DST(0x01)=10.103.0.0
+        0x08, 0x00, 0x01, 0x00, 0x0a, 0x67, 0x00, 0x00,
+        // RTA_METRICS(0x08) containing:
+        //   RTAX_MTU(2)=1500(0x05dc), RTAX_WINDOW(3)=65535(0xffff),
+        //   RTAX_RTT(4)=800(100ms*8=0x0320), RTAX_HOPLIMIT(10)=64(0x40)
+        0x24, 0x00, 0x08, 0x00, 0x08, 0x00, 0x02, 0x00, 0xdc, 0x05, 0x00, 0x00,
+        0x08, 0x00, 0x03, 0x00, 0xff, 0xff, 0x00, 0x00, 0x08, 0x00, 0x04, 0x00,
+        0x20, 0x03, 0x00, 0x00, 0x08, 0x00, 0x0a, 0x00, 0x40, 0x00, 0x00, 0x00,
+        // RTA_GATEWAY(0x05)=10.0.0.254
+        0x08, 0x00, 0x05, 0x00, 0x0a, 0x00, 0x00, 0xfe,
+        // RTA_OIF(0x04)=17
+        0x08, 0x00, 0x04, 0x00, 0x11, 0x00, 0x00, 0x00,
+    ];
+
+    let expected = RouteMessage {
+        header: RouteHeader {
+            address_family: AddressFamily::Inet,
+            destination_prefix_length: 16,
+            source_prefix_length: 0,
+            tos: 0,
+            table: 254,
+            protocol: RouteProtocol::Boot,
+            scope: RouteScope::Universe,
+            kind: RouteType::Unicast,
+            flags: RouteFlags::empty(),
+        },
+        attributes: vec![
+            RouteAttribute::Table(254),
+            RouteAttribute::Destination(Ipv4Addr::new(10, 103, 0, 0).into()),
+            RouteAttribute::Metrics(vec![
+                RouteMetric::Mtu(1500),
+                RouteMetric::Window(65535),
+                RouteMetric::Rtt(800),
+                RouteMetric::Hoplimit(64),
+            ]),
+            RouteAttribute::Gateway(Ipv4Addr::new(10, 0, 0, 254).into()),
+            RouteAttribute::Oif(17),
+        ],
+    };
+
+    assert_eq!(
+        expected,
+        RouteMessage::parse(&RouteMessageBuffer::new(&raw)).unwrap()
+    );
+
+    let mut buf = vec![0; expected.buffer_len()];
+    expected.emit(&mut buf);
+    assert_eq!(buf, raw);
+}
+
+// wireshark capture of nlmon against command:
+//   ip route add 10.106.0.0/16 via 10.0.0.254 dev test-dummy
+//       advmss 1460 ssthresh 100 cwnd 100 initcwnd 10 initrwnd 10
+#[test]
+fn test_route_metrics_advmss_ssthresh_cwnd_initcwnd_initrwnd() {
+    let raw = vec![
+        // rtmsg: family=AF_INET(2), dst_len=16, src_len=0, tos=0,
+        //        table=main(254), proto=boot(3), scope=global(0),
+        //        type=unicast(1), flags=0
+        0x02, 0x10, 0x00, 0x00, 0xfe, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+        // RTA_TABLE(0x0f)=254
+        0x08, 0x00, 0x0f, 0x00, 0xfe, 0x00, 0x00, 0x00,
+        // RTA_DST(0x01)=10.106.0.0
+        0x08, 0x00, 0x01, 0x00, 0x0a, 0x6a, 0x00, 0x00,
+        // RTA_METRICS(0x08):
+        //   RTAX_SSTHRESH(6)=100, RTAX_CWND(7)=100, RTAX_ADVMSS(8)=1460,
+        //   RTAX_INITCWND(11)=10, RTAX_INITRWND(14)=10
+        0x2c, 0x00, 0x08, 0x00, 0x08, 0x00, 0x06, 0x00, 0x64, 0x00, 0x00, 0x00,
+        0x08, 0x00, 0x07, 0x00, 0x64, 0x00, 0x00, 0x00, 0x08, 0x00, 0x08, 0x00,
+        0xb4, 0x05, 0x00, 0x00, 0x08, 0x00, 0x0b, 0x00, 0x0a, 0x00, 0x00, 0x00,
+        0x08, 0x00, 0x0e, 0x00, 0x0a, 0x00, 0x00, 0x00,
+        // RTA_GATEWAY(0x05)=10.0.0.254
+        0x08, 0x00, 0x05, 0x00, 0x0a, 0x00, 0x00, 0xfe,
+        // RTA_OIF(0x04)=17
+        0x08, 0x00, 0x04, 0x00, 0x11, 0x00, 0x00, 0x00,
+    ];
+
+    let expected = RouteMessage {
+        header: RouteHeader {
+            address_family: AddressFamily::Inet,
+            destination_prefix_length: 16,
+            source_prefix_length: 0,
+            tos: 0,
+            table: 254,
+            protocol: RouteProtocol::Boot,
+            scope: RouteScope::Universe,
+            kind: RouteType::Unicast,
+            flags: RouteFlags::empty(),
+        },
+        attributes: vec![
+            RouteAttribute::Table(254),
+            RouteAttribute::Destination(Ipv4Addr::new(10, 106, 0, 0).into()),
+            RouteAttribute::Metrics(vec![
+                RouteMetric::SsThresh(100),
+                RouteMetric::Cwnd(100),
+                RouteMetric::Advmss(1460),
+                RouteMetric::InitCwnd(10),
+                RouteMetric::InitRwnd(10),
+            ]),
+            RouteAttribute::Gateway(Ipv4Addr::new(10, 0, 0, 254).into()),
+            RouteAttribute::Oif(17),
+        ],
+    };
+
+    assert_eq!(
+        expected,
+        RouteMessage::parse(&RouteMessageBuffer::new(&raw)).unwrap()
+    );
+
+    let mut buf = vec![0; expected.buffer_len()];
+    expected.emit(&mut buf);
+    assert_eq!(buf, raw);
+}
+
+// wireshark capture of nlmon against command:
+//   ip route add 10.107.0.0/16 via 10.0.0.254 dev test-dummy
+//       reordering 5 rto_min 200ms quickack 1 fastopen_no_cookie 1
+#[test]
+fn test_route_metrics_reordering_rto_min_quickack_fastopen() {
+    let raw = vec![
+        0x02, 0x10, 0x00, 0x00, 0xfe, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+        // RTA_TABLE(0x0f)=254
+        0x08, 0x00, 0x0f, 0x00, 0xfe, 0x00, 0x00, 0x00,
+        // RTA_DST(0x01)=10.107.0.0
+        0x08, 0x00, 0x01, 0x00, 0x0a, 0x6b, 0x00, 0x00,
+        // RTA_METRICS(0x08):
+        //   RTAX_LOCK(1)=0x2000 (RTAX_RTO_MIN bit), RTAX_REORDERING(9)=5,
+        //   RTAX_RTO_MIN(13)=200(0xc8), RTAX_QUICKACK(15)=1,
+        //   RTAX_FASTOPEN_NO_COOKIE(17)=1
+        0x2c, 0x00, 0x08, 0x00, 0x08, 0x00, 0x01, 0x00, 0x00, 0x20, 0x00, 0x00,
+        0x08, 0x00, 0x09, 0x00, 0x05, 0x00, 0x00, 0x00, 0x08, 0x00, 0x0d, 0x00,
+        0xc8, 0x00, 0x00, 0x00, 0x08, 0x00, 0x0f, 0x00, 0x01, 0x00, 0x00, 0x00,
+        0x08, 0x00, 0x11, 0x00, 0x01, 0x00, 0x00, 0x00,
+        // RTA_GATEWAY(0x05)=10.0.0.254
+        0x08, 0x00, 0x05, 0x00, 0x0a, 0x00, 0x00, 0xfe,
+        // RTA_OIF(0x04)=17
+        0x08, 0x00, 0x04, 0x00, 0x11, 0x00, 0x00, 0x00,
+    ];
+
+    let expected = RouteMessage {
+        header: RouteHeader {
+            address_family: AddressFamily::Inet,
+            destination_prefix_length: 16,
+            source_prefix_length: 0,
+            tos: 0,
+            table: 254,
+            protocol: RouteProtocol::Boot,
+            scope: RouteScope::Universe,
+            kind: RouteType::Unicast,
+            flags: RouteFlags::empty(),
+        },
+        attributes: vec![
+            RouteAttribute::Table(254),
+            RouteAttribute::Destination(Ipv4Addr::new(10, 107, 0, 0).into()),
+            RouteAttribute::Metrics(vec![
+                RouteMetric::Lock(0x2000),
+                RouteMetric::Reordering(5),
+                RouteMetric::RtoMin(200),
+                RouteMetric::QuickAck(1),
+                RouteMetric::FastopenNoCookie(1),
+            ]),
+            RouteAttribute::Gateway(Ipv4Addr::new(10, 0, 0, 254).into()),
+            RouteAttribute::Oif(17),
+        ],
+    };
+
+    assert_eq!(
+        expected,
+        RouteMessage::parse(&RouteMessageBuffer::new(&raw)).unwrap()
+    );
+
+    let mut buf = vec![0; expected.buffer_len()];
+    expected.emit(&mut buf);
+    assert_eq!(buf, raw);
+}
+
+// wireshark capture of nlmon against command:
+//   ip route add 10.108.0.0/16 via 10.0.0.254 dev test-dummy features ecn
+#[test]
+fn test_route_metrics_features_ecn() {
+    let raw = vec![
+        0x02, 0x10, 0x00, 0x00, 0xfe, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+        // RTA_TABLE(0x0f)=254
+        0x08, 0x00, 0x0f, 0x00, 0xfe, 0x00, 0x00, 0x00,
+        // RTA_DST(0x01)=10.108.0.0
+        0x08, 0x00, 0x01, 0x00, 0x0a, 0x6c, 0x00, 0x00,
+        // RTA_METRICS(0x08): RTAX_FEATURES(12)=1 (ecn bit)
+        0x0c, 0x00, 0x08, 0x00, 0x08, 0x00, 0x0c, 0x00, 0x01, 0x00, 0x00, 0x00,
+        // RTA_GATEWAY(0x05)=10.0.0.254
+        0x08, 0x00, 0x05, 0x00, 0x0a, 0x00, 0x00, 0xfe,
+        // RTA_OIF(0x04)=17
+        0x08, 0x00, 0x04, 0x00, 0x11, 0x00, 0x00, 0x00,
+    ];
+
+    let expected = RouteMessage {
+        header: RouteHeader {
+            address_family: AddressFamily::Inet,
+            destination_prefix_length: 16,
+            source_prefix_length: 0,
+            tos: 0,
+            table: 254,
+            protocol: RouteProtocol::Boot,
+            scope: RouteScope::Universe,
+            kind: RouteType::Unicast,
+            flags: RouteFlags::empty(),
+        },
+        attributes: vec![
+            RouteAttribute::Table(254),
+            RouteAttribute::Destination(Ipv4Addr::new(10, 108, 0, 0).into()),
+            RouteAttribute::Metrics(vec![RouteMetric::Features(1)]),
+            RouteAttribute::Gateway(Ipv4Addr::new(10, 0, 0, 254).into()),
+            RouteAttribute::Oif(17),
+        ],
+    };
+
+    assert_eq!(
+        expected,
+        RouteMessage::parse(&RouteMessageBuffer::new(&raw)).unwrap()
+    );
+
+    let mut buf = vec![0; expected.buffer_len()];
+    expected.emit(&mut buf);
+    assert_eq!(buf, raw);
+}

--- a/src/route/tests/mod.rs
+++ b/src/route/tests/mod.rs
@@ -9,6 +9,8 @@ mod ip6_tunnel;
 #[cfg(test)]
 mod loopback;
 #[cfg(test)]
+mod metrics;
+#[cfg(test)]
 mod mpls;
 #[cfg(test)]
 mod multipath;

--- a/src/route/tests/multipath.rs
+++ b/src/route/tests/multipath.rs
@@ -1,1 +1,84 @@
 // SPDX-License-Identifier: MIT
+
+use std::net::Ipv4Addr;
+
+use netlink_packet_core::{Emitable, Parseable};
+
+use crate::{
+    route::{
+        flags::RouteFlags, RouteAttribute, RouteHeader, RouteMessage,
+        RouteMessageBuffer, RouteNextHop, RouteNextHopFlags, RouteProtocol,
+        RouteScope, RouteType,
+    },
+    AddressFamily,
+};
+
+// wireshark capture(netlink message header removed) of nlmon against command:
+//   ip route add 10.109.0.0/16 nexthop via 10.0.0.254 dev test-dummy weight 1
+//       nexthop via 10.0.0.253 dev test-dummy weight 2
+#[test]
+fn test_route_multipath_two_nexthops() {
+    let raw = vec![
+        // rtmsg: family=AF_INET(2), dst_len=16, src_len=0, tos=0,
+        //        table=main(254), proto=boot(3), scope=global(0),
+        //        type=unicast(1), flags=0
+        0x02, 0x10, 0x00, 0x00, 0xfe, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+        // RTA_TABLE(0x0f)=254
+        0x08, 0x00, 0x0f, 0x00, 0xfe, 0x00, 0x00, 0x00,
+        // RTA_DST(0x01)=10.109.0.0
+        0x08, 0x00, 0x01, 0x00, 0x0a, 0x6d, 0x00, 0x00,
+        // RTA_MULTIPATH(0x09) with 2 nexthops:
+        //   nexthop 0: len=16, flags=0, hops=0(weight=1), ifindex=17
+        //              RTA_GATEWAY=10.0.0.254
+        //   nexthop 1: len=16, flags=0, hops=1(weight=2), ifindex=17
+        //              RTA_GATEWAY=10.0.0.253
+        0x24, 0x00, 0x09, 0x00, 0x10, 0x00, 0x00, 0x00, 0x11, 0x00, 0x00, 0x00,
+        0x08, 0x00, 0x05, 0x00, 0x0a, 0x00, 0x00, 0xfe, 0x10, 0x00, 0x00, 0x01,
+        0x11, 0x00, 0x00, 0x00, 0x08, 0x00, 0x05, 0x00, 0x0a, 0x00, 0x00, 0xfd,
+    ];
+
+    let expected = RouteMessage {
+        header: RouteHeader {
+            address_family: AddressFamily::Inet,
+            destination_prefix_length: 16,
+            source_prefix_length: 0,
+            tos: 0,
+            table: 254,
+            protocol: RouteProtocol::Boot,
+            scope: RouteScope::Universe,
+            kind: RouteType::Unicast,
+            flags: RouteFlags::empty(),
+        },
+        attributes: vec![
+            RouteAttribute::Table(254),
+            RouteAttribute::Destination(Ipv4Addr::new(10, 109, 0, 0).into()),
+            RouteAttribute::MultiPath(vec![
+                RouteNextHop {
+                    flags: RouteNextHopFlags::empty(),
+                    hops: 0,
+                    interface_index: 17,
+                    attributes: vec![RouteAttribute::Gateway(
+                        Ipv4Addr::new(10, 0, 0, 254).into(),
+                    )],
+                },
+                RouteNextHop {
+                    flags: RouteNextHopFlags::empty(),
+                    hops: 1,
+                    interface_index: 17,
+                    attributes: vec![RouteAttribute::Gateway(
+                        Ipv4Addr::new(10, 0, 0, 253).into(),
+                    )],
+                },
+            ]),
+        ],
+    };
+
+    assert_eq!(
+        expected,
+        RouteMessage::parse(&RouteMessageBuffer::new(&raw)).unwrap()
+    );
+
+    let mut buf = vec![0; expected.buffer_len()];
+    expected.emit(&mut buf);
+    assert_eq!(buf, raw);
+}


### PR DESCRIPTION
Unit test cases included.