### PR TITLE
API break: link: use zerocopy for link buffer parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ bitflags = "2"
 libc = "0.2.66"
 log = { version = "0.4.20", features = ["std"] }
 netlink-packet-core = { version = "0.8.2" }
+zerocopy = { version = "0.8", features = ["derive"] }
 
 [[example]]
 name = "dump_packet_links"

--- a/src/link/af_spec/inet.rs
+++ b/src/link/af_spec/inet.rs
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: MIT
 
+use std::mem::size_of;
+
 use netlink_packet_core::{
     DecodeError, DefaultNla, Emitable, ErrorContext, Nla, NlaBuffer,
     NlasIterator, Parseable, NLA_F_NESTED,
 };
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use super::super::buffer_tool::expand_buffer_if_small;
 
@@ -12,7 +15,6 @@ pub(crate) const IFLA_INET_CONF: u16 = 1;
 // This number might change when kernel add more IPV4_DEV_CONF
 const __IPV4_DEVCONF_MAX: usize = 34;
 const IPV4_DEVCONF_MAX: usize = __IPV4_DEVCONF_MAX - 1;
-pub(crate) const DEV_CONF_LEN: usize = IPV4_DEVCONF_MAX * 4;
 
 // IPV4_DEVCONF_* enum values from linux/ip.h (1-based)
 const IPV4_DEVCONF_FORWARDING: u16 = 1;
