### PR TITLE
tc: fix TCA_ROOT_TIME_DELTA byte order

### DIFF
--- a/src/tc/actions/message.rs
+++ b/src/tc/actions/message.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 use netlink_packet_core::{
-    parse_string, parse_u32, parse_u32_be, DecodeError, DefaultNla, Emitable,
-    ErrorContext, Nla, NlaBuffer, NlasIterator, Parseable,
+    parse_string, parse_u32, DecodeError, DefaultNla, Emitable, ErrorContext,
+    Nla, NlaBuffer, NlasIterator, Parseable,
 };
 
 use crate::tc::{
@@ -173,7 +173,7 @@ impl<'a, T: AsRef<[u8]> + 'a + ?Sized> Parseable<NlaBuffer<&'a T>>
                 Self::RootCount(count)
             }
             TCA_ROOT_TIME_DELTA => {
-                let delta = parse_u32_be(buf.value())
+                let delta = parse_u32(buf.value())
                     .context("Invalid TCA_ROOT_TIME_DELTA")?;
                 Self::RootTimeDelta(delta)
             }
@@ -220,7 +220,7 @@ impl Nla for TcActionMessageAttribute {
                 buffer.copy_from_slice(&count.to_ne_bytes());
             }
             Self::RootTimeDelta(delta) => {
-                buffer.copy_from_slice(&delta.to_be_bytes());
+                buffer.copy_from_slice(&delta.to_ne_bytes());
             }
             Self::RootExtWarnMsg(msg) => buffer.copy_from_slice(msg.as_bytes()),
             Self::Other(nla) => nla.emit_value(buffer),

--- a/src/tc/actions/tests/message.rs
+++ b/src/tc/actions/tests/message.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{DefaultNla, Emitable, NlaBuffer, Parseable};
+use netlink_packet_core::{DefaultNla, Emitable, Nla, NlaBuffer, Parseable};
 
 use crate::{
     tc::{
@@ -418,4 +418,27 @@ fn tc_action_message_parse_back_example_value() {
     )
     .unwrap();
     assert_eq!(orig, parsed);
+}
+
+#[test]
+fn tc_action_root_time_delta_native_byte_order() {
+    // TCA_ROOT_TIME_DELTA is an NLA_U32 attribute: the kernel reads it with
+    // nla_get_u32(), i.e. in native byte order. The payload must therefore be
+    // the native-endian bytes of the value, not big-endian.
+    let value = 0x12345678u32;
+    let attr = RootTimeDelta(value);
+
+    let mut payload = vec![0u8; attr.value_len()];
+    attr.emit_value(&mut payload);
+    assert_eq!(payload, value.to_ne_bytes());
+
+    let mut raw = Vec::new();
+    raw.extend_from_slice(&8u16.to_ne_bytes());
+    raw.extend_from_slice(&attr.kind().to_ne_bytes());
+    raw.extend_from_slice(&value.to_ne_bytes());
+    let buf = NlaBuffer::new_checked(&raw).unwrap();
+    assert_eq!(
+        TcActionMessageAttribute::parse(&buf).unwrap(),
+        RootTimeDelta(value)
+    );
 }


### PR DESCRIPTION
The TCA_ROOT_TIME_DELTA is a native endian in kernel code.