@@ -107,16 +109,14 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for AfSpecInet {
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();
         Ok(match buf.kind() {
-            IFLA_INET_CONF => {
-                Self::DevConf(InetDevConf::parse(&InetDevConfBuffer::new(
-                    expand_buffer_if_small(
-                        payload,
-                        DEV_CONF_LEN,
-                        "IFLA_INET_CONF",
-                    )
-                    .as_slice(),
-                ))?)
-            }
+            IFLA_INET_CONF => Self::DevConf(InetDevConf::parse(
+                expand_buffer_if_small(
+                    payload,
+                    size_of::<InetDevConfBuffer>(),
+                    "IFLA_INET_CONF",
+                )
+                .as_slice(),
+            )?),
             kind => Self::Other(DefaultNla::parse(buf).context(format!(
                 "Unknown NLA type {kind} for IFLA_AF_SPEC(inet)"
             ))?),
@@ -202,41 +202,53 @@ fn devconf_entries(conf: &InetDevConf) -> [(u16, i32); IPV4_DEVCONF_MAX] {
 
 // ---- InetDevConf (flat buffer, matches kernel dump format) ----
 
-buffer!(InetDevConfBuffer(DEV_CONF_LEN) {
-    forwarding: (i32, 0..4),
-    mc_forwarding: (i32, 4..8),
-    proxy_arp: (i32, 8..12),
-    accept_redirects: (i32, 12..16),
-    secure_redirects: (i32, 16..20),
-    send_redirects: (i32, 20..24),
-    shared_media: (i32, 24..28),
-    rp_filter: (i32, 28..32),
-    accept_source_route: (i32, 32..36),
-    bootp_relay: (i32, 36..40),
-    log_martians: (i32, 40..44),
-    tag: (i32, 44..48),
-    arpfilter: (i32, 48..52),
-    medium_id: (i32, 52..56),
-    noxfrm: (i32, 56..60),
-    nopolicy: (i32, 60..64),
-    force_igmp_version: (i32, 64..68),
-    arp_announce: (i32, 68..72),
-    arp_ignore: (i32, 72..76),
-    promote_secondaries: (i32, 76..80),
-    arp_accept: (i32, 80..84),
-    arp_notify: (i32, 84..88),
-    accept_local: (i32, 88..92),
-    src_vmark: (i32, 92..96),
-    proxy_arp_pvlan: (i32, 96..100),
-    route_localnet: (i32, 100..104),
-    igmpv2_unsolicited_report_interval: (i32, 104..108),
-    igmpv3_unsolicited_report_interval: (i32, 108..112),
-    ignore_routes_with_linkdown: (i32, 112..116),
-    drop_unicast_in_l2_multicast: (i32, 116..120),
-    drop_gratuitous_arp: (i32, 120..124),
-    bc_forwarding: (i32, 124..128),
-    arp_evict_nocarrier: (i32, 128..132),
-});
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct InetDevConfBuffer {
+    forwarding: i32,
+    mc_forwarding: i32,
+    proxy_arp: i32,
+    accept_redirects: i32,
+    secure_redirects: i32,
+    send_redirects: i32,
+    shared_media: i32,
+    rp_filter: i32,
+    accept_source_route: i32,
+    bootp_relay: i32,
+    log_martians: i32,
+    tag: i32,
+    arpfilter: i32,
+    medium_id: i32,
+    noxfrm: i32,
+    nopolicy: i32,
+    force_igmp_version: i32,
+    arp_announce: i32,
+    arp_ignore: i32,
+    promote_secondaries: i32,
+    arp_accept: i32,
+    arp_notify: i32,
+    accept_local: i32,
+    src_vmark: i32,
+    proxy_arp_pvlan: i32,
+    route_localnet: i32,
+    igmpv2_unsolicited_report_interval: i32,
+    igmpv3_unsolicited_report_interval: i32,
+    ignore_routes_with_linkdown: i32,
+    drop_unicast_in_l2_multicast: i32,
+    drop_gratuitous_arp: i32,
+    bc_forwarding: i32,
+    arp_evict_nocarrier: i32,
+}
 
 #[derive(Clone, Copy, Eq, PartialEq, Debug, Default)]
 #[non_exhaustive]
@@ -276,94 +288,104 @@ pub struct InetDevConf {
     pub arp_evict_nocarrier: i32,
 }
 
-impl<T: AsRef<[u8]>> Parseable<InetDevConfBuffer<T>> for InetDevConf {
-    fn parse(buf: &InetDevConfBuffer<T>) -> Result<Self, DecodeError> {
+impl InetDevConf {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) =
+            InetDevConfBuffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    size_of::<InetDevConfBuffer>(),
+                )
+            })?;
         Ok(Self {
-            forwarding: buf.forwarding(),
-            mc_forwarding: buf.mc_forwarding(),
-            proxy_arp: buf.proxy_arp(),
-            accept_redirects: buf.accept_redirects(),
-            secure_redirects: buf.secure_redirects(),
-            send_redirects: buf.send_redirects(),
-            shared_media: buf.shared_media(),
-            rp_filter: buf.rp_filter(),
-            accept_source_route: buf.accept_source_route(),
-            bootp_relay: buf.bootp_relay(),
-            log_martians: buf.log_martians(),
-            tag: buf.tag(),
-            arpfilter: buf.arpfilter(),
-            medium_id: buf.medium_id(),
-            noxfrm: buf.noxfrm(),
-            nopolicy: buf.nopolicy(),
-            force_igmp_version: buf.force_igmp_version(),
-            arp_announce: buf.arp_announce(),
-            arp_ignore: buf.arp_ignore(),
-            promote_secondaries: buf.promote_secondaries(),
-            arp_accept: buf.arp_accept(),
-            arp_notify: buf.arp_notify(),
-            accept_local: buf.accept_local(),
-            src_vmark: buf.src_vmark(),
-            proxy_arp_pvlan: buf.proxy_arp_pvlan(),
-            route_localnet: buf.route_localnet(),
-            igmpv2_unsolicited_report_interval: buf
-                .igmpv2_unsolicited_report_interval(),
-            igmpv3_unsolicited_report_interval: buf
-                .igmpv3_unsolicited_report_interval(),
-            ignore_routes_with_linkdown: buf.ignore_routes_with_linkdown(),
-            drop_unicast_in_l2_multicast: buf.drop_unicast_in_l2_multicast(),
-            drop_gratuitous_arp: buf.drop_gratuitous_arp(),
-            bc_forwarding: buf.bc_forwarding(),
-            arp_evict_nocarrier: buf.arp_evict_nocarrier(),
+            forwarding: raw.forwarding,
+            mc_forwarding: raw.mc_forwarding,
+            proxy_arp: raw.proxy_arp,
+            accept_redirects: raw.accept_redirects,
+            secure_redirects: raw.secure_redirects,
+            send_redirects: raw.send_redirects,
+            shared_media: raw.shared_media,
+            rp_filter: raw.rp_filter,
+            accept_source_route: raw.accept_source_route,
+            bootp_relay: raw.bootp_relay,
+            log_martians: raw.log_martians,
+            tag: raw.tag,
+            arpfilter: raw.arpfilter,
+            medium_id: raw.medium_id,
+            noxfrm: raw.noxfrm,
+            nopolicy: raw.nopolicy,
+            force_igmp_version: raw.force_igmp_version,
+            arp_announce: raw.arp_announce,
+            arp_ignore: raw.arp_ignore,
+            promote_secondaries: raw.promote_secondaries,
+            arp_accept: raw.arp_accept,
+            arp_notify: raw.arp_notify,
+            accept_local: raw.accept_local,
+            src_vmark: raw.src_vmark,
+            proxy_arp_pvlan: raw.proxy_arp_pvlan,
+            route_localnet: raw.route_localnet,
+            igmpv2_unsolicited_report_interval: raw
+                .igmpv2_unsolicited_report_interval,
+            igmpv3_unsolicited_report_interval: raw
+                .igmpv3_unsolicited_report_interval,
+            ignore_routes_with_linkdown: raw.ignore_routes_with_linkdown,
+            drop_unicast_in_l2_multicast: raw.drop_unicast_in_l2_multicast,
+            drop_gratuitous_arp: raw.drop_gratuitous_arp,
+            bc_forwarding: raw.bc_forwarding,
+            arp_evict_nocarrier: raw.arp_evict_nocarrier,
         })
+    }
+}
+
+impl From<&InetDevConf> for InetDevConfBuffer {
+    fn from(value: &InetDevConf) -> Self {
+        Self {
+            forwarding: value.forwarding,
+            mc_forwarding: value.mc_forwarding,
+            proxy_arp: value.proxy_arp,
+            accept_redirects: value.accept_redirects,
+            secure_redirects: value.secure_redirects,
+            send_redirects: value.send_redirects,
+            shared_media: value.shared_media,
+            rp_filter: value.rp_filter,
+            accept_source_route: value.accept_source_route,
+            bootp_relay: value.bootp_relay,
+            log_martians: value.log_martians,
+            tag: value.tag,
+            arpfilter: value.arpfilter,
+            medium_id: value.medium_id,
+            noxfrm: value.noxfrm,
+            nopolicy: value.nopolicy,
+            force_igmp_version: value.force_igmp_version,
+            arp_announce: value.arp_announce,
+            arp_ignore: value.arp_ignore,
+            promote_secondaries: value.promote_secondaries,
+            arp_accept: value.arp_accept,
+            arp_notify: value.arp_notify,
+            accept_local: value.accept_local,
+            src_vmark: value.src_vmark,
+            proxy_arp_pvlan: value.proxy_arp_pvlan,
+            route_localnet: value.route_localnet,
+            igmpv2_unsolicited_report_interval: value
+                .igmpv2_unsolicited_report_interval,
+            igmpv3_unsolicited_report_interval: value
+                .igmpv3_unsolicited_report_interval,
+            ignore_routes_with_linkdown: value.ignore_routes_with_linkdown,
+            drop_unicast_in_l2_multicast: value.drop_unicast_in_l2_multicast,
+            drop_gratuitous_arp: value.drop_gratuitous_arp,
+            bc_forwarding: value.bc_forwarding,
+            arp_evict_nocarrier: value.arp_evict_nocarrier,
+        }
     }
 }
 
 impl Emitable for InetDevConf {
     fn buffer_len(&self) -> usize {
-        DEV_CONF_LEN
+        size_of::<InetDevConfBuffer>()
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buffer = InetDevConfBuffer::new(buffer);
-        buffer.set_forwarding(self.forwarding);
-        buffer.set_mc_forwarding(self.mc_forwarding);
-        buffer.set_proxy_arp(self.proxy_arp);
-        buffer.set_accept_redirects(self.accept_redirects);
-        buffer.set_secure_redirects(self.secure_redirects);
-        buffer.set_send_redirects(self.send_redirects);
-        buffer.set_shared_media(self.shared_media);
-        buffer.set_rp_filter(self.rp_filter);
-        buffer.set_accept_source_route(self.accept_source_route);
-        buffer.set_bootp_relay(self.bootp_relay);
-        buffer.set_log_martians(self.log_martians);
-        buffer.set_tag(self.tag);
-        buffer.set_arpfilter(self.arpfilter);
-        buffer.set_medium_id(self.medium_id);
-        buffer.set_noxfrm(self.noxfrm);
-        buffer.set_nopolicy(self.nopolicy);
-        buffer.set_force_igmp_version(self.force_igmp_version);
-        buffer.set_arp_announce(self.arp_announce);
-        buffer.set_arp_ignore(self.arp_ignore);
-        buffer.set_promote_secondaries(self.promote_secondaries);
-        buffer.set_arp_accept(self.arp_accept);
-        buffer.set_arp_notify(self.arp_notify);
-        buffer.set_accept_local(self.accept_local);
-        buffer.set_src_vmark(self.src_vmark);
-        buffer.set_proxy_arp_pvlan(self.proxy_arp_pvlan);
-        buffer.set_route_localnet(self.route_localnet);
-        buffer.set_igmpv2_unsolicited_report_interval(
-            self.igmpv2_unsolicited_report_interval,
-        );
-        buffer.set_igmpv3_unsolicited_report_interval(
-            self.igmpv3_unsolicited_report_interval,
-        );
-        buffer
-            .set_ignore_routes_with_linkdown(self.ignore_routes_with_linkdown);
-        buffer.set_drop_unicast_in_l2_multicast(
-            self.drop_unicast_in_l2_multicast,
-        );
-        buffer.set_drop_gratuitous_arp(self.drop_gratuitous_arp);
-        buffer.set_bc_forwarding(self.bc_forwarding);
-        buffer.set_arp_evict_nocarrier(self.arp_evict_nocarrier);
+        let raw = InetDevConfBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/link/af_spec/inet6.rs
+++ b/src/link/af_spec/inet6.rs
@@ -1,21 +1,16 @@
 // SPDX-License-Identifier: MIT
 
-use std::net::Ipv6Addr;
+use std::{mem::size_of, net::Ipv6Addr};
 
 use netlink_packet_core::{
     emit_u32, parse_u32, parse_u8, DecodeError, DefaultNla, Emitable,
     ErrorContext, Nla, NlaBuffer, NlasIterator, Parseable,
 };
 
-use super::{
-    super::{
-        buffer_tool::expand_buffer_if_small, Icmp6Stats, Icmp6StatsBuffer,
-        Inet6CacheInfo, Inet6CacheInfoBuffer, Inet6DevConf, Inet6DevConfBuffer,
-        Inet6IfaceFlags, Inet6Stats, Inet6StatsBuffer,
-    },
-    inet6_devconf::LINK_INET6_DEV_CONF_LEN,
-    inet6_icmp::ICMP6_STATS_LEN,
-    inet6_stats::INET6_STATS_LEN,
+use super::super::{
+    buffer_tool::expand_buffer_if_small, Icmp6Stats, Icmp6StatsBuffer,
+    Inet6CacheInfo, Inet6DevConf, Inet6DevConfBuffer, Inet6IfaceFlags,
+    Inet6Stats, Inet6StatsBuffer,
 };
 use crate::{ip::parse_ipv6_addr, link::af_spec::In6AddrGenMode};
 
@@ -111,47 +106,46 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for AfSpecInet6 {
             IFLA_INET6_FLAGS => Self::Flags(Inet6IfaceFlags::from_bits_retain(
                 parse_u32(payload).context("invalid IFLA_INET6_FLAGS value")?,
             )),
-            IFLA_INET6_CACHEINFO => Self::CacheInfo(
-                Inet6CacheInfo::parse(&Inet6CacheInfoBuffer::new(payload))
-                    .context(format!(
-                        "invalid IFLA_INET6_CACHEINFO value {payload:?}"
-                    ))?,
-            ),
+            IFLA_INET6_CACHEINFO => {
+                Self::CacheInfo(Inet6CacheInfo::parse(payload).context(
+                    format!("invalid IFLA_INET6_CACHEINFO value {payload:?}"),
+                )?)
+            }
             IFLA_INET6_CONF => Self::DevConf(
-                Inet6DevConf::parse(&Inet6DevConfBuffer::new(
+                Inet6DevConf::parse(
                     expand_buffer_if_small(
                         payload,
-                        LINK_INET6_DEV_CONF_LEN,
+                        size_of::<Inet6DevConfBuffer>(),
                         "IFLA_INET6_CONF",
                     )
                     .as_slice(),
-                ))
+                )
                 .context(format!(
                     "invalid IFLA_INET6_CONF value {payload:?}"
                 ))?,
             ),
             IFLA_INET6_STATS => Self::Stats(
-                Inet6Stats::parse(&Inet6StatsBuffer::new(
+                Inet6Stats::parse(
                     expand_buffer_if_small(
                         payload,
-                        INET6_STATS_LEN,
+                        size_of::<Inet6StatsBuffer>(),
                         "IFLA_INET6_STATS",
                     )
                     .as_slice(),
-                ))
+                )
                 .context(format!(
                     "invalid IFLA_INET6_STATS value {payload:?}"
                 ))?,
             ),
             IFLA_INET6_ICMP6STATS => Self::Icmp6Stats(
-                super::super::Icmp6Stats::parse(&Icmp6StatsBuffer::new(
+                Icmp6Stats::parse(
                     expand_buffer_if_small(
                         payload,
-                        ICMP6_STATS_LEN,
+                        size_of::<Icmp6StatsBuffer>(),
                         "IFLA_INET6_ICMP6STATS",
                     )
                     .as_slice(),
-                ))
+                )
                 .context(format!(
                     "invalid IFLA_INET6_ICMP6STATS value {payload:?}"
                 ))?,

--- a/src/link/af_spec/inet6_cache.rs
+++ b/src/link/af_spec/inet6_cache.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{DecodeError, Emitable, Parseable};
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]
 #[non_exhaustive]
@@ -13,21 +14,51 @@ pub struct Inet6CacheInfo {
 
 const LINK_INET6_CACHE_INFO_LEN: usize = 16;
 
-buffer!(Inet6CacheInfoBuffer(LINK_INET6_CACHE_INFO_LEN) {
-    max_reasm_len: (i32, 0..4),
-    tstamp: (i32, 4..8),
-    reachable_time: (i32, 8..12),
-    retrans_time: (i32, 12..16),
-});
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct Inet6CacheInfoBuffer {
+    max_reasm_len: i32,
+    tstamp: i32,
+    reachable_time: i32,
+    retrans_time: i32,
+}
 
-impl<T: AsRef<[u8]>> Parseable<Inet6CacheInfoBuffer<T>> for Inet6CacheInfo {
-    fn parse(buf: &Inet6CacheInfoBuffer<T>) -> Result<Self, DecodeError> {
+impl Inet6CacheInfo {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) =
+            Inet6CacheInfoBuffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    LINK_INET6_CACHE_INFO_LEN,
+                )
+            })?;
         Ok(Self {
-            max_reasm_len: buf.max_reasm_len(),
-            tstamp: buf.tstamp(),
-            reachable_time: buf.reachable_time(),
-            retrans_time: buf.retrans_time(),
+            max_reasm_len: raw.max_reasm_len,
+            tstamp: raw.tstamp,
+            reachable_time: raw.reachable_time,
+            retrans_time: raw.retrans_time,
         })
+    }
+}
+
+impl From<&Inet6CacheInfo> for Inet6CacheInfoBuffer {
+    fn from(cache_info: &Inet6CacheInfo) -> Self {
+        Self {
+            max_reasm_len: cache_info.max_reasm_len,
+            tstamp: cache_info.tstamp,
+            reachable_time: cache_info.reachable_time,
+            retrans_time: cache_info.retrans_time,
+        }
     }
 }
 
@@ -37,10 +68,7 @@ impl Emitable for Inet6CacheInfo {
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buffer = Inet6CacheInfoBuffer::new(buffer);
-        buffer.set_max_reasm_len(self.max_reasm_len);
-        buffer.set_tstamp(self.tstamp);
-        buffer.set_reachable_time(self.reachable_time);
-        buffer.set_retrans_time(self.retrans_time);
+        let raw = Inet6CacheInfoBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/link/af_spec/inet6_devconf.rs
+++ b/src/link/af_spec/inet6_devconf.rs
@@ -1,218 +1,238 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{DecodeError, Emitable, Parseable};
+use std::mem::size_of;
 
-// The DEVCONF_MAX will increase when kernel add more DEVCONF
-const DEVCONF_MAX: usize = 60;
-pub(crate) const LINK_INET6_DEV_CONF_LEN: usize = DEVCONF_MAX * 4;
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
-buffer!(Inet6DevConfBuffer(LINK_INET6_DEV_CONF_LEN) {
-    forwarding: (i32, 0..4),
-    hoplimit: (i32, 4..8),
-    mtu6: (i32, 8..12),
-    accept_ra: (i32, 12..16),
-    accept_redirects: (i32, 16..20),
-    autoconf: (i32, 20..24),
-    dad_transmits: (i32, 24..28),
-    rtr_solicits: (i32, 28..32),
-    rtr_solicit_interval: (i32, 32..36),
-    rtr_solicit_delay: (i32, 36..40),
-    use_tempaddr: (i32, 40..44),
-    temp_valid_lft: (i32, 44..48),
-    temp_prefered_lft: (i32, 48..52),
-    regen_max_retry: (i32, 52..56),
-    max_desync_factor: (i32, 56..60),
-    max_addresses: (i32, 60..64),
-    force_mld_version: (i32, 64..68),
-    accept_ra_defrtr: (i32, 68..72),
-    accept_ra_pinfo: (i32, 72..76),
-    accept_ra_rtr_pref: (i32, 76..80),
-    rtr_probe_interval: (i32, 80..84),
-    accept_ra_rt_info_max_plen: (i32, 84..88),
-    proxy_ndp: (i32, 88..92),
-    optimistic_dad: (i32, 92..96),
-    accept_source_route: (i32, 96..100),
-    mc_forwarding: (i32, 100..104),
-    disable_ipv6: (i32, 104..108),
-    accept_dad: (i32, 108..112),
-    force_tllao: (i32, 112..116),
-    ndisc_notify: (i32, 116..120),
-    mldv1_unsolicited_report_interval: (i32, 120..124),
-    mldv2_unsolicited_report_interval: (i32, 124..128),
-    suppress_frag_ndisc: (i32, 128..132),
-    accept_ra_from_local: (i32, 132..136),
-    use_optimistic: (i32, 136..140),
-    accept_ra_mtu: (i32, 140..144),
-    stable_secret: (i32, 144..148),
-    use_oif_addrs_only: (i32, 148..152),
-    accept_ra_min_hop_limit: (i32, 152..156),
-    ignore_routes_with_linkdown: (i32, 156..160),
-    drop_unicast_in_l2_multicast: (i32, 160..164),
-    drop_unsolicited_na: (i32, 164..168),
-    keep_addr_on_down: (i32, 168..172),
-    rtr_solicit_max_interval: (i32, 172..176),
-    seg6_enabled: (i32, 176..180),
-    seg6_require_hmac: (i32, 180..184),
-    enhanced_dad: (i32, 184..188),
-    addr_gen_mode: (i32, 188..192),
-    disable_policy: (i32, 192..196),
-    accept_ra_rt_info_min_plen: (i32, 196..200),
-    ndisc_tclass: (i32, 200..204),
-    rpl_seg_enabled: (i32, 204..208),
-    ra_defrtr_metric: (i32, 208..212),
-    ioam6_enabled: (i32, 212..216),
-    ioam6_id: (i32, 216..220),
-    ioam6_id_wide: (i32, 220..224),
-    ndisc_evict_nocarrier: (i32, 224..228),
-    accept_untracked_na: (i32, 228..232),
-    accept_ra_min_lft: (i32, 232..236),
-    force_forwarding: (i32, 236..240),
-});
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct Inet6DevConfBuffer {
+    forwarding: i32,
+    hoplimit: i32,
+    mtu6: i32,
+    accept_ra: i32,
+    accept_redirects: i32,
+    autoconf: i32,
+    dad_transmits: i32,
+    rtr_solicits: i32,
+    rtr_solicit_interval: i32,
+    rtr_solicit_delay: i32,
+    use_tempaddr: i32,
+    temp_valid_lft: i32,
+    temp_prefered_lft: i32,
+    regen_max_retry: i32,
+    max_desync_factor: i32,
+    max_addresses: i32,
+    force_mld_version: i32,
+    accept_ra_defrtr: i32,
+    accept_ra_pinfo: i32,
+    accept_ra_rtr_pref: i32,
+    rtr_probe_interval: i32,
+    accept_ra_rt_info_max_plen: i32,
+    proxy_ndp: i32,
+    optimistic_dad: i32,
+    accept_source_route: i32,
+    mc_forwarding: i32,
+    disable_ipv6: i32,
+    accept_dad: i32,
+    force_tllao: i32,
+    ndisc_notify: i32,
+    mldv1_unsolicited_report_interval: i32,
+    mldv2_unsolicited_report_interval: i32,
+    suppress_frag_ndisc: i32,
+    accept_ra_from_local: i32,
+    use_optimistic: i32,
+    accept_ra_mtu: i32,
+    stable_secret: i32,
+    use_oif_addrs_only: i32,
+    accept_ra_min_hop_limit: i32,
+    ignore_routes_with_linkdown: i32,
+    drop_unicast_in_l2_multicast: i32,
+    drop_unsolicited_na: i32,
+    keep_addr_on_down: i32,
+    rtr_solicit_max_interval: i32,
+    seg6_enabled: i32,
+    seg6_require_hmac: i32,
+    enhanced_dad: i32,
+    addr_gen_mode: i32,
+    disable_policy: i32,
+    accept_ra_rt_info_min_plen: i32,
+    ndisc_tclass: i32,
+    rpl_seg_enabled: i32,
+    ra_defrtr_metric: i32,
+    ioam6_enabled: i32,
+    ioam6_id: i32,
+    ioam6_id_wide: i32,
+    ndisc_evict_nocarrier: i32,
+    accept_untracked_na: i32,
+    accept_ra_min_lft: i32,
+    force_forwarding: i32,
+}
 
-impl<T: AsRef<[u8]>> Parseable<Inet6DevConfBuffer<T>> for Inet6DevConf {
-    fn parse(buf: &Inet6DevConfBuffer<T>) -> Result<Self, DecodeError> {
+impl Inet6DevConf {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) =
+            Inet6DevConfBuffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    size_of::<Inet6DevConfBuffer>(),
+                )
+            })?;
         Ok(Self {
-            forwarding: buf.forwarding(),
-            hoplimit: buf.hoplimit(),
-            mtu6: buf.mtu6(),
-            accept_ra: buf.accept_ra(),
-            accept_redirects: buf.accept_redirects(),
-            autoconf: buf.autoconf(),
-            dad_transmits: buf.dad_transmits(),
-            rtr_solicits: buf.rtr_solicits(),
-            rtr_solicit_interval: buf.rtr_solicit_interval(),
-            rtr_solicit_delay: buf.rtr_solicit_delay(),
-            use_tempaddr: buf.use_tempaddr(),
-            temp_valid_lft: buf.temp_valid_lft(),
-            temp_prefered_lft: buf.temp_prefered_lft(),
-            regen_max_retry: buf.regen_max_retry(),
-            max_desync_factor: buf.max_desync_factor(),
-            max_addresses: buf.max_addresses(),
-            force_mld_version: buf.force_mld_version(),
-            accept_ra_defrtr: buf.accept_ra_defrtr(),
-            accept_ra_pinfo: buf.accept_ra_pinfo(),
-            accept_ra_rtr_pref: buf.accept_ra_rtr_pref(),
-            rtr_probe_interval: buf.rtr_probe_interval(),
-            accept_ra_rt_info_max_plen: buf.accept_ra_rt_info_max_plen(),
-            proxy_ndp: buf.proxy_ndp(),
-            optimistic_dad: buf.optimistic_dad(),
-            accept_source_route: buf.accept_source_route(),
-            mc_forwarding: buf.mc_forwarding(),
-            disable_ipv6: buf.disable_ipv6(),
-            accept_dad: buf.accept_dad(),
-            force_tllao: buf.force_tllao(),
-            ndisc_notify: buf.ndisc_notify(),
-            mldv1_unsolicited_report_interval: buf
-                .mldv1_unsolicited_report_interval(),
-            mldv2_unsolicited_report_interval: buf
-                .mldv2_unsolicited_report_interval(),
-            suppress_frag_ndisc: buf.suppress_frag_ndisc(),
-            accept_ra_from_local: buf.accept_ra_from_local(),
-            use_optimistic: buf.use_optimistic(),
-            accept_ra_mtu: buf.accept_ra_mtu(),
-            stable_secret: buf.stable_secret(),
-            use_oif_addrs_only: buf.use_oif_addrs_only(),
-            accept_ra_min_hop_limit: buf.accept_ra_min_hop_limit(),
-            ignore_routes_with_linkdown: buf.ignore_routes_with_linkdown(),
-            drop_unicast_in_l2_multicast: buf.drop_unicast_in_l2_multicast(),
-            drop_unsolicited_na: buf.drop_unsolicited_na(),
-            keep_addr_on_down: buf.keep_addr_on_down(),
-            rtr_solicit_max_interval: buf.rtr_solicit_max_interval(),
-            seg6_enabled: buf.seg6_enabled(),
-            seg6_require_hmac: buf.seg6_require_hmac(),
-            enhanced_dad: buf.enhanced_dad(),
-            addr_gen_mode: buf.addr_gen_mode(),
-            disable_policy: buf.disable_policy(),
-            accept_ra_rt_info_min_plen: buf.accept_ra_rt_info_min_plen(),
-            ndisc_tclass: buf.ndisc_tclass(),
-            rpl_seg_enabled: buf.rpl_seg_enabled(),
-            ra_defrtr_metric: buf.ra_defrtr_metric(),
-            ioam6_enabled: buf.ioam6_enabled(),
-            ioam6_id: buf.ioam6_id(),
-            ioam6_id_wide: buf.ioam6_id_wide(),
-            ndisc_evict_nocarrier: buf.ndisc_evict_nocarrier(),
-            accept_untracked_na: buf.accept_untracked_na(),
-            accept_ra_min_lft: buf.accept_ra_min_lft(),
-            force_forwarding: buf.force_forwarding(),
+            forwarding: raw.forwarding,
+            hoplimit: raw.hoplimit,
+            mtu6: raw.mtu6,
+            accept_ra: raw.accept_ra,
+            accept_redirects: raw.accept_redirects,
+            autoconf: raw.autoconf,
+            dad_transmits: raw.dad_transmits,
+            rtr_solicits: raw.rtr_solicits,
+            rtr_solicit_interval: raw.rtr_solicit_interval,
+            rtr_solicit_delay: raw.rtr_solicit_delay,
+            use_tempaddr: raw.use_tempaddr,
+            temp_valid_lft: raw.temp_valid_lft,
+            temp_prefered_lft: raw.temp_prefered_lft,
+            regen_max_retry: raw.regen_max_retry,
+            max_desync_factor: raw.max_desync_factor,
+            max_addresses: raw.max_addresses,
+            force_mld_version: raw.force_mld_version,
+            accept_ra_defrtr: raw.accept_ra_defrtr,
+            accept_ra_pinfo: raw.accept_ra_pinfo,
+            accept_ra_rtr_pref: raw.accept_ra_rtr_pref,
+            rtr_probe_interval: raw.rtr_probe_interval,
+            accept_ra_rt_info_max_plen: raw.accept_ra_rt_info_max_plen,
+            proxy_ndp: raw.proxy_ndp,
+            optimistic_dad: raw.optimistic_dad,
+            accept_source_route: raw.accept_source_route,
+            mc_forwarding: raw.mc_forwarding,
+            disable_ipv6: raw.disable_ipv6,
+            accept_dad: raw.accept_dad,
+            force_tllao: raw.force_tllao,
+            ndisc_notify: raw.ndisc_notify,
+            mldv1_unsolicited_report_interval: raw
+                .mldv1_unsolicited_report_interval,
+            mldv2_unsolicited_report_interval: raw
+                .mldv2_unsolicited_report_interval,
+            suppress_frag_ndisc: raw.suppress_frag_ndisc,
+            accept_ra_from_local: raw.accept_ra_from_local,
+            use_optimistic: raw.use_optimistic,
+            accept_ra_mtu: raw.accept_ra_mtu,
+            stable_secret: raw.stable_secret,
+            use_oif_addrs_only: raw.use_oif_addrs_only,
+            accept_ra_min_hop_limit: raw.accept_ra_min_hop_limit,
+            ignore_routes_with_linkdown: raw.ignore_routes_with_linkdown,
+            drop_unicast_in_l2_multicast: raw.drop_unicast_in_l2_multicast,
+            drop_unsolicited_na: raw.drop_unsolicited_na,
+            keep_addr_on_down: raw.keep_addr_on_down,
+            rtr_solicit_max_interval: raw.rtr_solicit_max_interval,
+            seg6_enabled: raw.seg6_enabled,
+            seg6_require_hmac: raw.seg6_require_hmac,
+            enhanced_dad: raw.enhanced_dad,
+            addr_gen_mode: raw.addr_gen_mode,
+            disable_policy: raw.disable_policy,
+            accept_ra_rt_info_min_plen: raw.accept_ra_rt_info_min_plen,
+            ndisc_tclass: raw.ndisc_tclass,
+            rpl_seg_enabled: raw.rpl_seg_enabled,
+            ra_defrtr_metric: raw.ra_defrtr_metric,
+            ioam6_enabled: raw.ioam6_enabled,
+            ioam6_id: raw.ioam6_id,
+            ioam6_id_wide: raw.ioam6_id_wide,
+            ndisc_evict_nocarrier: raw.ndisc_evict_nocarrier,
+            accept_untracked_na: raw.accept_untracked_na,
+            accept_ra_min_lft: raw.accept_ra_min_lft,
+            force_forwarding: raw.force_forwarding,
         })
+    }
+}
+
+impl From<&Inet6DevConf> for Inet6DevConfBuffer {
+    fn from(value: &Inet6DevConf) -> Self {
+        Self {
+            forwarding: value.forwarding,
+            hoplimit: value.hoplimit,
+            mtu6: value.mtu6,
+            accept_ra: value.accept_ra,
+            accept_redirects: value.accept_redirects,
+            autoconf: value.autoconf,
+            dad_transmits: value.dad_transmits,
+            rtr_solicits: value.rtr_solicits,
+            rtr_solicit_interval: value.rtr_solicit_interval,
+            rtr_solicit_delay: value.rtr_solicit_delay,
+            use_tempaddr: value.use_tempaddr,
+            temp_valid_lft: value.temp_valid_lft,
+            temp_prefered_lft: value.temp_prefered_lft,
+            regen_max_retry: value.regen_max_retry,
+            max_desync_factor: value.max_desync_factor,
+            max_addresses: value.max_addresses,
+            force_mld_version: value.force_mld_version,
+            accept_ra_defrtr: value.accept_ra_defrtr,
+            accept_ra_pinfo: value.accept_ra_pinfo,
+            accept_ra_rtr_pref: value.accept_ra_rtr_pref,
+            rtr_probe_interval: value.rtr_probe_interval,
+            accept_ra_rt_info_max_plen: value.accept_ra_rt_info_max_plen,
+            proxy_ndp: value.proxy_ndp,
+            optimistic_dad: value.optimistic_dad,
+            accept_source_route: value.accept_source_route,
+            mc_forwarding: value.mc_forwarding,
+            disable_ipv6: value.disable_ipv6,
+            accept_dad: value.accept_dad,
+            force_tllao: value.force_tllao,
+            ndisc_notify: value.ndisc_notify,
+            mldv1_unsolicited_report_interval: value
+                .mldv1_unsolicited_report_interval,
+            mldv2_unsolicited_report_interval: value
+                .mldv2_unsolicited_report_interval,
+            suppress_frag_ndisc: value.suppress_frag_ndisc,
+            accept_ra_from_local: value.accept_ra_from_local,
+            use_optimistic: value.use_optimistic,
+            accept_ra_mtu: value.accept_ra_mtu,
+            stable_secret: value.stable_secret,
+            use_oif_addrs_only: value.use_oif_addrs_only,
+            accept_ra_min_hop_limit: value.accept_ra_min_hop_limit,
+            ignore_routes_with_linkdown: value.ignore_routes_with_linkdown,
+            drop_unicast_in_l2_multicast: value.drop_unicast_in_l2_multicast,
+            drop_unsolicited_na: value.drop_unsolicited_na,
+            keep_addr_on_down: value.keep_addr_on_down,
+            rtr_solicit_max_interval: value.rtr_solicit_max_interval,
+            seg6_enabled: value.seg6_enabled,
+            seg6_require_hmac: value.seg6_require_hmac,
+            enhanced_dad: value.enhanced_dad,
+            addr_gen_mode: value.addr_gen_mode,
+            disable_policy: value.disable_policy,
+            accept_ra_rt_info_min_plen: value.accept_ra_rt_info_min_plen,
+            ndisc_tclass: value.ndisc_tclass,
+            rpl_seg_enabled: value.rpl_seg_enabled,
+            ra_defrtr_metric: value.ra_defrtr_metric,
+            ioam6_enabled: value.ioam6_enabled,
+            ioam6_id: value.ioam6_id,
+            ioam6_id_wide: value.ioam6_id_wide,
+            ndisc_evict_nocarrier: value.ndisc_evict_nocarrier,
+            accept_untracked_na: value.accept_untracked_na,
+            accept_ra_min_lft: value.accept_ra_min_lft,
+            force_forwarding: value.force_forwarding,
+        }
     }
 }
 
 impl Emitable for Inet6DevConf {
     fn buffer_len(&self) -> usize {
-        LINK_INET6_DEV_CONF_LEN
+        size_of::<Inet6DevConfBuffer>()
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buffer = Inet6DevConfBuffer::new(buffer);
-        buffer.set_forwarding(self.forwarding);
-        buffer.set_hoplimit(self.hoplimit);
-        buffer.set_mtu6(self.mtu6);
-        buffer.set_accept_ra(self.accept_ra);
-        buffer.set_accept_redirects(self.accept_redirects);
-        buffer.set_autoconf(self.autoconf);
-        buffer.set_dad_transmits(self.dad_transmits);
-        buffer.set_rtr_solicits(self.rtr_solicits);
-        buffer.set_rtr_solicit_interval(self.rtr_solicit_interval);
-        buffer.set_rtr_solicit_delay(self.rtr_solicit_delay);
-        buffer.set_use_tempaddr(self.use_tempaddr);
-        buffer.set_temp_valid_lft(self.temp_valid_lft);
-        buffer.set_temp_prefered_lft(self.temp_prefered_lft);
-        buffer.set_regen_max_retry(self.regen_max_retry);
-        buffer.set_max_desync_factor(self.max_desync_factor);
-        buffer.set_max_addresses(self.max_addresses);
-        buffer.set_force_mld_version(self.force_mld_version);
-        buffer.set_accept_ra_defrtr(self.accept_ra_defrtr);
-        buffer.set_accept_ra_pinfo(self.accept_ra_pinfo);
-        buffer.set_accept_ra_rtr_pref(self.accept_ra_rtr_pref);
-        buffer.set_rtr_probe_interval(self.rtr_probe_interval);
-        buffer.set_accept_ra_rt_info_max_plen(self.accept_ra_rt_info_max_plen);
-        buffer.set_proxy_ndp(self.proxy_ndp);
-        buffer.set_optimistic_dad(self.optimistic_dad);
-        buffer.set_accept_source_route(self.accept_source_route);
-        buffer.set_mc_forwarding(self.mc_forwarding);
-        buffer.set_disable_ipv6(self.disable_ipv6);
-        buffer.set_accept_dad(self.accept_dad);
-        buffer.set_force_tllao(self.force_tllao);
-        buffer.set_ndisc_notify(self.ndisc_notify);
-        buffer.set_mldv1_unsolicited_report_interval(
-            self.mldv1_unsolicited_report_interval,
-        );
-        buffer.set_mldv2_unsolicited_report_interval(
-            self.mldv2_unsolicited_report_interval,
-        );
-        buffer.set_suppress_frag_ndisc(self.suppress_frag_ndisc);
-        buffer.set_accept_ra_from_local(self.accept_ra_from_local);
-        buffer.set_use_optimistic(self.use_optimistic);
-        buffer.set_accept_ra_mtu(self.accept_ra_mtu);
-        buffer.set_stable_secret(self.stable_secret);
-        buffer.set_use_oif_addrs_only(self.use_oif_addrs_only);
-        buffer.set_accept_ra_min_hop_limit(self.accept_ra_min_hop_limit);
-        buffer
-            .set_ignore_routes_with_linkdown(self.ignore_routes_with_linkdown);
-        buffer.set_drop_unicast_in_l2_multicast(
-            self.drop_unicast_in_l2_multicast,
-        );
-        buffer.set_drop_unsolicited_na(self.drop_unsolicited_na);
-        buffer.set_keep_addr_on_down(self.keep_addr_on_down);
-        buffer.set_rtr_solicit_max_interval(self.rtr_solicit_max_interval);
-        buffer.set_seg6_enabled(self.seg6_enabled);
-        buffer.set_seg6_require_hmac(self.seg6_require_hmac);
-        buffer.set_enhanced_dad(self.enhanced_dad);
-        buffer.set_addr_gen_mode(self.addr_gen_mode);
-        buffer.set_disable_policy(self.disable_policy);
-        buffer.set_accept_ra_rt_info_min_plen(self.accept_ra_rt_info_min_plen);
-        buffer.set_ndisc_tclass(self.ndisc_tclass);
-        buffer.set_ndisc_tclass(self.ndisc_tclass);
-        buffer.set_rpl_seg_enabled(self.rpl_seg_enabled);
-        buffer.set_ra_defrtr_metric(self.ra_defrtr_metric);
-        buffer.set_ioam6_enabled(self.ioam6_enabled);
-        buffer.set_ioam6_id(self.ioam6_id);
-        buffer.set_ioam6_id_wide(self.ioam6_id_wide);
-        buffer.set_ndisc_evict_nocarrier(self.ndisc_evict_nocarrier);
-        buffer.set_accept_untracked_na(self.accept_untracked_na);
-        buffer.set_accept_ra_min_lft(self.accept_ra_min_lft);
-        buffer.set_force_forwarding(self.force_forwarding);
+        let raw = Inet6DevConfBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }
 

--- a/src/link/af_spec/inet6_icmp.rs
+++ b/src/link/af_spec/inet6_icmp.rs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{DecodeError, Emitable, Parseable};
+use std::mem::size_of;
 
-pub(crate) const ICMP6_STATS_LEN: usize = 56;
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 #[derive(Clone, Copy, Eq, PartialEq, Debug, Default)]
 #[non_exhaustive]
@@ -16,43 +17,70 @@ pub struct Icmp6Stats {
     pub rate_limit_host: i64,
 }
 
-buffer!(Icmp6StatsBuffer(ICMP6_STATS_LEN) {
-    num: (i64, 0..8),
-    in_msgs: (i64, 8..16),
-    in_errors: (i64, 16..24),
-    out_msgs: (i64, 24..32),
-    out_errors: (i64, 32..40),
-    csum_errors: (i64, 40..48),
-    rate_limit_host: (i64, 48..56),
-});
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct Icmp6StatsBuffer {
+    num: i64,
+    in_msgs: i64,
+    in_errors: i64,
+    out_msgs: i64,
+    out_errors: i64,
+    csum_errors: i64,
+    rate_limit_host: i64,
+}
 
-impl<T: AsRef<[u8]>> Parseable<Icmp6StatsBuffer<T>> for Icmp6Stats {
-    fn parse(buf: &Icmp6StatsBuffer<T>) -> Result<Self, DecodeError> {
+impl Icmp6Stats {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) =
+            Icmp6StatsBuffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    size_of::<Icmp6StatsBuffer>(),
+                )
+            })?;
         Ok(Self {
-            num: buf.num(),
-            in_msgs: buf.in_msgs(),
-            in_errors: buf.in_errors(),
-            out_msgs: buf.out_msgs(),
-            out_errors: buf.out_errors(),
-            csum_errors: buf.csum_errors(),
-            rate_limit_host: buf.rate_limit_host(),
+            num: raw.num,
+            in_msgs: raw.in_msgs,
+            in_errors: raw.in_errors,
+            out_msgs: raw.out_msgs,
+            out_errors: raw.out_errors,
+            csum_errors: raw.csum_errors,
+            rate_limit_host: raw.rate_limit_host,
         })
+    }
+}
+
+impl From<&Icmp6Stats> for Icmp6StatsBuffer {
+    fn from(stats: &Icmp6Stats) -> Self {
+        Self {
+            num: stats.num,
+            in_msgs: stats.in_msgs,
+            in_errors: stats.in_errors,
+            out_msgs: stats.out_msgs,
+            out_errors: stats.out_errors,
+            csum_errors: stats.csum_errors,
+            rate_limit_host: stats.rate_limit_host,
+        }
     }
 }
 
 impl Emitable for Icmp6Stats {
     fn buffer_len(&self) -> usize {
-        ICMP6_STATS_LEN
+        size_of::<Icmp6StatsBuffer>()
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buffer = Icmp6StatsBuffer::new(buffer);
-        buffer.set_num(self.num);
-        buffer.set_in_msgs(self.in_msgs);
-        buffer.set_in_errors(self.in_errors);
-        buffer.set_out_msgs(self.out_msgs);
-        buffer.set_out_errors(self.out_errors);
-        buffer.set_csum_errors(self.csum_errors);
-        buffer.set_rate_limit_host(self.rate_limit_host);
+        let raw = Icmp6StatsBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/link/af_spec/inet6_stats.rs
+++ b/src/link/af_spec/inet6_stats.rs
@@ -1,49 +1,62 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{DecodeError, Emitable, Parseable};
+use std::mem::size_of;
 
-pub(crate) const INET6_STATS_LEN: usize = 304;
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
-buffer!(Inet6StatsBuffer(INET6_STATS_LEN) {
-    num: (i64, 0..8),
-    in_pkts: (i64, 8..16),
-    in_octets: (i64, 16..24),
-    in_delivers: (i64, 24..32),
-    out_forw_datagrams: (i64, 32..40),
-    out_requests: (i64, 40..48),
-    out_octets: (i64, 48..56),
-    in_hdr_errors: (i64, 56..64),
-    in_too_big_errors: (i64, 64..72),
-    in_no_routes: (i64, 72..80),
-    in_addr_errors: (i64, 80..88),
-    in_unknown_protos: (i64, 88..96),
-    in_truncated_pkts: (i64, 96..104),
-    in_discards: (i64, 104..112),
-    out_discards: (i64, 112..120),
-    out_no_routes: (i64, 120..128),
-    reasm_timeout: (i64, 128..136),
-    reasm_reqds: (i64, 136..144),
-    reasm_oks: (i64, 144..152),
-    reasm_fails: (i64, 152..160),
-    frag_oks: (i64, 160..168),
-    frag_fails: (i64, 168..176),
-    frag_creates: (i64, 176..184),
-    in_mcast_pkts: (i64, 184..192),
-    out_mcast_pkts: (i64, 192..200),
-    in_bcast_pkts: (i64, 200..208),
-    out_bcast_pkts: (i64, 208..216),
-    in_mcast_octets: (i64, 216..224),
-    out_mcast_octets: (i64, 224..232),
-    in_bcast_octets: (i64, 232..240),
-    out_bcast_octets: (i64, 240..248),
-    in_csum_errors: (i64, 248..256),
-    in_no_ect_pkts: (i64, 256..264),
-    in_ect1_pkts: (i64, 264..272),
-    in_ect0_pkts: (i64, 272..280),
-    in_ce_pkts: (i64, 280..288),
-    reasm_overlaps: (i64, 288..296),
-    out_pkts: (i64, 296..304),
-});
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct Inet6StatsBuffer {
+    num: i64,
+    in_pkts: i64,
+    in_octets: i64,
+    in_delivers: i64,
+    out_forw_datagrams: i64,
+    out_requests: i64,
+    out_octets: i64,
+    in_hdr_errors: i64,
+    in_too_big_errors: i64,
+    in_no_routes: i64,
+    in_addr_errors: i64,
+    in_unknown_protos: i64,
+    in_truncated_pkts: i64,
+    in_discards: i64,
+    out_discards: i64,
+    out_no_routes: i64,
+    reasm_timeout: i64,
+    reasm_reqds: i64,
+    reasm_oks: i64,
+    reasm_fails: i64,
+    frag_oks: i64,
+    frag_fails: i64,
+    frag_creates: i64,
+    in_mcast_pkts: i64,
+    out_mcast_pkts: i64,
+    in_bcast_pkts: i64,
+    out_bcast_pkts: i64,
+    in_mcast_octets: i64,
+    out_mcast_octets: i64,
+    in_bcast_octets: i64,
+    out_bcast_octets: i64,
+    in_csum_errors: i64,
+    in_no_ect_pkts: i64,
+    in_ect1_pkts: i64,
+    in_ect0_pkts: i64,
+    in_ce_pkts: i64,
+    reasm_overlaps: i64,
+    out_pkts: i64,
+}
 
 #[derive(Clone, Copy, Eq, PartialEq, Debug, Default)]
 #[non_exhaustive]
@@ -88,95 +101,110 @@ pub struct Inet6Stats {
     pub out_pkts: i64,
 }
 
-impl<T: AsRef<[u8]>> Parseable<Inet6StatsBuffer<T>> for Inet6Stats {
-    fn parse(buf: &Inet6StatsBuffer<T>) -> Result<Self, DecodeError> {
+impl Inet6Stats {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) =
+            Inet6StatsBuffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    size_of::<Inet6StatsBuffer>(),
+                )
+            })?;
         Ok(Self {
-            num: buf.num(),
-            in_pkts: buf.in_pkts(),
-            in_octets: buf.in_octets(),
-            in_delivers: buf.in_delivers(),
-            out_forw_datagrams: buf.out_forw_datagrams(),
-            out_requests: buf.out_requests(),
-            out_octets: buf.out_octets(),
-            in_hdr_errors: buf.in_hdr_errors(),
-            in_too_big_errors: buf.in_too_big_errors(),
-            in_no_routes: buf.in_no_routes(),
-            in_addr_errors: buf.in_addr_errors(),
-            in_unknown_protos: buf.in_unknown_protos(),
-            in_truncated_pkts: buf.in_truncated_pkts(),
-            in_discards: buf.in_discards(),
-            out_discards: buf.out_discards(),
-            out_no_routes: buf.out_no_routes(),
-            reasm_timeout: buf.reasm_timeout(),
-            reasm_reqds: buf.reasm_reqds(),
-            reasm_oks: buf.reasm_oks(),
-            reasm_fails: buf.reasm_fails(),
-            frag_oks: buf.frag_oks(),
-            frag_fails: buf.frag_fails(),
-            frag_creates: buf.frag_creates(),
-            in_mcast_pkts: buf.in_mcast_pkts(),
-            out_mcast_pkts: buf.out_mcast_pkts(),
-            in_bcast_pkts: buf.in_bcast_pkts(),
-            out_bcast_pkts: buf.out_bcast_pkts(),
-            in_mcast_octets: buf.in_mcast_octets(),
-            out_mcast_octets: buf.out_mcast_octets(),
-            in_bcast_octets: buf.in_bcast_octets(),
-            out_bcast_octets: buf.out_bcast_octets(),
-            in_csum_errors: buf.in_csum_errors(),
-            in_no_ect_pkts: buf.in_no_ect_pkts(),
-            in_ect1_pkts: buf.in_ect1_pkts(),
-            in_ect0_pkts: buf.in_ect0_pkts(),
-            in_ce_pkts: buf.in_ce_pkts(),
-            reasm_overlaps: buf.reasm_overlaps(),
-            out_pkts: buf.out_pkts(),
+            num: raw.num,
+            in_pkts: raw.in_pkts,
+            in_octets: raw.in_octets,
+            in_delivers: raw.in_delivers,
+            out_forw_datagrams: raw.out_forw_datagrams,
+            out_requests: raw.out_requests,
+            out_octets: raw.out_octets,
+            in_hdr_errors: raw.in_hdr_errors,
+            in_too_big_errors: raw.in_too_big_errors,
+            in_no_routes: raw.in_no_routes,
+            in_addr_errors: raw.in_addr_errors,
+            in_unknown_protos: raw.in_unknown_protos,
+            in_truncated_pkts: raw.in_truncated_pkts,
+            in_discards: raw.in_discards,
+            out_discards: raw.out_discards,
+            out_no_routes: raw.out_no_routes,
+            reasm_timeout: raw.reasm_timeout,
+            reasm_reqds: raw.reasm_reqds,
+            reasm_oks: raw.reasm_oks,
+            reasm_fails: raw.reasm_fails,
+            frag_oks: raw.frag_oks,
+            frag_fails: raw.frag_fails,
+            frag_creates: raw.frag_creates,
+            in_mcast_pkts: raw.in_mcast_pkts,
+            out_mcast_pkts: raw.out_mcast_pkts,
+            in_bcast_pkts: raw.in_bcast_pkts,
+            out_bcast_pkts: raw.out_bcast_pkts,
+            in_mcast_octets: raw.in_mcast_octets,
+            out_mcast_octets: raw.out_mcast_octets,
+            in_bcast_octets: raw.in_bcast_octets,
+            out_bcast_octets: raw.out_bcast_octets,
+            in_csum_errors: raw.in_csum_errors,
+            in_no_ect_pkts: raw.in_no_ect_pkts,
+            in_ect1_pkts: raw.in_ect1_pkts,
+            in_ect0_pkts: raw.in_ect0_pkts,
+            in_ce_pkts: raw.in_ce_pkts,
+            reasm_overlaps: raw.reasm_overlaps,
+            out_pkts: raw.out_pkts,
         })
+    }
+}
+
+impl From<&Inet6Stats> for Inet6StatsBuffer {
+    fn from(stats: &Inet6Stats) -> Self {
+        Self {
+            num: stats.num,
+            in_pkts: stats.in_pkts,
+            in_octets: stats.in_octets,
+            in_delivers: stats.in_delivers,
+            out_forw_datagrams: stats.out_forw_datagrams,
+            out_requests: stats.out_requests,
+            out_octets: stats.out_octets,
+            in_hdr_errors: stats.in_hdr_errors,
+            in_too_big_errors: stats.in_too_big_errors,
+            in_no_routes: stats.in_no_routes,
+            in_addr_errors: stats.in_addr_errors,
+            in_unknown_protos: stats.in_unknown_protos,
+            in_truncated_pkts: stats.in_truncated_pkts,
+            in_discards: stats.in_discards,
+            out_discards: stats.out_discards,
+            out_no_routes: stats.out_no_routes,
+            reasm_timeout: stats.reasm_timeout,
+            reasm_reqds: stats.reasm_reqds,
+            reasm_oks: stats.reasm_oks,
+            reasm_fails: stats.reasm_fails,
+            frag_oks: stats.frag_oks,
+            frag_fails: stats.frag_fails,
+            frag_creates: stats.frag_creates,
+            in_mcast_pkts: stats.in_mcast_pkts,
+            out_mcast_pkts: stats.out_mcast_pkts,
+            in_bcast_pkts: stats.in_bcast_pkts,
+            out_bcast_pkts: stats.out_bcast_pkts,
+            in_mcast_octets: stats.in_mcast_octets,
+            out_mcast_octets: stats.out_mcast_octets,
+            in_bcast_octets: stats.in_bcast_octets,
+            out_bcast_octets: stats.out_bcast_octets,
+            in_csum_errors: stats.in_csum_errors,
+            in_no_ect_pkts: stats.in_no_ect_pkts,
+            in_ect1_pkts: stats.in_ect1_pkts,
+            in_ect0_pkts: stats.in_ect0_pkts,
+            in_ce_pkts: stats.in_ce_pkts,
+            reasm_overlaps: stats.reasm_overlaps,
+            out_pkts: stats.out_pkts,
+        }
     }
 }
 
 impl Emitable for Inet6Stats {
     fn buffer_len(&self) -> usize {
-        INET6_STATS_LEN
+        size_of::<Inet6StatsBuffer>()
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buffer = Inet6StatsBuffer::new(buffer);
-        buffer.set_num(self.num);
-        buffer.set_in_pkts(self.in_pkts);
-        buffer.set_in_octets(self.in_octets);
-        buffer.set_in_delivers(self.in_delivers);
-        buffer.set_out_forw_datagrams(self.out_forw_datagrams);
-        buffer.set_out_requests(self.out_requests);
-        buffer.set_out_octets(self.out_octets);
-        buffer.set_in_hdr_errors(self.in_hdr_errors);
-        buffer.set_in_too_big_errors(self.in_too_big_errors);
-        buffer.set_in_no_routes(self.in_no_routes);
-        buffer.set_in_addr_errors(self.in_addr_errors);
-        buffer.set_in_unknown_protos(self.in_unknown_protos);
-        buffer.set_in_truncated_pkts(self.in_truncated_pkts);
-        buffer.set_in_discards(self.in_discards);
-        buffer.set_out_discards(self.out_discards);
-        buffer.set_out_no_routes(self.out_no_routes);
-        buffer.set_reasm_timeout(self.reasm_timeout);
-        buffer.set_reasm_reqds(self.reasm_reqds);
-        buffer.set_reasm_oks(self.reasm_oks);
-        buffer.set_reasm_fails(self.reasm_fails);
-        buffer.set_frag_oks(self.frag_oks);
-        buffer.set_frag_fails(self.frag_fails);
-        buffer.set_frag_creates(self.frag_creates);
-        buffer.set_in_mcast_pkts(self.in_mcast_pkts);
-        buffer.set_out_mcast_pkts(self.out_mcast_pkts);
-        buffer.set_in_bcast_pkts(self.in_bcast_pkts);
-        buffer.set_out_bcast_pkts(self.out_bcast_pkts);
-        buffer.set_in_mcast_octets(self.in_mcast_octets);
-        buffer.set_out_mcast_octets(self.out_mcast_octets);
-        buffer.set_in_bcast_octets(self.in_bcast_octets);
-        buffer.set_out_bcast_octets(self.out_bcast_octets);
-        buffer.set_in_csum_errors(self.in_csum_errors);
-        buffer.set_in_no_ect_pkts(self.in_no_ect_pkts);
-        buffer.set_in_ect1_pkts(self.in_ect1_pkts);
-        buffer.set_in_ect0_pkts(self.in_ect0_pkts);
-        buffer.set_in_ce_pkts(self.in_ce_pkts);
-        buffer.set_reasm_overlaps(self.reasm_overlaps);
-        buffer.set_out_pkts(self.out_pkts);
+        let raw = Inet6StatsBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/link/af_spec/mod.rs
+++ b/src/link/af_spec/mod.rs
@@ -24,7 +24,7 @@ pub use self::{
         BridgeVlanInfoFlags, BridgeVlanTunnelInfo,
     },
     in6_addr_gen_mode::In6AddrGenMode,
-    inet::{AfSpecInet, InetDevConf},
+    inet::{AfSpecInet, InetDevConf, InetDevConfBuffer},
     inet6::AfSpecInet6,
     inet6_cache::{Inet6CacheInfo, Inet6CacheInfoBuffer},
     inet6_devconf::{Inet6DevConf, Inet6DevConfBuffer},

--- a/src/link/attribute.rs
+++ b/src/link/attribute.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use std::os::unix::io::RawFd;
+use std::{mem::size_of, os::unix::io::RawFd};
 
 use netlink_packet_core::{
     emit_i32, emit_u32, parse_i32, parse_string, parse_u32, parse_u8,
@@ -29,13 +29,11 @@ use super::{
     link_info::VecLinkInfo,
     proto_info::VecLinkProtoInfoInet6,
     sriov::{VecLinkVfInfo, VecLinkVfPort},
-    stats::LINK_STATS_LEN,
-    stats64::LINK_STATS64_LEN,
     xdp::VecLinkXdp,
     AfSpecBridge, AfSpecUnspec, LinkEvent, LinkExtentMask, LinkInfo, LinkMode,
     LinkPhysId, LinkProtoInfoBridge, LinkProtoInfoInet6,
-    LinkProtocolDownReason, LinkVfInfo, LinkVfPort, LinkXdp, Map, MapBuffer,
-    Prop, State, Stats, Stats64, Stats64Buffer, StatsBuffer, WirelessEvent,
+    LinkProtocolDownReason, LinkVfInfo, LinkVfPort, LinkXdp, Map, Prop, State,
+    Stats, Stats64, Stats64Buffer, StatsBuffer, WirelessEvent,
 };
 use crate::AddressFamily;
 
@@ -249,8 +247,8 @@ impl Nla for LinkAttribute {
             | Self::GroIpv4MaxSize(_) => 4,
 
             Self::OperState(_) => 1,
-            Self::Stats(_) => LINK_STATS_LEN,
-            Self::Stats64(_) => LINK_STATS64_LEN,
+            Self::Stats(_) => size_of::<StatsBuffer>(),
+            Self::Stats64(_) => size_of::<Stats64Buffer>(),
             Self::Map(nla) => nla.buffer_len(),
             Self::LinkInfo(nlas) => nlas.as_slice().buffer_len(),
             Self::Xdp(nlas) => nlas.as_slice().buffer_len(),
@@ -662,38 +660,29 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
             IFLA_MAP => {
                 let err =
                     |payload| format!("Invalid IFLA_MAP value {payload:?}");
-                Self::Map(
-                    super::Map::parse(
-                        &MapBuffer::new_checked(payload)
-                            .context(err(payload))?,
-                    )
-                    .context(err(payload))?,
-                )
+                Self::Map(super::Map::parse(payload).context(err(payload))?)
             }
             IFLA_STATS => Self::Stats(
-                super::Stats::parse(&StatsBuffer::new(
+                super::Stats::parse(
                     expand_buffer_if_small(
                         payload,
-                        LINK_STATS_LEN,
+                        size_of::<StatsBuffer>(),
                         "IFLA_STATS",
                     )
                     .as_slice(),
-                ))
+                )
                 .context(format!("Invalid IFLA_STATS value {payload:?}"))?,
             ),
             IFLA_STATS64 => {
                 let payload = expand_buffer_if_small(
                     payload,
-                    LINK_STATS64_LEN,
+                    size_of::<Stats64Buffer>(),
                     "IFLA_STATS64",
                 );
                 Self::Stats64(
-                    super::Stats64::parse(&Stats64Buffer::new(
-                        payload.as_slice(),
-                    ))
-                    .context(format!(
-                        "Invalid IFLA_STATS64 value {payload:?}"
-                    ))?,
+                    super::Stats64::parse(payload.as_slice()).context(
+                        format!("Invalid IFLA_STATS64 value {payload:?}"),
+                    )?,
                 )
             }
             IFLA_AF_SPEC => match interface_family {

--- a/src/link/header.rs
+++ b/src/link/header.rs
@@ -1,30 +1,32 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{
-    DecodeError, Emitable, NlaBuffer, NlasIterator, Parseable,
-};
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use super::link_flag::LinkFlags;
 use crate::{link::LinkLayerType, AddressFamily};
 
-const LINK_HEADER_LEN: usize = 16;
+pub(crate) const LINK_HEADER_LEN: usize = 16;
 
-buffer!(LinkMessageBuffer(LINK_HEADER_LEN) {
-    interface_family: (u8, 0),
-    reserved_1: (u8, 1),
-    link_layer_type: (u16, 2..4),
-    link_index: (u32, 4..8),
-    flags: (u32, 8..12),
-    change_mask: (u32, 12..LINK_HEADER_LEN),
-    payload: (slice, LINK_HEADER_LEN..),
-});
-
-impl<'a, T: AsRef<[u8]> + ?Sized> LinkMessageBuffer<&'a T> {
-    pub fn attributes(
-        &self,
-    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
-        NlasIterator::new(self.payload())
-    }
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct LinkMessageBuffer {
+    interface_family: u8,
+    reserved_1: u8,
+    link_layer_type: u16,
+    link_index: u32,
+    flags: u32,
+    change_mask: u32,
 }
 
 /// High level representation of `RTM_GETLINK`, `RTM_SETLINK`, `RTM_NEWLINK` and
@@ -73,26 +75,37 @@ impl Emitable for LinkHeader {
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut packet = LinkMessageBuffer::new(buffer);
-        packet.set_interface_family(u8::from(self.interface_family));
-        // The kernel expects the reserved byte to always be zero.
-        // Zero it in case the callers didn't give us a zeroed buffer.
-        packet.set_reserved_1(0);
-        packet.set_link_index(self.index);
-        packet.set_change_mask(self.change_mask.bits());
-        packet.set_link_layer_type(u16::from(self.link_layer_type));
-        packet.set_flags(self.flags.bits());
+        let raw = LinkMessageBuffer::from(self);
+        buffer[..LINK_HEADER_LEN].copy_from_slice(raw.as_bytes());
     }
 }
 
-impl<T: AsRef<[u8]>> Parseable<LinkMessageBuffer<T>> for LinkHeader {
-    fn parse(buf: &LinkMessageBuffer<T>) -> Result<Self, DecodeError> {
+impl LinkHeader {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) =
+            LinkMessageBuffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(payload.len(), LINK_HEADER_LEN)
+            })?;
         Ok(Self {
-            interface_family: buf.interface_family().into(),
-            link_layer_type: buf.link_layer_type().into(),
-            index: buf.link_index(),
-            change_mask: LinkFlags::from_bits_retain(buf.change_mask()),
-            flags: LinkFlags::from_bits_retain(buf.flags()),
+            interface_family: raw.interface_family.into(),
+            link_layer_type: raw.link_layer_type.into(),
+            index: raw.link_index,
+            change_mask: LinkFlags::from_bits_retain(raw.change_mask),
+            flags: LinkFlags::from_bits_retain(raw.flags),
         })
+    }
+}
+
+impl From<&LinkHeader> for LinkMessageBuffer {
+    fn from(header: &LinkHeader) -> Self {
+        Self {
+            interface_family: u8::from(header.interface_family),
+            // The kernel expects the reserved byte to always be zero.
+            reserved_1: 0,
+            link_layer_type: u16::from(header.link_layer_type),
+            link_index: header.index,
+            flags: header.flags.bits(),
+            change_mask: header.change_mask.bits(),
+        }
     }
 }

--- a/src/link/link_info/bridge.rs
+++ b/src/link/link_info/bridge.rs
@@ -8,6 +8,10 @@ use netlink_packet_core::{
     Emitable, ErrorContext, Nla, NlaBuffer, NlasIterator, Parseable,
     NLA_F_NESTED,
 };
+use zerocopy::{
+    byteorder::big_endian::U16, FromBytes, Immutable, IntoBytes, KnownLayout,
+    Unaligned,
+};
 
 use crate::link::{BridgeBooleanOptions, VlanProtocol};
 
@@ -438,11 +442,11 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoBridge {
                     .context("invalid IFLA_BR_GROUP_FWD_MASK value")?,
             ),
             IFLA_BR_ROOT_ID => Self::RootId(
-                BridgeId::parse(&BridgeIdBuffer::new(payload))
+                BridgeId::parse(payload)
                     .context("invalid IFLA_BR_ROOT_ID value")?,
             ),
             IFLA_BR_BRIDGE_ID => Self::BridgeId(
-                BridgeId::parse(&BridgeIdBuffer::new(payload))
+                BridgeId::parse(payload)
                     .context("invalid IFLA_BR_BRIDGE_ID value")?,
             ),
             IFLA_BR_GROUP_ADDR => Self::GroupAddr(
@@ -562,41 +566,65 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoBridge {
     }
 }
 
-const BRIDGE_ID_LEN: usize = 8;
-
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct BridgeId {
     pub priority: u16,
     pub address: [u8; 6],
 }
 
-buffer!(BridgeIdBuffer(BRIDGE_ID_LEN) {
-    priority: (u16, 0..2),
-    address: (slice, 2..BRIDGE_ID_LEN)
-});
+// Wire format of a bridge ID: 2-byte big-endian priority followed by the
+// 6-byte MAC address.
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct BridgeIdBuffer {
+    priority: U16,
+    address: [u8; 6],
+}
 
-impl<T: AsRef<[u8]> + ?Sized> Parseable<BridgeIdBuffer<&T>> for BridgeId {
-    fn parse(buf: &BridgeIdBuffer<&T>) -> Result<Self, DecodeError> {
-        // Priority is encoded in big endian. From kernel's
-        // net/bridge/br_netlink.c br_fill_info():
-        // u16 priority = (br->bridge_id.prio[0] << 8) | br->bridge_id.prio[1];
-        Ok(Self {
-            priority: u16::from_be(buf.priority()),
-            address: parse_mac(buf.address())
-                .context("invalid MAC address in BridgeId buffer")?,
-        })
+impl BridgeId {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        BridgeIdBuffer::ref_from_bytes(payload)
+            .map(|raw| Self::from(raw.clone()))
+            .map_err(|_| DecodeError::from("invalid BridgeId buffer"))
+    }
+}
+
+impl From<BridgeIdBuffer> for BridgeId {
+    fn from(raw: BridgeIdBuffer) -> Self {
+        Self {
+            priority: raw.priority.get(),
+            address: raw.address,
+        }
+    }
+}
+
+impl From<&BridgeId> for BridgeIdBuffer {
+    fn from(bridge_id: &BridgeId) -> Self {
+        Self {
+            priority: U16::new(bridge_id.priority),
+            address: bridge_id.address,
+        }
     }
 }
 
 impl Emitable for BridgeId {
     fn buffer_len(&self) -> usize {
-        BRIDGE_ID_LEN
+        std::mem::size_of::<BridgeIdBuffer>()
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buffer = BridgeIdBuffer::new(buffer);
-        buffer.set_priority(self.priority.to_be());
-        buffer.address_mut().copy_from_slice(&self.address[..]);
+        let raw = BridgeIdBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }
 

--- a/src/link/link_info/bridge_port.rs
+++ b/src/link/link_info/bridge_port.rs
@@ -5,7 +5,7 @@ use netlink_packet_core::{
     DecodeError, DefaultNla, Emitable, ErrorContext, Nla, NlaBuffer, Parseable,
 };
 
-use crate::link::{BridgeId, BridgeIdBuffer, BridgeMulticastRouterType};
+use crate::link::{BridgeId, BridgeMulticastRouterType};
 
 const IFLA_BRPORT_STATE: u16 = 1;
 const IFLA_BRPORT_PRIORITY: u16 = 2;
@@ -340,16 +340,16 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                     format!("invalid IFLA_BRPORT_PROXYARP_WIFI {payload:?}")
                 })? > 0,
             ),
-            IFLA_BRPORT_ROOT_ID => Self::RootId(
-                BridgeId::parse(&BridgeIdBuffer::new(payload)).context(
-                    format!("invalid IFLA_BRPORT_ROOT_ID {payload:?}"),
-                )?,
-            ),
-            IFLA_BRPORT_BRIDGE_ID => Self::BridgeId(
-                BridgeId::parse(&BridgeIdBuffer::new(payload)).context(
-                    format!("invalid IFLA_BRPORT_BRIDGE_ID {payload:?}"),
-                )?,
-            ),
+            IFLA_BRPORT_ROOT_ID => {
+                Self::RootId(BridgeId::parse(payload).context(format!(
+                    "invalid IFLA_BRPORT_ROOT_ID {payload:?}"
+                ))?)
+            }
+            IFLA_BRPORT_BRIDGE_ID => {
+                Self::BridgeId(BridgeId::parse(payload).context(format!(
+                    "invalid IFLA_BRPORT_BRIDGE_ID {payload:?}"
+                ))?)
+            }
             IFLA_BRPORT_DESIGNATED_PORT => {
                 InfoBridgePort::DesignatedPort(parse_u16(payload).context({
                     format!("invalid IFLA_BRPORT_DESIGNATED_PORT {payload:?}")

--- a/src/link/link_info/netkit.rs
+++ b/src/link/link_info/netkit.rs
@@ -5,7 +5,7 @@ use netlink_packet_core::{
     DefaultNla, Emitable, ErrorContext, Nla, NlaBuffer, Parseable,
 };
 
-use super::super::{LinkMessage, LinkMessageBuffer};
+use super::super::LinkMessage;
 
 const NETKIT_L2: u32 = 0;
 const NETKIT_L3: u32 = 1;
@@ -254,9 +254,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoNetkit {
         Ok(match buf.kind() {
             IFLA_NETKIT_PEER_INFO => {
                 let err = "failed to parse netkit peer info";
-                let buffer =
-                    LinkMessageBuffer::new_checked(&payload).context(err)?;
-                Self::Peer(LinkMessage::parse(&buffer).context(err)?)
+                Self::Peer(LinkMessage::parse(payload).context(err)?)
             }
             IFLA_NETKIT_PRIMARY => {
                 let value = parse_u8(payload)? != 0;

--- a/src/link/link_info/veth.rs
+++ b/src/link/link_info/veth.rs
@@ -4,7 +4,7 @@ use netlink_packet_core::{
     DecodeError, DefaultNla, Emitable, ErrorContext, Nla, NlaBuffer, Parseable,
 };
 
-use super::super::{LinkMessage, LinkMessageBuffer};
+use super::super::LinkMessage;
 
 const VETH_INFO_PEER: u16 = 1;
 
@@ -47,9 +47,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoVeth {
         Ok(match buf.kind() {
             VETH_INFO_PEER => {
                 let err = "failed to parse veth link info";
-                let buffer =
-                    LinkMessageBuffer::new_checked(&payload).context(err)?;
-                Self::Peer(LinkMessage::parse(&buffer).context(err)?)
+                Self::Peer(LinkMessage::parse(payload).context(err)?)
             }
             kind => Self::Other(
                 DefaultNla::parse(buf)

--- a/src/link/link_info/vxcan.rs
+++ b/src/link/link_info/vxcan.rs
@@ -4,7 +4,7 @@ use netlink_packet_core::{
     DecodeError, DefaultNla, Emitable, ErrorContext, Nla, NlaBuffer, Parseable,
 };
 
-use super::super::{LinkMessage, LinkMessageBuffer};
+use super::super::LinkMessage;
 
 const VXCAN_INFO_PEER: u16 = 1;
 
@@ -47,9 +47,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoVxcan {
         Ok(match buf.kind() {
             VXCAN_INFO_PEER => {
                 let err = "failed to parse vxcan link info";
-                let buffer =
-                    LinkMessageBuffer::new_checked(&payload).context(err)?;
-                Self::Peer(LinkMessage::parse(&buffer).context(err)?)
+                Self::Peer(LinkMessage::parse(payload).context(err)?)
             }
             kind => Self::Other(
                 DefaultNla::parse(buf)

--- a/src/link/map.rs
+++ b/src/link/map.rs
@@ -1,17 +1,31 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{DecodeError, Emitable, Parseable};
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 const LINK_MAP_LEN: usize = 32;
 
-buffer!(MapBuffer(LINK_MAP_LEN) {
-    memory_start: (u64, 0..8),
-    memory_end: (u64, 8..16),
-    base_address: (u64, 16..24),
-    irq: (u16, 24..26),
-    dma: (u8, 26),
-    port: (u8, 27),
-});
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct MapBuffer {
+    memory_start: u64,
+    memory_end: u64,
+    base_address: u64,
+    irq: u16,
+    dma: u8,
+    port: u8,
+    _padding: [u8; 4],
+}
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
 #[non_exhaustive]
@@ -24,16 +38,33 @@ pub struct Map {
     pub port: u8,
 }
 
-impl<T: AsRef<[u8]>> Parseable<MapBuffer<T>> for Map {
-    fn parse(buf: &MapBuffer<T>) -> Result<Self, DecodeError> {
+impl Map {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) = MapBuffer::ref_from_prefix(payload).map_err(|_| {
+            DecodeError::buffer_too_small(payload.len(), LINK_MAP_LEN)
+        })?;
         Ok(Self {
-            memory_start: buf.memory_start(),
-            memory_end: buf.memory_end(),
-            base_address: buf.base_address(),
-            irq: buf.irq(),
-            dma: buf.dma(),
-            port: buf.port(),
+            memory_start: raw.memory_start,
+            memory_end: raw.memory_end,
+            base_address: raw.base_address,
+            irq: raw.irq,
+            dma: raw.dma,
+            port: raw.port,
         })
+    }
+}
+
+impl From<&Map> for MapBuffer {
+    fn from(map: &Map) -> Self {
+        Self {
+            memory_start: map.memory_start,
+            memory_end: map.memory_end,
+            base_address: map.base_address,
+            irq: map.irq,
+            dma: map.dma,
+            port: map.port,
+            _padding: [0; 4],
+        }
     }
 }
 
@@ -43,12 +74,7 @@ impl Emitable for Map {
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buffer = MapBuffer::new(buffer);
-        buffer.set_memory_start(self.memory_start);
-        buffer.set_memory_end(self.memory_end);
-        buffer.set_base_address(self.base_address);
-        buffer.set_irq(self.irq);
-        buffer.set_dma(self.dma);
-        buffer.set_port(self.port);
+        let raw = MapBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/link/message.rs
+++ b/src/link/message.rs
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MIT
 
 use netlink_packet_core::{
-    DecodeError, Emitable, ErrorContext, Parseable, ParseableParametrized,
+    DecodeError, Emitable, ErrorContext, NlasIterator, Parseable,
+    ParseableParametrized,
 };
 
 use crate::{
-    link::{LinkAttribute, LinkHeader, LinkMessageBuffer},
+    link::{header::LINK_HEADER_LEN, LinkAttribute, LinkHeader},
     AddressFamily,
 };
 
@@ -29,30 +30,27 @@ impl Emitable for LinkMessage {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<LinkMessageBuffer<&'a T>>
-    for LinkMessage
-{
-    fn parse(buf: &LinkMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl Parseable<[u8]> for LinkMessage {
+    fn parse(buf: &[u8]) -> Result<Self, DecodeError> {
         let header = LinkHeader::parse(buf)
             .context("failed to parse link message header")?;
         let interface_family = header.interface_family;
-        let attributes =
-            Vec::<LinkAttribute>::parse_with_param(buf, interface_family)
-                .context("failed to parse link message NLAs")?;
+        let attributes = Vec::<LinkAttribute>::parse_with_param(
+            &buf[LINK_HEADER_LEN..],
+            interface_family,
+        )
+        .context("failed to parse link message NLAs")?;
         Ok(LinkMessage { header, attributes })
     }
 }
 
-impl<'a, T: AsRef<[u8]> + 'a>
-    ParseableParametrized<LinkMessageBuffer<&'a T>, AddressFamily>
-    for Vec<LinkAttribute>
-{
+impl ParseableParametrized<[u8], AddressFamily> for Vec<LinkAttribute> {
     fn parse_with_param(
-        buf: &LinkMessageBuffer<&'a T>,
+        buf: &[u8],
         family: AddressFamily,
     ) -> Result<Self, DecodeError> {
         let mut attributes = vec![];
-        for nla_buf in buf.attributes() {
+        for nla_buf in NlasIterator::new(buf) {
             attributes
                 .push(LinkAttribute::parse_with_param(&nla_buf?, family)?);
         }

--- a/src/link/mod.rs
+++ b/src/link/mod.rs
@@ -36,7 +36,7 @@ pub use self::{
         BridgeVlanTunnelInfo, Icmp6Stats, Icmp6StatsBuffer, In6AddrGenMode,
         Inet6CacheInfo, Inet6CacheInfoBuffer, Inet6DevConf, Inet6DevConfBuffer,
         Inet6IfaceFlags, Inet6Stats, Inet6StatsBuffer, InetDevConf,
-        MctpPhysBinding,
+        InetDevConfBuffer, MctpPhysBinding,
     },
     attribute::LinkAttribute,
     devlink_port::DevlinkPort,

--- a/src/link/sriov/broadcast.rs
+++ b/src/link/sriov/broadcast.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{DecodeError, Emitable, Parseable};
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 const VF_INFO_BROADCAST_LEN: usize = 32;
 
@@ -22,15 +23,40 @@ impl VfInfoBroadcast {
     }
 }
 
-buffer!(VfInfoBroadcastBuffer(VF_INFO_BROADCAST_LEN) {
-    addr: (slice, 0..VF_INFO_BROADCAST_LEN),
-});
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct VfInfoBroadcastBuffer {
+    addr: [u8; VF_INFO_BROADCAST_LEN],
+}
 
-impl<T: AsRef<[u8]> + ?Sized> Parseable<VfInfoBroadcastBuffer<&T>>
-    for VfInfoBroadcast
-{
-    fn parse(buf: &VfInfoBroadcastBuffer<&T>) -> Result<Self, DecodeError> {
-        Ok(Self::new(buf.addr()))
+impl VfInfoBroadcast {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) = VfInfoBroadcastBuffer::ref_from_prefix(payload)
+            .map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    VF_INFO_BROADCAST_LEN,
+                )
+            })?;
+        Ok(Self::new(&raw.addr))
+    }
+}
+
+impl From<&VfInfoBroadcast> for VfInfoBroadcastBuffer {
+    fn from(broadcast: &VfInfoBroadcast) -> Self {
+        Self {
+            addr: broadcast.addr,
+        }
     }
 }
 
@@ -40,7 +66,7 @@ impl Emitable for VfInfoBroadcast {
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buffer = VfInfoBroadcastBuffer::new(buffer);
-        buffer.addr_mut().copy_from_slice(&self.addr);
+        let raw = VfInfoBroadcastBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/link/sriov/guid.rs
+++ b/src/link/sriov/guid.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{DecodeError, Emitable, Parseable};
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 const VF_INFO_GUID_LEN: usize = 12;
 
@@ -17,14 +18,39 @@ impl VfInfoGuid {
     }
 }
 
-buffer!(VfInfoGuidBuffer(VF_INFO_GUID_LEN) {
-    vf_id: (u32, 0..4),
-    guid: (u64, 4..12),
-});
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct VfInfoGuidBuffer {
+    vf_id: u32,
+    guid: u64,
+}
 
-impl<T: AsRef<[u8]> + ?Sized> Parseable<VfInfoGuidBuffer<&T>> for VfInfoGuid {
-    fn parse(buf: &VfInfoGuidBuffer<&T>) -> Result<Self, DecodeError> {
-        Ok(Self::new(buf.vf_id(), buf.guid()))
+impl VfInfoGuid {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) =
+            VfInfoGuidBuffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(payload.len(), VF_INFO_GUID_LEN)
+            })?;
+        Ok(Self::new(raw.vf_id, raw.guid))
+    }
+}
+
+impl From<&VfInfoGuid> for VfInfoGuidBuffer {
+    fn from(guid: &VfInfoGuid) -> Self {
+        Self {
+            vf_id: guid.vf_id,
+            guid: guid.guid,
+        }
     }
 }
 
@@ -34,8 +60,7 @@ impl Emitable for VfInfoGuid {
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buffer = VfInfoGuidBuffer::new(buffer);
-        buffer.set_vf_id(self.vf_id);
-        buffer.set_guid(self.guid);
+        let raw = VfInfoGuidBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/link/sriov/link_state.rs
+++ b/src/link/sriov/link_state.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{DecodeError, Emitable, Parseable};
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 const VF_INFO_LINK_STATE_LEN: usize = 8;
 
@@ -17,16 +18,42 @@ impl VfInfoLinkState {
     }
 }
 
-buffer!(VfInfoLinkStateBuffer(VF_INFO_LINK_STATE_LEN) {
-    vf_id: (u32, 0..4),
-    state: (u32, 4..8),
-});
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct VfInfoLinkStateBuffer {
+    vf_id: u32,
+    state: u32,
+}
 
-impl<T: AsRef<[u8]> + ?Sized> Parseable<VfInfoLinkStateBuffer<&T>>
-    for VfInfoLinkState
-{
-    fn parse(buf: &VfInfoLinkStateBuffer<&T>) -> Result<Self, DecodeError> {
-        Ok(Self::new(buf.vf_id(), buf.state().into()))
+impl VfInfoLinkState {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) = VfInfoLinkStateBuffer::ref_from_prefix(payload)
+            .map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    VF_INFO_LINK_STATE_LEN,
+                )
+            })?;
+        Ok(Self::new(raw.vf_id, raw.state.into()))
+    }
+}
+
+impl From<&VfInfoLinkState> for VfInfoLinkStateBuffer {
+    fn from(link_state: &VfInfoLinkState) -> Self {
+        Self {
+            vf_id: link_state.vf_id,
+            state: link_state.state.into(),
+        }
     }
 }
 
@@ -36,9 +63,8 @@ impl Emitable for VfInfoLinkState {
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buffer = VfInfoLinkStateBuffer::new(buffer);
-        buffer.set_vf_id(self.vf_id);
-        buffer.set_state(self.state.into());
+        let raw = VfInfoLinkStateBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }
 

--- a/src/link/sriov/mac.rs
+++ b/src/link/sriov/mac.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{DecodeError, Emitable, Parseable};
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 const MAX_ADDR_LEN: usize = 32;
 
@@ -28,14 +29,39 @@ impl VfInfoMac {
     }
 }
 
-buffer!(VfInfoMacBuffer(VF_INFO_MAC_LEN) {
-    vf_id: (u32, 0..4),
-    mac: (slice, 4..VF_INFO_MAC_LEN),
-});
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct VfInfoMacBuffer {
+    vf_id: u32,
+    mac: [u8; MAX_ADDR_LEN],
+}
 
-impl<T: AsRef<[u8]> + ?Sized> Parseable<VfInfoMacBuffer<&T>> for VfInfoMac {
-    fn parse(buf: &VfInfoMacBuffer<&T>) -> Result<Self, DecodeError> {
-        Ok(Self::new(buf.vf_id(), buf.mac()))
+impl VfInfoMac {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) =
+            VfInfoMacBuffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(payload.len(), VF_INFO_MAC_LEN)
+            })?;
+        Ok(Self::new(raw.vf_id, &raw.mac))
+    }
+}
+
+impl From<&VfInfoMac> for VfInfoMacBuffer {
+    fn from(mac: &VfInfoMac) -> Self {
+        Self {
+            vf_id: mac.vf_id,
+            mac: mac.mac,
+        }
     }
 }
 
@@ -45,8 +71,7 @@ impl Emitable for VfInfoMac {
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buffer = VfInfoMacBuffer::new(buffer);
-        buffer.set_vf_id(self.vf_id);
-        buffer.mac_mut().copy_from_slice(&self.mac);
+        let raw = VfInfoMacBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/link/sriov/rate.rs
+++ b/src/link/sriov/rate.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{DecodeError, Emitable, Parseable};
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 const VF_INFO_RATE_LEN: usize = 12;
 
@@ -22,19 +23,45 @@ impl VfInfoRate {
     }
 }
 
-buffer!(VfInfoRateBuffer(VF_INFO_RATE_LEN) {
-    vf_id: (u32, 0..4),
-    min_tx_rate: (u32, 4..8),
-    max_tx_rate: (u32, 8..12)
-});
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct VfInfoRateBuffer {
+    vf_id: u32,
+    min_tx_rate: u32,
+    max_tx_rate: u32,
+}
 
-impl<T: AsRef<[u8]> + ?Sized> Parseable<VfInfoRateBuffer<&T>> for VfInfoRate {
-    fn parse(buf: &VfInfoRateBuffer<&T>) -> Result<Self, DecodeError> {
+impl VfInfoRate {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) =
+            VfInfoRateBuffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(payload.len(), VF_INFO_RATE_LEN)
+            })?;
         Ok(Self {
-            vf_id: buf.vf_id(),
-            min_tx_rate: buf.min_tx_rate(),
-            max_tx_rate: buf.max_tx_rate(),
+            vf_id: raw.vf_id,
+            min_tx_rate: raw.min_tx_rate,
+            max_tx_rate: raw.max_tx_rate,
         })
+    }
+}
+
+impl From<&VfInfoRate> for VfInfoRateBuffer {
+    fn from(rate: &VfInfoRate) -> Self {
+        Self {
+            vf_id: rate.vf_id,
+            min_tx_rate: rate.min_tx_rate,
+            max_tx_rate: rate.max_tx_rate,
+        }
     }
 }
 
@@ -44,9 +71,7 @@ impl Emitable for VfInfoRate {
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buffer = VfInfoRateBuffer::new(buffer);
-        buffer.set_vf_id(self.vf_id);
-        buffer.set_min_tx_rate(self.min_tx_rate);
-        buffer.set_max_tx_rate(self.max_tx_rate);
+        let raw = VfInfoRateBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/link/sriov/rss_query.rs
+++ b/src/link/sriov/rss_query.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{DecodeError, Emitable, Parseable};
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 const VF_INFO_RSS_QUERY_EN_LEN: usize = 8;
 
@@ -17,19 +18,45 @@ impl VfInfoRssQueryEn {
     }
 }
 
-buffer!(VfInfoRssQueryEnBuffer(VF_INFO_RSS_QUERY_EN_LEN) {
-    vf_id: (u32, 0..4),
-    setting: (u32, 4..8),
-});
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct VfInfoRssQueryEnBuffer {
+    vf_id: u32,
+    setting: u32,
+}
 
-impl<T: AsRef<[u8]> + ?Sized> Parseable<VfInfoRssQueryEnBuffer<&T>>
-    for VfInfoRssQueryEn
-{
-    fn parse(buf: &VfInfoRssQueryEnBuffer<&T>) -> Result<Self, DecodeError> {
+impl VfInfoRssQueryEn {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) = VfInfoRssQueryEnBuffer::ref_from_prefix(payload)
+            .map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    VF_INFO_RSS_QUERY_EN_LEN,
+                )
+            })?;
         Ok(Self::new(
-            buf.vf_id(),
-            buf.setting() > 0 && buf.setting() != u32::MAX,
+            raw.vf_id,
+            raw.setting > 0 && raw.setting != u32::MAX,
         ))
+    }
+}
+
+impl From<&VfInfoRssQueryEn> for VfInfoRssQueryEnBuffer {
+    fn from(rss_query: &VfInfoRssQueryEn) -> Self {
+        Self {
+            vf_id: rss_query.vf_id,
+            setting: rss_query.enabled as u32,
+        }
     }
 }
 
@@ -39,8 +66,7 @@ impl Emitable for VfInfoRssQueryEn {
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buffer = VfInfoRssQueryEnBuffer::new(buffer);
-        buffer.set_vf_id(self.vf_id);
-        buffer.set_setting(self.enabled as u32);
+        let raw = VfInfoRssQueryEnBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/link/sriov/spoofchk.rs
+++ b/src/link/sriov/spoofchk.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{DecodeError, Emitable, Parseable};
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 const VF_INFO_SPOOFCHK_LEN: usize = 8;
 
@@ -17,19 +18,45 @@ impl VfInfoSpoofCheck {
     }
 }
 
-buffer!(VfInfoSpoofCheckBuffer(VF_INFO_SPOOFCHK_LEN) {
-    vf_id: (u32, 0..4),
-    setting: (u32, 4..8),
-});
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct VfInfoSpoofCheckBuffer {
+    vf_id: u32,
+    setting: u32,
+}
 
-impl<T: AsRef<[u8]> + ?Sized> Parseable<VfInfoSpoofCheckBuffer<&T>>
-    for VfInfoSpoofCheck
-{
-    fn parse(buf: &VfInfoSpoofCheckBuffer<&T>) -> Result<Self, DecodeError> {
+impl VfInfoSpoofCheck {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) = VfInfoSpoofCheckBuffer::ref_from_prefix(payload)
+            .map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    VF_INFO_SPOOFCHK_LEN,
+                )
+            })?;
         Ok(Self::new(
-            buf.vf_id(),
-            buf.setting() > 0 && buf.setting() != u32::MAX,
+            raw.vf_id,
+            raw.setting > 0 && raw.setting != u32::MAX,
         ))
+    }
+}
+
+impl From<&VfInfoSpoofCheck> for VfInfoSpoofCheckBuffer {
+    fn from(spoofchk: &VfInfoSpoofCheck) -> Self {
+        Self {
+            vf_id: spoofchk.vf_id,
+            setting: spoofchk.enabled as u32,
+        }
     }
 }
 
@@ -39,8 +66,7 @@ impl Emitable for VfInfoSpoofCheck {
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buffer = VfInfoSpoofCheckBuffer::new(buffer);
-        buffer.set_vf_id(self.vf_id);
-        buffer.set_setting(self.enabled as u32);
+        let raw = VfInfoSpoofCheckBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/link/sriov/trust.rs
+++ b/src/link/sriov/trust.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{DecodeError, Emitable, Parseable};
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 const VF_INFO_TRUST_LEN: usize = 8;
 
@@ -17,17 +18,42 @@ impl VfInfoTrust {
     }
 }
 
-buffer!(VfInfoTrustBuffer(VF_INFO_TRUST_LEN) {
-    vf_id: (u32, 0..4),
-    setting: (u32, 4..8),
-});
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct VfInfoTrustBuffer {
+    vf_id: u32,
+    setting: u32,
+}
 
-impl<T: AsRef<[u8]> + ?Sized> Parseable<VfInfoTrustBuffer<&T>> for VfInfoTrust {
-    fn parse(buf: &VfInfoTrustBuffer<&T>) -> Result<Self, DecodeError> {
+impl VfInfoTrust {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) =
+            VfInfoTrustBuffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(payload.len(), VF_INFO_TRUST_LEN)
+            })?;
         Ok(Self::new(
-            buf.vf_id(),
-            buf.setting() > 0 && buf.setting() != u32::MAX,
+            raw.vf_id,
+            raw.setting > 0 && raw.setting != u32::MAX,
         ))
+    }
+}
+
+impl From<&VfInfoTrust> for VfInfoTrustBuffer {
+    fn from(trust: &VfInfoTrust) -> Self {
+        Self {
+            vf_id: trust.vf_id,
+            setting: trust.enabled as u32,
+        }
     }
 }
 
@@ -37,8 +63,7 @@ impl Emitable for VfInfoTrust {
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buffer = VfInfoTrustBuffer::new(buffer);
-        buffer.set_vf_id(self.vf_id);
-        buffer.set_setting(self.enabled as u32);
+        let raw = VfInfoTrustBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/link/sriov/tx_rate.rs
+++ b/src/link/sriov/tx_rate.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{DecodeError, Emitable, Parseable};
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 const VF_INFO_TX_RATE_LEN: usize = 8;
 
@@ -17,19 +18,45 @@ impl VfInfoTxRate {
     }
 }
 
-buffer!(VfInfoTxRateBuffer(VF_INFO_TX_RATE_LEN) {
-    vf_id: (u32, 0..4),
-    rate: (u32, 4..8),
-});
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct VfInfoTxRateBuffer {
+    vf_id: u32,
+    rate: u32,
+}
 
-impl<T: AsRef<[u8]> + ?Sized> Parseable<VfInfoTxRateBuffer<&T>>
-    for VfInfoTxRate
-{
-    fn parse(buf: &VfInfoTxRateBuffer<&T>) -> Result<Self, DecodeError> {
+impl VfInfoTxRate {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) =
+            VfInfoTxRateBuffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    VF_INFO_TX_RATE_LEN,
+                )
+            })?;
         Ok(Self {
-            vf_id: buf.vf_id(),
-            rate: buf.rate(),
+            vf_id: raw.vf_id,
+            rate: raw.rate,
         })
+    }
+}
+
+impl From<&VfInfoTxRate> for VfInfoTxRateBuffer {
+    fn from(rate: &VfInfoTxRate) -> Self {
+        Self {
+            vf_id: rate.vf_id,
+            rate: rate.rate,
+        }
     }
 }
 
@@ -39,8 +66,7 @@ impl Emitable for VfInfoTxRate {
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buffer = VfInfoTxRateBuffer::new(buffer);
-        buffer.set_vf_id(self.vf_id);
-        buffer.set_rate(self.rate);
+        let raw = VfInfoTxRateBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/link/sriov/vf_list.rs
+++ b/src/link/sriov/vf_list.rs
@@ -6,12 +6,9 @@ use netlink_packet_core::{
 };
 
 use crate::link::{
-    VfInfoBroadcast, VfInfoBroadcastBuffer, VfInfoGuid, VfInfoGuidBuffer,
-    VfInfoLinkState, VfInfoLinkStateBuffer, VfInfoMac, VfInfoMacBuffer,
-    VfInfoRate, VfInfoRateBuffer, VfInfoRssQueryEn, VfInfoRssQueryEnBuffer,
-    VfInfoSpoofCheck, VfInfoSpoofCheckBuffer, VfInfoTrust, VfInfoTrustBuffer,
-    VfInfoTxRate, VfInfoTxRateBuffer, VfInfoVlan, VfInfoVlanBuffer, VfStats,
-    VfVlan,
+    VfInfoBroadcast, VfInfoGuid, VfInfoLinkState, VfInfoMac, VfInfoRate,
+    VfInfoRssQueryEn, VfInfoSpoofCheck, VfInfoTrust, VfInfoTxRate, VfInfoVlan,
+    VfStats, VfVlan,
 };
 
 const IFLA_VF_INFO: u16 = 1;
@@ -173,57 +170,54 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for VfInfo {
         let payload = buf.value();
         Ok(match buf.kind() {
             IFLA_VF_MAC => Self::Mac(
-                VfInfoMac::parse(&VfInfoMacBuffer::new(payload))
+                VfInfoMac::parse(payload)
                     .context(format!("invalid IFLA_VF_MAC {payload:?}"))?,
             ),
             IFLA_VF_VLAN => Self::Vlan(
-                VfInfoVlan::parse(&VfInfoVlanBuffer::new(payload))
+                VfInfoVlan::parse(payload)
                     .context(format!("invalid IFLA_VF_VLAN {payload:?}"))?,
             ),
-            IFLA_VF_BROADCAST => Self::Broadcast(
-                VfInfoBroadcast::parse(&VfInfoBroadcastBuffer::new(payload))
-                    .context(format!(
-                        "invalid IFLA_VF_BROADCAST {payload:?}"
-                    ))?,
-            ),
+            IFLA_VF_BROADCAST => {
+                Self::Broadcast(VfInfoBroadcast::parse(payload).context(
+                    format!("invalid IFLA_VF_BROADCAST {payload:?}"),
+                )?)
+            }
             IFLA_VF_RATE => Self::Rate(
-                VfInfoRate::parse(&VfInfoRateBuffer::new(payload))
+                VfInfoRate::parse(payload)
                     .context(format!("invalid IFLA_VF_RATE {payload:?}"))?,
             ),
             IFLA_VF_TX_RATE => Self::TxRate(
-                VfInfoTxRate::parse(&VfInfoTxRateBuffer::new(payload))
+                VfInfoTxRate::parse(payload)
                     .context(format!("invalid IFLA_VF_TX_RATE {payload:?}"))?,
             ),
             IFLA_VF_SPOOFCHK => Self::SpoofCheck(
-                VfInfoSpoofCheck::parse(&VfInfoSpoofCheckBuffer::new(payload))
+                VfInfoSpoofCheck::parse(payload)
                     .context(format!("invalid IFLA_VF_SPOOFCHK {payload:?}"))?,
             ),
-            IFLA_VF_LINK_STATE => Self::LinkState(
-                VfInfoLinkState::parse(&VfInfoLinkStateBuffer::new(payload))
-                    .context(format!(
-                        "invalid IFLA_VF_LINK_STATE {payload:?}"
-                    ))?,
-            ),
-            IFLA_VF_RSS_QUERY_EN => Self::RssQueryEn(
-                VfInfoRssQueryEn::parse(&VfInfoRssQueryEnBuffer::new(payload))
-                    .context(format!(
-                        "invalid IFLA_VF_RSS_QUERY_EN {payload:?}"
-                    ))?,
-            ),
+            IFLA_VF_LINK_STATE => {
+                Self::LinkState(VfInfoLinkState::parse(payload).context(
+                    format!("invalid IFLA_VF_LINK_STATE {payload:?}"),
+                )?)
+            }
+            IFLA_VF_RSS_QUERY_EN => {
+                Self::RssQueryEn(VfInfoRssQueryEn::parse(payload).context(
+                    format!("invalid IFLA_VF_RSS_QUERY_EN {payload:?}"),
+                )?)
+            }
             IFLA_VF_TRUST => Self::Trust(
-                VfInfoTrust::parse(&VfInfoTrustBuffer::new(payload))
+                VfInfoTrust::parse(payload)
                     .context(format!("invalid IFLA_VF_TRUST {payload:?}"))?,
             ),
-            IFLA_VF_IB_NODE_GUID => Self::IbNodeGuid(
-                VfInfoGuid::parse(&VfInfoGuidBuffer::new(payload)).context(
+            IFLA_VF_IB_NODE_GUID => {
+                Self::IbNodeGuid(VfInfoGuid::parse(payload).context(
                     format!("invalid IFLA_VF_IB_NODE_GUID {payload:?}"),
-                )?,
-            ),
-            IFLA_VF_IB_PORT_GUID => Self::IbPortGuid(
-                VfInfoGuid::parse(&VfInfoGuidBuffer::new(payload)).context(
+                )?)
+            }
+            IFLA_VF_IB_PORT_GUID => {
+                Self::IbPortGuid(VfInfoGuid::parse(payload).context(
                     format!("invalid IFLA_VF_IB_PORT_GUID {payload:?}"),
-                )?,
-            ),
+                )?)
+            }
             IFLA_VF_VLAN_LIST => {
                 let mut nlas: Vec<VfVlan> = Vec::new();
                 for nla in NlasIterator::new(payload) {

--- a/src/link/sriov/vf_vlan.rs
+++ b/src/link/sriov/vf_vlan.rs
@@ -3,6 +3,7 @@
 use netlink_packet_core::{
     DecodeError, DefaultNla, Emitable, ErrorContext, Nla, NlaBuffer, Parseable,
 };
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use crate::link::VlanProtocol;
 
@@ -42,11 +43,11 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for VfVlan {
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();
         Ok(match buf.kind() {
-            IFLA_VF_VLAN_INFO => Self::Info(
-                VfVlanInfo::parse(&VfVlanInfoBuffer::new(payload)).context(
-                    format!("invalid IFLA_VF_VLAN_INFO {payload:?}"),
-                )?,
-            ),
+            IFLA_VF_VLAN_INFO => {
+                Self::Info(VfVlanInfo::parse(payload).context(format!(
+                    "invalid IFLA_VF_VLAN_INFO {payload:?}"
+                ))?)
+            }
             kind => Self::Other(DefaultNla::parse(buf).context(format!(
                 "failed to parse {kind} as DefaultNla: {payload:?}"
             ))?),
@@ -81,21 +82,50 @@ impl VfVlanInfo {
     }
 }
 
-buffer!(VfVlanInfoBuffer(VF_VLAN_INFO_LEN) {
-    vf_id: (u32, 0..4),
-    vlan_id: (u32, 4..8),
-    qos: (u32, 8..12),
-    protocol: (u16, 12..14),
-});
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct VfVlanInfoBuffer {
+    vf_id: u32,
+    vlan_id: u32,
+    qos: u32,
+    protocol: u16,
+    _padding: [u8; 2],
+}
 
-impl<T: AsRef<[u8]> + ?Sized> Parseable<VfVlanInfoBuffer<&T>> for VfVlanInfo {
-    fn parse(buf: &VfVlanInfoBuffer<&T>) -> Result<Self, DecodeError> {
+impl VfVlanInfo {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) =
+            VfVlanInfoBuffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(payload.len(), VF_VLAN_INFO_LEN)
+            })?;
         Ok(Self {
-            vf_id: buf.vf_id(),
-            vlan_id: buf.vlan_id(),
-            qos: buf.qos(),
-            protocol: u16::from_be(buf.protocol()).into(),
+            vf_id: raw.vf_id,
+            vlan_id: raw.vlan_id,
+            qos: raw.qos,
+            protocol: u16::from_be(raw.protocol).into(),
         })
+    }
+}
+
+impl From<&VfVlanInfo> for VfVlanInfoBuffer {
+    fn from(vlan_info: &VfVlanInfo) -> Self {
+        Self {
+            vf_id: vlan_info.vf_id,
+            vlan_id: vlan_info.vlan_id,
+            qos: vlan_info.qos,
+            protocol: u16::from(vlan_info.protocol).to_be(),
+            _padding: [0; 2],
+        }
     }
 }
 
@@ -105,10 +135,7 @@ impl Emitable for VfVlanInfo {
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buffer = VfVlanInfoBuffer::new(buffer);
-        buffer.set_vf_id(self.vf_id);
-        buffer.set_vlan_id(self.vlan_id);
-        buffer.set_qos(self.qos);
-        buffer.set_protocol(u16::from(self.protocol).to_be());
+        let raw = VfVlanInfoBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/link/sriov/vlan.rs
+++ b/src/link/sriov/vlan.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{DecodeError, Emitable, Parseable};
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 const VF_INFO_VLAN_LEN: usize = 12;
 
@@ -22,19 +23,45 @@ impl VfInfoVlan {
     }
 }
 
-buffer!(VfInfoVlanBuffer(VF_INFO_VLAN_LEN) {
-    vf_id: (u32, 0..4),
-    vlan_id: (u32, 4..8),
-    qos: (u32, 8..12)
-});
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct VfInfoVlanBuffer {
+    vf_id: u32,
+    vlan_id: u32,
+    qos: u32,
+}
 
-impl<T: AsRef<[u8]> + ?Sized> Parseable<VfInfoVlanBuffer<&T>> for VfInfoVlan {
-    fn parse(buf: &VfInfoVlanBuffer<&T>) -> Result<Self, DecodeError> {
+impl VfInfoVlan {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) =
+            VfInfoVlanBuffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(payload.len(), VF_INFO_VLAN_LEN)
+            })?;
         Ok(Self {
-            vf_id: buf.vf_id(),
-            vlan_id: buf.vlan_id(),
-            qos: buf.qos(),
+            vf_id: raw.vf_id,
+            vlan_id: raw.vlan_id,
+            qos: raw.qos,
         })
+    }
+}
+
+impl From<&VfInfoVlan> for VfInfoVlanBuffer {
+    fn from(vlan: &VfInfoVlan) -> Self {
+        Self {
+            vf_id: vlan.vf_id,
+            vlan_id: vlan.vlan_id,
+            qos: vlan.qos,
+        }
     }
 }
 
@@ -44,9 +71,7 @@ impl Emitable for VfInfoVlan {
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buffer = VfInfoVlanBuffer::new(buffer);
-        buffer.set_vf_id(self.vf_id);
-        buffer.set_vlan_id(self.vlan_id);
-        buffer.set_qos(self.qos);
+        let raw = VfInfoVlanBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/link/stats.rs
+++ b/src/link/stats.rs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{DecodeError, Emitable, Parseable};
+use std::mem::size_of;
 
-pub(crate) const LINK_STATS_LEN: usize = 96;
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
 #[non_exhaustive]
@@ -55,94 +56,120 @@ pub struct Stats {
     pub rx_nohandler: u32,
 }
 
-buffer!(StatsBuffer(LINK_STATS_LEN) {
-    rx_packets: (u32, 0..4),
-    tx_packets: (u32, 4..8),
-    rx_bytes: (u32, 8..12),
-    tx_bytes: (u32, 12..16),
-    rx_errors: (u32, 16..20),
-    tx_errors: (u32, 20..24),
-    rx_dropped: (u32, 24..28),
-    tx_dropped: (u32, 28..32),
-    multicast: (u32, 32..36),
-    collisions: (u32, 36..40),
-    rx_length_errors: (u32, 40..44),
-    rx_over_errors: (u32, 44..48),
-    rx_crc_errors: (u32, 48..52),
-    rx_frame_errors: (u32, 52..56),
-    rx_fifo_errors: (u32, 56..60),
-    rx_missed_errors: (u32, 60..64),
-    tx_aborted_errors: (u32, 64..68),
-    tx_carrier_errors: (u32, 68..72),
-    tx_fifo_errors: (u32, 72..76),
-    tx_heartbeat_errors: (u32, 76..80),
-    tx_window_errors: (u32, 80..84),
-    rx_compressed: (u32, 84..88),
-    tx_compressed: (u32, 88..92),
-    rx_nohandler: (u32, 92..96),
-});
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct StatsBuffer {
+    rx_packets: u32,
+    tx_packets: u32,
+    rx_bytes: u32,
+    tx_bytes: u32,
+    rx_errors: u32,
+    tx_errors: u32,
+    rx_dropped: u32,
+    tx_dropped: u32,
+    multicast: u32,
+    collisions: u32,
+    rx_length_errors: u32,
+    rx_over_errors: u32,
+    rx_crc_errors: u32,
+    rx_frame_errors: u32,
+    rx_fifo_errors: u32,
+    rx_missed_errors: u32,
+    tx_aborted_errors: u32,
+    tx_carrier_errors: u32,
+    tx_fifo_errors: u32,
+    tx_heartbeat_errors: u32,
+    tx_window_errors: u32,
+    rx_compressed: u32,
+    tx_compressed: u32,
+    rx_nohandler: u32,
+}
 
-impl<T: AsRef<[u8]>> Parseable<StatsBuffer<T>> for Stats {
-    fn parse(buf: &StatsBuffer<T>) -> Result<Self, DecodeError> {
+impl Stats {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) = StatsBuffer::ref_from_prefix(payload).map_err(|_| {
+            DecodeError::buffer_too_small(
+                payload.len(),
+                size_of::<StatsBuffer>(),
+            )
+        })?;
         Ok(Self {
-            rx_packets: buf.rx_packets(),
-            tx_packets: buf.tx_packets(),
-            rx_bytes: buf.rx_bytes(),
-            tx_bytes: buf.tx_bytes(),
-            rx_errors: buf.rx_errors(),
-            tx_errors: buf.tx_errors(),
-            rx_dropped: buf.rx_dropped(),
-            tx_dropped: buf.tx_dropped(),
-            multicast: buf.multicast(),
-            collisions: buf.collisions(),
-            rx_length_errors: buf.rx_length_errors(),
-            rx_over_errors: buf.rx_over_errors(),
-            rx_crc_errors: buf.rx_crc_errors(),
-            rx_frame_errors: buf.rx_frame_errors(),
-            rx_fifo_errors: buf.rx_fifo_errors(),
-            rx_missed_errors: buf.rx_missed_errors(),
-            tx_aborted_errors: buf.tx_aborted_errors(),
-            tx_carrier_errors: buf.tx_carrier_errors(),
-            tx_fifo_errors: buf.tx_fifo_errors(),
-            tx_heartbeat_errors: buf.tx_heartbeat_errors(),
-            tx_window_errors: buf.tx_window_errors(),
-            rx_compressed: buf.rx_compressed(),
-            tx_compressed: buf.tx_compressed(),
-            rx_nohandler: buf.rx_nohandler(),
+            rx_packets: raw.rx_packets,
+            tx_packets: raw.tx_packets,
+            rx_bytes: raw.rx_bytes,
+            tx_bytes: raw.tx_bytes,
+            rx_errors: raw.rx_errors,
+            tx_errors: raw.tx_errors,
+            rx_dropped: raw.rx_dropped,
+            tx_dropped: raw.tx_dropped,
+            multicast: raw.multicast,
+            collisions: raw.collisions,
+            rx_length_errors: raw.rx_length_errors,
+            rx_over_errors: raw.rx_over_errors,
+            rx_crc_errors: raw.rx_crc_errors,
+            rx_frame_errors: raw.rx_frame_errors,
+            rx_fifo_errors: raw.rx_fifo_errors,
+            rx_missed_errors: raw.rx_missed_errors,
+            tx_aborted_errors: raw.tx_aborted_errors,
+            tx_carrier_errors: raw.tx_carrier_errors,
+            tx_fifo_errors: raw.tx_fifo_errors,
+            tx_heartbeat_errors: raw.tx_heartbeat_errors,
+            tx_window_errors: raw.tx_window_errors,
+            rx_compressed: raw.rx_compressed,
+            tx_compressed: raw.tx_compressed,
+            rx_nohandler: raw.rx_nohandler,
         })
+    }
+}
+
+impl From<&Stats> for StatsBuffer {
+    fn from(value: &Stats) -> Self {
+        Self {
+            rx_packets: value.rx_packets,
+            tx_packets: value.tx_packets,
+            rx_bytes: value.rx_bytes,
+            tx_bytes: value.tx_bytes,
+            rx_errors: value.rx_errors,
+            tx_errors: value.tx_errors,
+            rx_dropped: value.rx_dropped,
+            tx_dropped: value.tx_dropped,
+            multicast: value.multicast,
+            collisions: value.collisions,
+            rx_length_errors: value.rx_length_errors,
+            rx_over_errors: value.rx_over_errors,
+            rx_crc_errors: value.rx_crc_errors,
+            rx_frame_errors: value.rx_frame_errors,
+            rx_fifo_errors: value.rx_fifo_errors,
+            rx_missed_errors: value.rx_missed_errors,
+            tx_aborted_errors: value.tx_aborted_errors,
+            tx_carrier_errors: value.tx_carrier_errors,
+            tx_fifo_errors: value.tx_fifo_errors,
+            tx_heartbeat_errors: value.tx_heartbeat_errors,
+            tx_window_errors: value.tx_window_errors,
+            rx_compressed: value.rx_compressed,
+            tx_compressed: value.tx_compressed,
+            rx_nohandler: value.rx_nohandler,
+        }
     }
 }
 
 impl Emitable for Stats {
     fn buffer_len(&self) -> usize {
-        LINK_STATS_LEN
+        size_of::<StatsBuffer>()
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buffer = StatsBuffer::new(buffer);
-        buffer.set_rx_packets(self.rx_packets);
-        buffer.set_tx_packets(self.tx_packets);
-        buffer.set_rx_bytes(self.rx_bytes);
-        buffer.set_tx_bytes(self.tx_bytes);
-        buffer.set_rx_errors(self.rx_errors);
-        buffer.set_tx_errors(self.tx_errors);
-        buffer.set_rx_dropped(self.rx_dropped);
-        buffer.set_tx_dropped(self.tx_dropped);
-        buffer.set_multicast(self.multicast);
-        buffer.set_collisions(self.collisions);
-        buffer.set_rx_length_errors(self.rx_length_errors);
-        buffer.set_rx_over_errors(self.rx_over_errors);
-        buffer.set_rx_crc_errors(self.rx_crc_errors);
-        buffer.set_rx_frame_errors(self.rx_frame_errors);
-        buffer.set_rx_fifo_errors(self.rx_fifo_errors);
-        buffer.set_rx_missed_errors(self.rx_missed_errors);
-        buffer.set_tx_aborted_errors(self.tx_aborted_errors);
-        buffer.set_tx_carrier_errors(self.tx_carrier_errors);
-        buffer.set_tx_fifo_errors(self.tx_fifo_errors);
-        buffer.set_tx_heartbeat_errors(self.tx_heartbeat_errors);
-        buffer.set_tx_window_errors(self.tx_window_errors);
-        buffer.set_rx_compressed(self.rx_compressed);
-        buffer.set_tx_compressed(self.tx_compressed);
-        buffer.set_rx_nohandler(self.rx_nohandler);
+        let raw = StatsBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/link/stats64.rs
+++ b/src/link/stats64.rs
@@ -1,36 +1,49 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{DecodeError, Emitable, Parseable};
+use std::mem::size_of;
 
-pub(crate) const LINK_STATS64_LEN: usize = 200;
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
-buffer!(Stats64Buffer(LINK_STATS64_LEN) {
-    rx_packets: (u64, 0..8),
-    tx_packets: (u64, 8..16),
-    rx_bytes: (u64, 16..24),
-    tx_bytes: (u64, 24..32),
-    rx_errors: (u64, 32..40),
-    tx_errors: (u64, 40..48),
-    rx_dropped: (u64, 48..56),
-    tx_dropped: (u64, 56..64),
-    multicast: (u64, 64..72),
-    collisions: (u64, 72..80),
-    rx_length_errors: (u64, 80..88),
-    rx_over_errors: (u64, 88..96),
-    rx_crc_errors: (u64, 96..104),
-    rx_frame_errors: (u64, 104..112),
-    rx_fifo_errors: (u64, 112..120),
-    rx_missed_errors: (u64, 120..128),
-    tx_aborted_errors: (u64, 128..136),
-    tx_carrier_errors: (u64, 136..144),
-    tx_fifo_errors: (u64, 144..152),
-    tx_heartbeat_errors: (u64, 152..160),
-    tx_window_errors: (u64, 160..168),
-    rx_compressed: (u64, 168..176),
-    tx_compressed: (u64, 176..184),
-    rx_nohandler: (u64, 184..192),
-    rx_otherhost_dropped: (u64, 192..200),
-});
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct Stats64Buffer {
+    rx_packets: u64,
+    tx_packets: u64,
+    rx_bytes: u64,
+    tx_bytes: u64,
+    rx_errors: u64,
+    tx_errors: u64,
+    rx_dropped: u64,
+    tx_dropped: u64,
+    multicast: u64,
+    collisions: u64,
+    rx_length_errors: u64,
+    rx_over_errors: u64,
+    rx_crc_errors: u64,
+    rx_frame_errors: u64,
+    rx_fifo_errors: u64,
+    rx_missed_errors: u64,
+    tx_aborted_errors: u64,
+    tx_carrier_errors: u64,
+    tx_fifo_errors: u64,
+    tx_heartbeat_errors: u64,
+    tx_window_errors: u64,
+    rx_compressed: u64,
+    tx_compressed: u64,
+    rx_nohandler: u64,
+    rx_otherhost_dropped: u64,
+}
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
 #[non_exhaustive]
@@ -85,69 +98,84 @@ pub struct Stats64 {
     pub rx_otherhost_dropped: u64,
 }
 
-impl<T: AsRef<[u8]>> Parseable<Stats64Buffer<T>> for Stats64 {
-    fn parse(buf: &Stats64Buffer<T>) -> Result<Self, DecodeError> {
+impl Stats64 {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) =
+            Stats64Buffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    size_of::<Stats64Buffer>(),
+                )
+            })?;
         Ok(Self {
-            rx_packets: buf.rx_packets(),
-            tx_packets: buf.tx_packets(),
-            rx_bytes: buf.rx_bytes(),
-            tx_bytes: buf.tx_bytes(),
-            rx_errors: buf.rx_errors(),
-            tx_errors: buf.tx_errors(),
-            rx_dropped: buf.rx_dropped(),
-            tx_dropped: buf.tx_dropped(),
-            multicast: buf.multicast(),
-            collisions: buf.collisions(),
-            rx_length_errors: buf.rx_length_errors(),
-            rx_over_errors: buf.rx_over_errors(),
-            rx_crc_errors: buf.rx_crc_errors(),
-            rx_frame_errors: buf.rx_frame_errors(),
-            rx_fifo_errors: buf.rx_fifo_errors(),
-            rx_missed_errors: buf.rx_missed_errors(),
-            tx_aborted_errors: buf.tx_aborted_errors(),
-            tx_carrier_errors: buf.tx_carrier_errors(),
-            tx_fifo_errors: buf.tx_fifo_errors(),
-            tx_heartbeat_errors: buf.tx_heartbeat_errors(),
-            tx_window_errors: buf.tx_window_errors(),
-            rx_compressed: buf.rx_compressed(),
-            tx_compressed: buf.tx_compressed(),
-            rx_nohandler: buf.rx_nohandler(),
-            rx_otherhost_dropped: buf.rx_otherhost_dropped(),
+            rx_packets: raw.rx_packets,
+            tx_packets: raw.tx_packets,
+            rx_bytes: raw.rx_bytes,
+            tx_bytes: raw.tx_bytes,
+            rx_errors: raw.rx_errors,
+            tx_errors: raw.tx_errors,
+            rx_dropped: raw.rx_dropped,
+            tx_dropped: raw.tx_dropped,
+            multicast: raw.multicast,
+            collisions: raw.collisions,
+            rx_length_errors: raw.rx_length_errors,
+            rx_over_errors: raw.rx_over_errors,
+            rx_crc_errors: raw.rx_crc_errors,
+            rx_frame_errors: raw.rx_frame_errors,
+            rx_fifo_errors: raw.rx_fifo_errors,
+            rx_missed_errors: raw.rx_missed_errors,
+            tx_aborted_errors: raw.tx_aborted_errors,
+            tx_carrier_errors: raw.tx_carrier_errors,
+            tx_fifo_errors: raw.tx_fifo_errors,
+            tx_heartbeat_errors: raw.tx_heartbeat_errors,
+            tx_window_errors: raw.tx_window_errors,
+            rx_compressed: raw.rx_compressed,
+            tx_compressed: raw.tx_compressed,
+            rx_nohandler: raw.rx_nohandler,
+            rx_otherhost_dropped: raw.rx_otherhost_dropped,
         })
+    }
+}
+
+impl From<&Stats64> for Stats64Buffer {
+    fn from(value: &Stats64) -> Self {
+        Self {
+            rx_packets: value.rx_packets,
+            tx_packets: value.tx_packets,
+            rx_bytes: value.rx_bytes,
+            tx_bytes: value.tx_bytes,
+            rx_errors: value.rx_errors,
+            tx_errors: value.tx_errors,
+            rx_dropped: value.rx_dropped,
+            tx_dropped: value.tx_dropped,
+            multicast: value.multicast,
+            collisions: value.collisions,
+            rx_length_errors: value.rx_length_errors,
+            rx_over_errors: value.rx_over_errors,
+            rx_crc_errors: value.rx_crc_errors,
+            rx_frame_errors: value.rx_frame_errors,
+            rx_fifo_errors: value.rx_fifo_errors,
+            rx_missed_errors: value.rx_missed_errors,
+            tx_aborted_errors: value.tx_aborted_errors,
+            tx_carrier_errors: value.tx_carrier_errors,
+            tx_fifo_errors: value.tx_fifo_errors,
+            tx_heartbeat_errors: value.tx_heartbeat_errors,
+            tx_window_errors: value.tx_window_errors,
+            rx_compressed: value.rx_compressed,
+            tx_compressed: value.tx_compressed,
+            rx_nohandler: value.rx_nohandler,
+            rx_otherhost_dropped: value.rx_otherhost_dropped,
+        }
     }
 }
 
 impl Emitable for Stats64 {
     fn buffer_len(&self) -> usize {
-        LINK_STATS64_LEN
+        size_of::<Stats64Buffer>()
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buffer = Stats64Buffer::new(buffer);
-        buffer.set_rx_packets(self.rx_packets);
-        buffer.set_tx_packets(self.tx_packets);
-        buffer.set_rx_bytes(self.rx_bytes);
-        buffer.set_tx_bytes(self.tx_bytes);
-        buffer.set_rx_errors(self.rx_errors);
-        buffer.set_tx_errors(self.tx_errors);
-        buffer.set_rx_dropped(self.rx_dropped);
-        buffer.set_tx_dropped(self.tx_dropped);
-        buffer.set_multicast(self.multicast);
-        buffer.set_collisions(self.collisions);
-        buffer.set_rx_length_errors(self.rx_length_errors);
-        buffer.set_rx_over_errors(self.rx_over_errors);
-        buffer.set_rx_crc_errors(self.rx_crc_errors);
-        buffer.set_rx_frame_errors(self.rx_frame_errors);
-        buffer.set_rx_fifo_errors(self.rx_fifo_errors);
-        buffer.set_rx_missed_errors(self.rx_missed_errors);
-        buffer.set_tx_aborted_errors(self.tx_aborted_errors);
-        buffer.set_tx_carrier_errors(self.tx_carrier_errors);
-        buffer.set_tx_fifo_errors(self.tx_fifo_errors);
-        buffer.set_tx_heartbeat_errors(self.tx_heartbeat_errors);
-        buffer.set_tx_window_errors(self.tx_window_errors);
-        buffer.set_rx_compressed(self.rx_compressed);
-        buffer.set_tx_compressed(self.tx_compressed);
-        buffer.set_rx_nohandler(self.rx_nohandler);
-        buffer.set_rx_otherhost_dropped(self.rx_otherhost_dropped);
+        let raw = Stats64Buffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/link/tests/afspec.rs
+++ b/src/link/tests/afspec.rs
@@ -5,8 +5,8 @@ use netlink_packet_core::{Emitable, Parseable};
 use crate::{
     link::{
         link_flag::LinkFlags, AfSpecMctp, AfSpecUnspec, LinkAttribute,
-        LinkHeader, LinkLayerType, LinkMessage, LinkMessageBuffer, LinkMode,
-        LinkXdp, Map, MctpPhysBinding, State, Stats, Stats64, XdpAttached,
+        LinkHeader, LinkLayerType, LinkMessage, LinkMode, LinkXdp, Map,
+        MctpPhysBinding, State, Stats, Stats64, XdpAttached,
     },
     AddressFamily,
 };
@@ -184,10 +184,7 @@ fn test_empty_af_spec() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -230,10 +227,7 @@ fn test_af_spec_mctp_net() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -276,10 +270,7 @@ fn test_af_spec_mctp_binding() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/link/tests/amt.rs
+++ b/src/link/tests/amt.rs
@@ -8,7 +8,6 @@ use crate::{
     link::{
         link_flag::LinkFlags, AmtMode, InfoAmt, InfoData, InfoKind,
         LinkAttribute, LinkHeader, LinkInfo, LinkLayerType, LinkMessage,
-        LinkMessageBuffer,
     },
     AddressFamily,
 };
@@ -73,10 +72,7 @@ fn test_parsing_link_amt_gateway() {
         ])],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -134,10 +130,7 @@ fn test_parsing_link_amt_relay() {
         ])],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -189,10 +182,7 @@ fn test_parsing_link_amt_minimal() {
         ])],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/link/tests/bareudp.rs
+++ b/src/link/tests/bareudp.rs
@@ -5,7 +5,7 @@ use netlink_packet_core::{Emitable, Parseable};
 use crate::{
     link::{
         link_flag::LinkFlags, InfoBareUdp, InfoData, InfoKind, LinkAttribute,
-        LinkHeader, LinkInfo, LinkLayerType, LinkMessage, LinkMessageBuffer,
+        LinkHeader, LinkInfo, LinkLayerType, LinkMessage,
     },
     AddressFamily, EthernetProtocol,
 };
@@ -62,10 +62,7 @@ fn test_parsing_link_bareudp_basic() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/link/tests/batadv.rs
+++ b/src/link/tests/batadv.rs
@@ -5,7 +5,7 @@ use netlink_packet_core::{Emitable, Parseable};
 use crate::{
     link::{
         link_flag::LinkFlags, InfoBatAdv, InfoData, InfoKind, LinkAttribute,
-        LinkHeader, LinkInfo, LinkLayerType, LinkMessage, LinkMessageBuffer,
+        LinkHeader, LinkInfo, LinkLayerType, LinkMessage,
     },
     AddressFamily,
 };
@@ -59,10 +59,7 @@ fn test_parsing_link_batadv_with_ra() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/link/tests/bond.rs
+++ b/src/link/tests/bond.rs
@@ -9,8 +9,7 @@ use crate::{
         BondPrimaryReselect, BondXmitHashPolicy, ChurnState, InfoBond,
         InfoBondPort, InfoData, InfoKind, InfoPortData, InfoPortKind,
         LacpState, LinkAttribute, LinkFlags, LinkHeader, LinkInfo,
-        LinkLayerType, LinkMessage, LinkMessageBuffer, LinkMode, Map,
-        MiiStatus, State,
+        LinkLayerType, LinkMessage, LinkMode, Map, MiiStatus, State,
     },
     AddressFamily, RouteNetlinkMessage,
 };
@@ -91,10 +90,7 @@ fn test_bond_link_info() {
         ])],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -146,10 +142,7 @@ fn test_bond_port_link_info() {
         ])],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -258,10 +251,7 @@ fn test_parsing_link_bond_port_ad() {
         ])],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/link/tests/bridge.rs
+++ b/src/link/tests/bridge.rs
@@ -16,9 +16,8 @@ use crate::{
         BridgeVlanTunnelInfo, In6AddrGenMode, Inet6CacheInfo, Inet6DevConf,
         Inet6IfaceFlags, InetDevConf, InfoBridge, InfoBridgePort, InfoData,
         InfoKind, InfoPortData, InfoPortKind, LinkAttribute, LinkHeader,
-        LinkInfo, LinkLayerType, LinkMessage, LinkMessageBuffer, LinkMode,
-        LinkProtoInfoBridge, LinkXdp, Map, State, Stats, Stats64, VlanProtocol,
-        XdpAttached,
+        LinkInfo, LinkLayerType, LinkMessage, LinkMode, LinkProtoInfoBridge,
+        LinkXdp, Map, State, Stats, Stats64, VlanProtocol, XdpAttached,
     },
     AddressFamily,
 };
@@ -427,10 +426,7 @@ fn test_parse_link_bridge_no_extention_mask() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -782,10 +778,7 @@ fn test_parse_link_bridge_stp_mode() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -820,10 +813,7 @@ fn test_parse_link_bridge_port_neigh_forward_grat() {
         ])],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -961,10 +951,7 @@ fn test_bridge_port_link_info() {
         ])],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -1093,10 +1080,7 @@ fn test_bridge_boolean_options() {
         ])],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -1138,10 +1122,7 @@ fn test_bridge_boolean_options_fdb_local_vlan_0() {
         ])],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -1618,10 +1599,7 @@ fn test_bridge_netns_immutable() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/link/tests/can.rs
+++ b/src/link/tests/can.rs
@@ -5,7 +5,7 @@ use netlink_packet_core::{Emitable, Parseable};
 use crate::link::{
     link_flag::LinkFlags, CanBitTiming, CanCtrlMode, CanCtrlModeFlags, InfoCan,
     InfoData, InfoKind, LinkAttribute, LinkHeader, LinkInfo, LinkLayerType,
-    LinkMessage, LinkMessageBuffer,
+    LinkMessage,
 };
 
 // nlmon capture of packet sent by
@@ -56,10 +56,7 @@ fn test_parsing_link_can_add() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
     expected.emit(&mut buf);

--- a/src/link/tests/geneve.rs
+++ b/src/link/tests/geneve.rs
@@ -11,7 +11,6 @@ use crate::{
     link::{
         link_flag::LinkFlags, GeneveDf, InfoData, InfoGeneve, InfoKind,
         LinkAttribute, LinkHeader, LinkInfo, LinkLayerType, LinkMessage,
-        LinkMessageBuffer,
     },
     AddressFamily,
 };
@@ -58,10 +57,7 @@ fn test_geneve_link_info() {
         ])],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -113,10 +109,7 @@ fn test_geneve_link_local() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -174,10 +167,7 @@ fn test_geneve_link_local6() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/link/tests/gre.rs
+++ b/src/link/tests/gre.rs
@@ -7,7 +7,6 @@ use netlink_packet_core::{DefaultNla, Emitable, Parseable};
 use crate::link::{
     ErSpanDir, GreEncapFlags, GreEncapType, GreIOFlags, InfoData, InfoGre,
     InfoGre6, InfoKind, LinkAttribute, LinkInfo, LinkMessage,
-    LinkMessageBuffer,
 };
 
 #[test]
@@ -50,10 +49,7 @@ fn test_create_gre6_external() {
         ],
         ..Default::default()
     };
-    assert_eq!(
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap(),
-        expected
-    );
+    assert_eq!(LinkMessage::parse(&raw).unwrap(), expected);
     let mut buf = vec![0; expected.buffer_len()];
     expected.emit(&mut buf);
     assert_eq!(buf, raw);
@@ -98,10 +94,7 @@ fn test_create_gre6tap_external() {
         ],
         ..Default::default()
     };
-    assert_eq!(
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap(),
-        expected
-    );
+    assert_eq!(LinkMessage::parse(&raw).unwrap(), expected);
     let mut buf = vec![0; expected.buffer_len()];
     expected.emit(&mut buf);
     assert_eq!(buf, raw);
@@ -232,10 +225,7 @@ fn test_create_gre6() {
         ],
         ..Default::default()
     };
-    assert_eq!(
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap(),
-        expected
-    );
+    assert_eq!(LinkMessage::parse(&raw).unwrap(), expected);
     let mut buf = vec![0; expected.buffer_len()];
     expected.emit(&mut buf);
     assert_eq!(buf, raw);
@@ -361,10 +351,7 @@ fn test_create_gre6_with_link() {
         ],
         ..Default::default()
     };
-    assert_eq!(
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap(),
-        expected
-    );
+    assert_eq!(LinkMessage::parse(&raw).unwrap(), expected);
     let mut buf = vec![0; expected.buffer_len()];
     expected.emit(&mut buf);
     assert_eq!(buf, raw);
@@ -493,10 +480,7 @@ fn test_create_gre6tap() {
         ],
         ..Default::default()
     };
-    assert_eq!(
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap(),
-        expected
-    );
+    assert_eq!(LinkMessage::parse(&raw).unwrap(), expected);
     let mut buf = vec![0; expected.buffer_len()];
     expected.emit(&mut buf);
     assert_eq!(buf, raw);
@@ -539,10 +523,7 @@ fn test_create_gre_external() {
         ],
         ..Default::default()
     };
-    assert_eq!(
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap(),
-        expected
-    );
+    assert_eq!(LinkMessage::parse(&raw).unwrap(), expected);
     let mut buf = vec![0; expected.buffer_len()];
     expected.emit(&mut buf);
     assert_eq!(buf, raw);
@@ -586,10 +567,7 @@ fn test_create_gretap_external() {
         ],
         ..Default::default()
     };
-    assert_eq!(
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap(),
-        expected
-    );
+    assert_eq!(LinkMessage::parse(&raw).unwrap(), expected);
     let mut buf = vec![0; expected.buffer_len()];
     expected.emit(&mut buf);
     assert_eq!(buf, raw);
@@ -699,10 +677,7 @@ fn test_create_gre() {
         ],
         ..Default::default()
     };
-    assert_eq!(
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap(),
-        expected
-    );
+    assert_eq!(LinkMessage::parse(&raw).unwrap(), expected);
     let mut buf = vec![0; expected.buffer_len()];
     expected.emit(&mut buf);
     assert_eq!(buf, raw);
@@ -812,10 +787,7 @@ fn test_create_gre_with_link() {
         ],
         ..Default::default()
     };
-    assert_eq!(
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap(),
-        expected
-    );
+    assert_eq!(LinkMessage::parse(&raw).unwrap(), expected);
     let mut buf = vec![0; expected.buffer_len()];
     expected.emit(&mut buf);
     assert_eq!(buf, raw);
@@ -926,10 +898,7 @@ fn test_create_gretap() {
         ],
         ..Default::default()
     };
-    assert_eq!(
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap(),
-        expected
-    );
+    assert_eq!(LinkMessage::parse(&raw).unwrap(), expected);
     let mut buf = vec![0; expected.buffer_len()];
     expected.emit(&mut buf);
     assert_eq!(buf, raw);
@@ -1046,10 +1015,7 @@ fn test_create_erspan_v1() {
         ],
         ..Default::default()
     };
-    assert_eq!(
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap(),
-        expected
-    );
+    assert_eq!(LinkMessage::parse(&raw).unwrap(), expected);
     let mut buf = vec![0; expected.buffer_len()];
     expected.emit(&mut buf);
     assert_eq!(buf, raw);
@@ -1172,10 +1138,7 @@ fn test_create_erspan_v2() {
         ],
         ..Default::default()
     };
-    assert_eq!(
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap(),
-        expected
-    );
+    assert_eq!(LinkMessage::parse(&raw).unwrap(), expected);
     let mut buf = vec![0; expected.buffer_len()];
     expected.emit(&mut buf);
     assert_eq!(buf, raw);
@@ -1302,10 +1265,7 @@ fn test_create_ip6erspan_v1() {
         ],
         ..Default::default()
     };
-    assert_eq!(
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap(),
-        expected
-    );
+    assert_eq!(LinkMessage::parse(&raw).unwrap(), expected);
     let mut buf = vec![0; expected.buffer_len()];
     expected.emit(&mut buf);
     assert_eq!(buf, raw);
@@ -1438,10 +1398,7 @@ fn test_create_ip6erspan_v2() {
         ],
         ..Default::default()
     };
-    assert_eq!(
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap(),
-        expected
-    );
+    assert_eq!(LinkMessage::parse(&raw).unwrap(), expected);
     let mut buf = vec![0; expected.buffer_len()];
     expected.emit(&mut buf);
     assert_eq!(buf, raw);

--- a/src/link/tests/gtp.rs
+++ b/src/link/tests/gtp.rs
@@ -6,7 +6,6 @@ use crate::{
     link::{
         link_flag::LinkFlags, GtpRole, InfoData, InfoGtp, InfoKind,
         LinkAttribute, LinkHeader, LinkInfo, LinkLayerType, LinkMessage,
-        LinkMessageBuffer,
     },
     AddressFamily,
 };
@@ -45,10 +44,7 @@ fn test_parsing_link_gtp() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/link/tests/hsr.rs
+++ b/src/link/tests/hsr.rs
@@ -6,7 +6,6 @@ use crate::{
     link::{
         link_flag::LinkFlags, HsrProtocol, InfoData, InfoHsr, InfoKind,
         LinkAttribute, LinkHeader, LinkInfo, LinkLayerType, LinkMessage,
-        LinkMessageBuffer,
     },
     AddressFamily,
 };
@@ -47,10 +46,7 @@ fn test_parsing_link_hsr() {
         ])],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -98,10 +94,7 @@ fn test_parsing_interlink_hsr() {
         ])],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/link/tests/inet.rs
+++ b/src/link/tests/inet.rs
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MIT
 
+use std::mem::size_of;
+
 use netlink_packet_core::{Nla, NLA_F_NESTED};
 
-use crate::link::{AfSpecInet, InetDevConf};
+use crate::link::{AfSpecInet, InetDevConf, InetDevConfBuffer};
 
 const IFLA_INET_CONF: u16 = 1;
-const DEV_CONF_LEN: usize = 132;
 
 #[test]
 fn test_devconf_request_emit_forwarding_on() {
@@ -65,7 +66,7 @@ fn test_devconf_flat_emit_forwarding_on() {
     req.emit_value(&mut buf);
 
     // Flat buffer: 132 bytes, first 4 bytes = forwarding=1
-    assert_eq!(val_len, DEV_CONF_LEN);
+    assert_eq!(val_len, size_of::<InetDevConfBuffer>());
     assert_eq!(&buf[0..4], &[0x01, 0x00, 0x00, 0x00]);
 }
 

--- a/src/link/tests/ipoib.rs
+++ b/src/link/tests/ipoib.rs
@@ -5,7 +5,7 @@ use netlink_packet_core::{Emitable, Parseable};
 use crate::{
     link::{
         InfoData, InfoIpoib, InfoKind, IpoibMode, LinkAttribute, LinkFlags,
-        LinkHeader, LinkInfo, LinkLayerType, LinkMessage, LinkMessageBuffer,
+        LinkHeader, LinkInfo, LinkLayerType, LinkMessage,
     },
     AddressFamily,
 };
@@ -48,10 +48,7 @@ fn test_create_ipoib_with_pkey_and_mode() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/link/tests/iptunnel.rs
+++ b/src/link/tests/iptunnel.rs
@@ -11,7 +11,7 @@ use crate::{
     link::{
         InfoData, InfoIpTunnel, InfoKind, Ip6TunnelFlags, LinkAttribute,
         LinkFlags, LinkHeader, LinkInfo, LinkLayerType, LinkMessage,
-        LinkMessageBuffer, TunnelEncapFlags, TunnelEncapType,
+        TunnelEncapFlags, TunnelEncapType,
     },
     AddressFamily, IpProtocol,
 };
@@ -69,10 +69,7 @@ fn test_iptunnel_ipip_link_info() {
         ])],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -140,10 +137,7 @@ fn test_iptunnel_ipip6_link_info() {
         ])],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -211,10 +205,7 @@ fn test_iptunnel_ip6ip6_link_info() {
         ])],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -278,10 +269,7 @@ fn test_iptunnel_sit_link_info() {
         ])],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/link/tests/ipvlan.rs
+++ b/src/link/tests/ipvlan.rs
@@ -6,7 +6,7 @@ use crate::{
     link::{
         link_flag::LinkFlags, InfoData, InfoIpVlan, InfoKind, IpVlanFlags,
         IpVlanMode, LinkAttribute, LinkHeader, LinkInfo, LinkLayerType,
-        LinkMessage, LinkMessageBuffer,
+        LinkMessage,
     },
     AddressFamily,
 };
@@ -38,10 +38,7 @@ fn test_ipvlan_link_info() {
         ])],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -77,10 +74,7 @@ fn test_ipvlan_bridge_link_info() {
         ])],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/link/tests/ipvtap.rs
+++ b/src/link/tests/ipvtap.rs
@@ -6,7 +6,7 @@ use crate::{
     link::{
         link_flag::LinkFlags, InfoData, InfoIpVtap, InfoKind, IpVtapFlags,
         IpVtapMode, LinkAttribute, LinkHeader, LinkInfo, LinkLayerType,
-        LinkMessage, LinkMessageBuffer,
+        LinkMessage,
     },
     AddressFamily,
 };
@@ -38,10 +38,7 @@ fn test_ipvtap_link_info() {
         ])],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/link/tests/macsec.rs
+++ b/src/link/tests/macsec.rs
@@ -5,8 +5,8 @@ use netlink_packet_core::{Emitable, Parseable};
 use crate::{
     link::{
         link_flag::LinkFlags, InfoData, InfoKind, InfoMacSec, LinkAttribute,
-        LinkHeader, LinkInfo, LinkLayerType, LinkMessage, LinkMessageBuffer,
-        MacSecCipherId, MacSecOffload, MacSecValidate,
+        LinkHeader, LinkInfo, LinkLayerType, LinkMessage, MacSecCipherId,
+        MacSecOffload, MacSecValidate,
     },
     AddressFamily,
 };
@@ -60,10 +60,7 @@ fn test_macsec_link_info() {
         ])],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/link/tests/macvlan.rs
+++ b/src/link/tests/macvlan.rs
@@ -5,8 +5,8 @@ use netlink_packet_core::{Emitable, Parseable};
 use crate::{
     link::{
         link_flag::LinkFlags, InfoData, InfoKind, InfoMacVlan, LinkAttribute,
-        LinkHeader, LinkInfo, LinkLayerType, LinkMessage, LinkMessageBuffer,
-        MacVlanFlags, MacVlanMacAddressMode, MacVlanMode,
+        LinkHeader, LinkInfo, LinkLayerType, LinkMessage, MacVlanFlags,
+        MacVlanMacAddressMode, MacVlanMode,
     },
     AddressFamily,
 };
@@ -53,10 +53,7 @@ fn test_macvlan_link_info() {
         ])],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -98,10 +95,7 @@ fn test_macvlan_modify_mac_addr_mode() {
         ])],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/link/tests/macvtap.rs
+++ b/src/link/tests/macvtap.rs
@@ -7,9 +7,9 @@ use crate::{
         link_flag::LinkFlags, AfSpecInet, AfSpecInet6, AfSpecUnspec,
         Inet6CacheInfo, Inet6DevConf, Inet6IfaceFlags, InetDevConf, InfoData,
         InfoKind, InfoMacVtap, LinkAttribute, LinkHeader, LinkInfo,
-        LinkLayerType, LinkMessage, LinkMessageBuffer, LinkMode, LinkXdp,
-        MacVtapFlags, MacVtapMacAddressMode, MacVtapMode, Map, State, Stats,
-        Stats64, XdpAttached,
+        LinkLayerType, LinkMessage, LinkMode, LinkXdp, MacVtapFlags,
+        MacVtapMacAddressMode, MacVtapMode, Map, State, Stats, Stats64,
+        XdpAttached,
     },
     AddressFamily,
 };
@@ -334,10 +334,7 @@ fn test_macvtap_link_info() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -379,10 +376,7 @@ fn test_macvtap_modify_mac_addr_mode() {
         ])],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/link/tests/message.rs
+++ b/src/link/tests/message.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{Emitable, ParseableParametrized};
+use netlink_packet_core::{Emitable, NlasIterator, ParseableParametrized};
 
 use crate::{
     link::{
         link_flag::LinkFlags, LinkAttribute, LinkHeader, LinkLayerType,
-        LinkMessage, LinkMessageBuffer, LinkMode, State,
+        LinkMessage, LinkMode, State,
     },
     AddressFamily,
 };
@@ -40,48 +40,41 @@ static LINK_MSG: [u8; 96] = [
 
 #[test]
 fn link_message_packet_header_read() {
-    let packet = LinkMessageBuffer::new(&LINK_MSG[0..16]);
-    assert_eq!(packet.interface_family(), AddressFamily::Unspec.into());
-    assert_eq!(packet.reserved_1(), 0);
-    assert_eq!(packet.link_layer_type(), LinkLayerType::Loopback.into());
-    assert_eq!(packet.link_index(), 1);
+    let header = LinkHeader::parse(&LINK_MSG[0..16]).unwrap();
+    assert_eq!(header.interface_family, AddressFamily::Unspec);
+    assert_eq!(header.link_layer_type, LinkLayerType::Loopback);
+    assert_eq!(header.index, 1);
     assert_eq!(
-        packet.flags(),
-        (LinkFlags::Loopback
+        header.flags,
+        LinkFlags::Loopback
             | LinkFlags::LowerUp
             | LinkFlags::Running
-            | LinkFlags::Up)
-            .bits()
+            | LinkFlags::Up
     );
-    assert_eq!(packet.change_mask(), 0);
+    assert_eq!(header.change_mask, LinkFlags::empty());
 }
 
 #[test]
 fn link_message_packet_header_build() {
     let mut buf = vec![0xff; 16];
-    {
-        let mut packet = LinkMessageBuffer::new(&mut buf);
-        packet.set_interface_family(AddressFamily::Unspec.into());
-        packet.set_reserved_1(0);
-        packet.set_link_layer_type(LinkLayerType::Loopback.into());
-        packet.set_link_index(1);
-        packet.set_flags(
-            (LinkFlags::Loopback
-                | LinkFlags::LowerUp
-                | LinkFlags::Running
-                | LinkFlags::Up)
-                .bits(),
-        );
-        packet.set_change_mask(0);
-    }
+    let header = LinkHeader {
+        interface_family: AddressFamily::Unspec,
+        link_layer_type: LinkLayerType::Loopback,
+        index: 1,
+        flags: LinkFlags::Loopback
+            | LinkFlags::LowerUp
+            | LinkFlags::Running
+            | LinkFlags::Up,
+        change_mask: LinkFlags::empty(),
+    };
+    header.emit(&mut buf);
     assert_eq!(&buf[..], &LINK_MSG[0..16]);
 }
 
 #[test]
 fn link_mssage_packet_attributes_read() {
-    let packet = LinkMessageBuffer::new(&LINK_MSG[..]);
-    assert_eq!(packet.attributes().count(), 10);
-    let mut attributes = packet.attributes();
+    assert_eq!(NlasIterator::new(&LINK_MSG[16..]).count(), 10);
+    let mut attributes = NlasIterator::new(&LINK_MSG[16..]);
 
     // device name L=7,T=3,V=lo
     let nla = attributes.next().unwrap().unwrap();
@@ -212,7 +205,7 @@ fn link_type_mctp() {
         0x41, 0x00, 0x01, 0x00, // flags: UP|RUNNING|LOWERUP
         0x00, 0x00, 0x00, 0x00, // reserved 2
     ];
-    let packet = LinkMessageBuffer::new(&LINK_MSG_MCTP);
-    assert_eq!(packet.interface_family(), AddressFamily::Unspec.into());
-    assert_eq!(packet.link_layer_type(), LinkLayerType::Mctp.into());
+    let header = LinkHeader::parse(&LINK_MSG_MCTP).unwrap();
+    assert_eq!(header.interface_family, AddressFamily::Unspec);
+    assert_eq!(header.link_layer_type, LinkLayerType::Mctp);
 }

--- a/src/link/tests/netdevsim.rs
+++ b/src/link/tests/netdevsim.rs
@@ -9,8 +9,7 @@ use crate::{
         AfSpecInet, AfSpecInet6, AfSpecUnspec, DevlinkPort, In6AddrGenMode,
         Inet6CacheInfo, Inet6DevConf, Inet6IfaceFlags, InetDevConf,
         LinkAttribute, LinkFlags, LinkHeader, LinkLayerType, LinkMessage,
-        LinkMessageBuffer, LinkMode, LinkPhysId, LinkXdp, Map, State,
-        XdpAttached,
+        LinkMode, LinkPhysId, LinkXdp, Map, State, XdpAttached,
     },
     AddressFamily,
 };
@@ -287,10 +286,7 @@ fn test_show_netdevsim() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/link/tests/netkit.rs
+++ b/src/link/tests/netkit.rs
@@ -5,8 +5,7 @@ use netlink_packet_core::{Emitable, Parseable};
 use crate::{
     link::{
         InfoData, InfoKind, InfoNetkit, LinkAttribute, LinkHeader, LinkInfo,
-        LinkLayerType, LinkMessage, LinkMessageBuffer, NetkitMode,
-        NetkitPolicy, NetkitScrub,
+        LinkLayerType, LinkMessage, NetkitMode, NetkitPolicy, NetkitScrub,
     },
     AddressFamily,
 };
@@ -74,10 +73,7 @@ fn test_create_netkit() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/link/tests/pfcp.rs
+++ b/src/link/tests/pfcp.rs
@@ -5,7 +5,7 @@ use netlink_packet_core::{Emitable, Parseable};
 use crate::{
     link::{
         link_flag::LinkFlags, InfoKind, LinkAttribute, LinkHeader, LinkInfo,
-        LinkLayerType, LinkMessage, LinkMessageBuffer,
+        LinkLayerType, LinkMessage,
     },
     AddressFamily,
 };
@@ -49,10 +49,7 @@ fn test_parsing_link_pfcp() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/link/tests/prop_list.rs
+++ b/src/link/tests/prop_list.rs
@@ -5,7 +5,7 @@ use netlink_packet_core::{Emitable, Parseable};
 use crate::{
     link::{
         link_flag::LinkFlags, LinkAttribute, LinkHeader, LinkLayerType,
-        LinkMessage, LinkMessageBuffer, Prop,
+        LinkMessage, Prop,
     },
     AddressFamily,
 };
@@ -39,10 +39,7 @@ fn test_wlan0_with_prop_altname() {
         ])],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/link/tests/rmnet.rs
+++ b/src/link/tests/rmnet.rs
@@ -10,8 +10,7 @@ use crate::{
         In6AddrGenMode, Inet6CacheInfo, Inet6DevConf, Inet6IfaceFlags,
         InetDevConf, InfoData, InfoKind, InfoRmNet, InfoRmNetFlags,
         LinkAttribute, LinkHeader, LinkInfo, LinkLayerType, LinkMessage,
-        LinkMessageBuffer, LinkMode, LinkXdp, Map, RmNetFlags, State,
-        XdpAttached,
+        LinkMode, LinkXdp, Map, RmNetFlags, State, XdpAttached,
     },
     AddressFamily,
 };
@@ -262,10 +261,7 @@ fn test_parsing_link_rmnet() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/link/tests/statistics.rs
+++ b/src/link/tests/statistics.rs
@@ -7,8 +7,8 @@ use crate::{
         af_spec::In6AddrGenMode, link_flag::LinkFlags, AfSpecInet, AfSpecInet6,
         AfSpecUnspec, Icmp6Stats, Inet6CacheInfo, Inet6DevConf,
         Inet6IfaceFlags, Inet6Stats, InetDevConf, LinkAttribute, LinkHeader,
-        LinkLayerType, LinkMessage, LinkMessageBuffer, LinkMode, LinkXdp, Map,
-        Prop, State, Stats, Stats64, XdpAttached,
+        LinkLayerType, LinkMessage, LinkMode, LinkXdp, Map, Prop, State, Stats,
+        Stats64, XdpAttached,
     },
     AddressFamily,
 };
@@ -395,10 +395,7 @@ fn test_parsing_link_statistics_on_kernel_4_18() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
     // We do not test emit here as old kernel has smaller buffer size of stats
 }
 
@@ -724,10 +721,7 @@ fn test_parsing_link_statistics() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/link/tests/vcan.rs
+++ b/src/link/tests/vcan.rs
@@ -8,8 +8,8 @@ use crate::{
     link::{
         AfSpecInet, AfSpecInet6, AfSpecUnspec, In6AddrGenMode, Inet6CacheInfo,
         Inet6DevConf, Inet6IfaceFlags, InetDevConf, InfoKind, LinkAttribute,
-        LinkFlags, LinkHeader, LinkInfo, LinkLayerType, LinkMessage,
-        LinkMessageBuffer, LinkMode, LinkXdp, Map, State, XdpAttached,
+        LinkFlags, LinkHeader, LinkInfo, LinkLayerType, LinkMessage, LinkMode,
+        LinkXdp, Map, State, XdpAttached,
     },
     AddressFamily,
 };
@@ -248,10 +248,7 @@ fn test_show_vcan() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/link/tests/veth.rs
+++ b/src/link/tests/veth.rs
@@ -5,7 +5,7 @@ use netlink_packet_core::{Emitable, Parseable};
 use crate::{
     link::{
         link_flag::LinkFlags, InfoData, InfoKind, InfoVeth, LinkAttribute,
-        LinkHeader, LinkInfo, LinkLayerType, LinkMessage, LinkMessageBuffer,
+        LinkHeader, LinkInfo, LinkLayerType, LinkMessage,
     },
     AddressFamily,
 };
@@ -43,10 +43,7 @@ fn test_veth_get_link_info() {
         )])],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -111,10 +108,7 @@ fn test_crate_veth() {
         ..Default::default()
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/link/tests/vlan.rs
+++ b/src/link/tests/vlan.rs
@@ -5,8 +5,8 @@ use netlink_packet_core::{Emitable, Parseable};
 use crate::{
     link::{
         link_flag::LinkFlags, InfoData, InfoKind, InfoVlan, LinkAttribute,
-        LinkHeader, LinkInfo, LinkLayerType, LinkMessage, LinkMessageBuffer,
-        VlanFlags, VlanProtocol, VlanQosMapping,
+        LinkHeader, LinkInfo, LinkLayerType, LinkMessage, VlanFlags,
+        VlanProtocol, VlanQosMapping,
     },
     AddressFamily,
 };
@@ -74,10 +74,7 @@ fn test_parsing_link_vlan() {
         ])],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/link/tests/vrf.rs
+++ b/src/link/tests/vrf.rs
@@ -10,8 +10,8 @@ use crate::{
         AfSpecInet, AfSpecInet6, AfSpecUnspec, Icmp6Stats, Inet6CacheInfo,
         Inet6DevConf, Inet6IfaceFlags, Inet6Stats, InetDevConf, InfoData,
         InfoKind, InfoPortData, InfoPortKind, InfoVrf, LinkAttribute,
-        LinkHeader, LinkInfo, LinkLayerType, LinkMessage, LinkMessageBuffer,
-        LinkMode, LinkXdp, Map, State, Stats, Stats64, XdpAttached,
+        LinkHeader, LinkInfo, LinkLayerType, LinkMessage, LinkMode, LinkXdp,
+        Map, State, Stats, Stats64, XdpAttached,
     },
     AddressFamily,
 };
@@ -43,10 +43,7 @@ fn test_parsing_link_vrf() {
         ])],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -350,7 +347,7 @@ fn test_link_info_with_ifla_vrf_port_table() {
             ]),
         ],
     };
-    let link = LinkMessage::parse(&LinkMessageBuffer::new(&data)).unwrap();
+    let link = LinkMessage::parse(&data).unwrap();
     assert_eq!(expected, link);
     let _buf = vec![0; data.len()];
     // FIXME: the packet we write is not a perfect match with the

--- a/src/link/tests/vti.rs
+++ b/src/link/tests/vti.rs
@@ -10,7 +10,7 @@ use crate::{
         AfSpecUnspec, DevlinkPort, DpllPin, Inet6CacheInfo, Inet6DevConf,
         Inet6IfaceFlags, InetDevConf, InfoData, InfoKind, InfoVti,
         LinkAttribute, LinkHeader, LinkInfo, LinkLayerType, LinkMessage,
-        LinkMessageBuffer, LinkMode, LinkXdp, Map, State, XdpAttached,
+        LinkMode, LinkXdp, Map, State, XdpAttached,
     },
     AddressFamily,
 };
@@ -211,10 +211,7 @@ fn test_parsing_link_vti() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
     expected.emit(&mut buf);
@@ -438,10 +435,7 @@ fn test_parsing_link_vti6() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
     expected.emit(&mut buf);

--- a/src/link/tests/vxcan.rs
+++ b/src/link/tests/vxcan.rs
@@ -6,7 +6,7 @@ use crate::{
     link::{
         link_flag::LinkFlags, link_state::State, InfoData, InfoKind, InfoVxcan,
         LinkAttribute, LinkHeader, LinkInfo, LinkLayerType, LinkMessage,
-        LinkMessageBuffer, LinkMode,
+        LinkMode,
     },
     AddressFamily,
 };
@@ -77,10 +77,7 @@ fn test_vxcan_get_link_info() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -150,10 +147,7 @@ fn test_create_vxcan() {
         ..Default::default()
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/link/tests/vxlan.rs
+++ b/src/link/tests/vxlan.rs
@@ -12,8 +12,8 @@ use crate::{
         af_spec::In6AddrGenMode, link_flag::LinkFlags, AfSpecInet, AfSpecInet6,
         AfSpecUnspec, Inet6CacheInfo, Inet6DevConf, Inet6IfaceFlags,
         InetDevConf, InfoData, InfoKind, InfoVxlan, LinkAttribute, LinkHeader,
-        LinkInfo, LinkLayerType, LinkMessage, LinkMessageBuffer, LinkMode,
-        LinkXdp, Map, State, VxlanDf, XdpAttached,
+        LinkInfo, LinkLayerType, LinkMessage, LinkMode, LinkXdp, Map, State,
+        VxlanDf, XdpAttached,
     },
     AddressFamily,
 };
@@ -314,10 +314,7 @@ fn test_parsing_link_vxlan() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -435,10 +432,7 @@ fn test_parsing_link_vxlan_ipv6() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -488,10 +482,7 @@ fn test_create_vxlan_with_mcroute() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/link/tests/wireguard.rs
+++ b/src/link/tests/wireguard.rs
@@ -9,8 +9,7 @@ use crate::{
         AfSpecInet, AfSpecInet6, AfSpecMctp, AfSpecUnspec, In6AddrGenMode,
         Inet6CacheInfo, Inet6DevConf, Inet6IfaceFlags, InetDevConf, InfoKind,
         LinkAttribute, LinkFlags, LinkHeader, LinkInfo, LinkLayerType,
-        LinkMessage, LinkMessageBuffer, LinkMode, LinkXdp, Map, State,
-        XdpAttached,
+        LinkMessage, LinkMode, LinkXdp, Map, State, XdpAttached,
     },
     AddressFamily,
 };
@@ -261,10 +260,7 @@ fn test_parsing_link_wireguard() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
     expected.emit(&mut buf);

--- a/src/link/tests/wwan.rs
+++ b/src/link/tests/wwan.rs
@@ -10,8 +10,7 @@ use crate::{
         AfSpecUnspec, In6AddrGenMode, Inet6CacheInfo, Inet6DevConf,
         Inet6IfaceFlags, InetDevConf, InfoData, InfoKind, InfoWwan,
         LinkAttribute, LinkHeader, LinkInfo, LinkLayerType, LinkMessage,
-        LinkMessageBuffer, LinkMode, LinkXdp, Map, MctpPhysBinding, State,
-        XdpAttached,
+        LinkMode, LinkXdp, Map, MctpPhysBinding, State, XdpAttached,
     },
     AddressFamily,
 };
@@ -263,10 +262,7 @@ fn test_parsing_link_wwan_show() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -306,10 +302,7 @@ fn test_parsing_link_wwan_add() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/link/tests/xfrm.rs
+++ b/src/link/tests/xfrm.rs
@@ -5,7 +5,7 @@ use netlink_packet_core::{Emitable, Parseable};
 use crate::{
     link::{
         link_flag::LinkFlags, InfoData, InfoKind, InfoXfrm, LinkAttribute,
-        LinkHeader, LinkInfo, LinkLayerType, LinkMessage, LinkMessageBuffer,
+        LinkHeader, LinkInfo, LinkLayerType, LinkMessage,
     },
     AddressFamily,
 };
@@ -40,10 +40,7 @@ fn test_parsing_link_xfrm() {
         ])],
     };
 
-    assert_eq!(
-        expected,
-        LinkMessage::parse(&LinkMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, LinkMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -7,7 +7,7 @@ use netlink_packet_core::{
 
 use crate::{
     address::{AddressHeader, AddressMessage, AddressMessageBuffer},
-    link::{LinkMessage, LinkMessageBuffer},
+    link::LinkMessage,
     neighbour::{NeighbourMessage, NeighbourMessageBuffer},
     neighbour_table::{NeighbourTableMessage, NeighbourTableMessageBuffer},
     nsid::{NsidMessage, NsidMessageBuffer},
@@ -89,23 +89,18 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
         let message = match message_type {
             // Link messages
             RTM_NEWLINK | RTM_GETLINK | RTM_DELLINK | RTM_SETLINK => {
-                let msg = match LinkMessageBuffer::new_checked(&buf.inner()) {
-                    Ok(buf) => LinkMessage::parse(&buf)
-                        .context("invalid link message")?,
-                    // HACK: iproute2 sends invalid RTM_GETLINK message, where
-                    // the header is limited to the
-                    // interface family (1 byte) and 3 bytes of padding.
-                    Err(e) => {
-                        if buf.inner().len() == 4 && message_type == RTM_GETLINK
-                        {
-                            let mut msg = LinkMessage::default();
-                            msg.header.interface_family = buf.inner()[0].into();
-                            msg
-                        } else {
-                            return Err(e);
-                        }
-                    }
-                };
+                // HACK: iproute2 sends invalid RTM_GETLINK message, where
+                // the header is limited to the interface family (1 byte) and
+                // 3 bytes of padding.
+                let msg =
+                    if buf.inner().len() == 4 && message_type == RTM_GETLINK {
+                        let mut msg = LinkMessage::default();
+                        msg.header.interface_family = buf.inner()[0].into();
+                        msg
+                    } else {
+                        LinkMessage::parse(buf.inner())
+                            .context("invalid link message")?
+                    };
                 match message_type {
                     RTM_NEWLINK => RouteNetlinkMessage::NewLink(msg),
                     RTM_GETLINK => RouteNetlinkMessage::GetLink(msg),

--- a/src/stats/attribute.rs
+++ b/src/stats/attribute.rs
@@ -9,7 +9,7 @@ use super::{
     offload::{parse_offload_xstats_inner, OffloadXstat},
     xstats::{LinkXstatGroup, VecLinkXstats},
 };
-use crate::link::{Stats64, Stats64Buffer};
+use crate::link::Stats64;
 
 pub(crate) const IFLA_STATS_LINK_64: u16 = 1;
 pub(crate) const IFLA_STATS_LINK_XSTATS: u16 = 2;
@@ -72,11 +72,8 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
         let payload = buf.value();
         Ok(match buf.kind() {
             IFLA_STATS_LINK_64 => Self::Link64(
-                Stats64::parse(
-                    &Stats64Buffer::new_checked(payload)
-                        .context("invalid IFLA_STATS_LINK_64 value")?,
-                )
-                .context("invalid IFLA_STATS_LINK_64 value")?,
+                Stats64::parse(payload)
+                    .context("invalid IFLA_STATS_LINK_64 value")?,
             ),
             IFLA_STATS_LINK_XSTATS => {
                 let err = "invalid IFLA_STATS_LINK_XSTATS value";

--- a/src/stats/offload.rs
+++ b/src/stats/offload.rs
@@ -5,7 +5,7 @@ use netlink_packet_core::{
     Parseable, NLA_F_NESTED,
 };
 
-use crate::link::{Stats64, Stats64Buffer};
+use crate::link::Stats64;
 
 const IFLA_OFFLOAD_XSTATS_CPU_HIT: u16 = 1;
 const IFLA_OFFLOAD_XSTATS_HW_S_INFO: u16 = 2;
@@ -65,11 +65,7 @@ pub(crate) fn parse_offload_xstats_inner(
         let val = nla.value();
         result.push(match kind {
             IFLA_OFFLOAD_XSTATS_CPU_HIT => OffloadXstat::CpuHit(
-                Stats64::parse(
-                    &Stats64Buffer::new_checked(val)
-                        .context("invalid cpu hit stats")?,
-                )
-                .context("invalid cpu hit stats")?,
+                Stats64::parse(val).context("invalid cpu hit stats")?,
             ),
             IFLA_OFFLOAD_XSTATS_HW_S_INFO => OffloadXstat::HwStatsInfo(
                 HwStatsInfo::parse(val).context("invalid hw stats info")?,


### PR DESCRIPTION
Replace `buffer!()` marco with `zerocopy` crate.

The goal of doing this is use community well tested zerocopy crate
for binary data parsing and drop the need of `paste` crate which is
unmaintained from netlink-packet-core.

Existing test cases cover the changes.