### PR TITLE
API break: route: use zerocopy for route buffer parsing

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -12,7 +12,7 @@ use crate::{
     neighbour_table::{NeighbourTableMessage, NeighbourTableMessageBuffer},
     nsid::{NsidMessage, NsidMessageBuffer},
     prefix::{PrefixMessage, PrefixMessageBuffer},
-    route::{RouteHeader, RouteMessage, RouteMessageBuffer},
+    route::{RouteHeader, RouteMessage},
     rule::{RuleMessage, RuleMessageBuffer},
     stats::{StatsMessage, StatsMessageBuffer},
     tc::{TcActionMessage, TcActionMessageBuffer, TcMessage, TcMessageBuffer},
@@ -181,34 +181,27 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
 
             // Route messages
             RTM_NEWROUTE | RTM_GETROUTE | RTM_DELROUTE => {
-                let msg = match RouteMessageBuffer::new_checked(&buf.inner()) {
-                    Ok(buf) => RouteMessage::parse(&buf)
-                        .context("invalid route message")?,
-                    // HACK: iproute2 sends invalid RTM_GETROUTE message, where
-                    // the header is limited to the
-                    // interface family (1 byte) and 3 bytes of padding.
-                    Err(e) => {
-                        // Not only does iproute2 sends invalid messages, it's
-                        // also inconsistent in
-                        // doing so: for link and address messages, the length
-                        // advertised in the
-                        // netlink header includes the 3 bytes of padding but it
-                        // does not seem to be the case
-                        // for the route message, hence the buf.length() == 1
-                        // check.
-                        if (buf.inner().len() == 4 || buf.inner().len() == 1)
-                            && message_type == RTM_GETROUTE
-                        {
-                            let mut msg = RouteMessage {
-                                header: RouteHeader::default(),
-                                attributes: vec![],
-                            };
-                            msg.header.address_family = buf.inner()[0].into();
-                            msg
-                        } else {
-                            return Err(e);
-                        }
-                    }
+                // HACK: iproute2 sends invalid RTM_GETROUTE message, where
+                // the header is limited to the interface family (1 byte) and
+                // 3 bytes of padding.
+                //
+                // Not only does iproute2 sends invalid messages, it's also
+                // inconsistent in doing so: for link and address messages, the
+                // length advertised in the netlink header includes the 3 bytes
+                // of padding but it does not seem to be the case for the route
+                // message, hence the buf.length() == 1 check.
+                let msg = if (buf.inner().len() == 4 || buf.inner().len() == 1)
+                    && message_type == RTM_GETROUTE
+                {
+                    let mut msg = RouteMessage {
+                        header: RouteHeader::default(),
+                        attributes: vec![],
+                    };
+                    msg.header.address_family = buf.inner()[0].into();
+                    msg
+                } else {
+                    RouteMessage::parse(buf.inner())
+                        .context("invalid route message")?
                 };
                 match message_type {
                     RTM_NEWROUTE => RouteNetlinkMessage::NewRoute(msg),

--- a/src/route/attribute.rs
+++ b/src/route/attribute.rs
@@ -3,16 +3,16 @@
 use netlink_packet_core::{
     emit_u32, emit_u64, parse_u16, parse_u16_be, parse_u32, parse_u64,
     parse_u8, DecodeError, DefaultNla, Emitable, ErrorContext, Nla, NlaBuffer,
-    Parseable, ParseableParametrized,
+    NlasIterator, Parseable, ParseableParametrized,
 };
 
 use super::{
     super::AddressFamily, lwtunnel::VecRouteLwTunnelEncap,
-    metrics::VecRouteMetric, mpls::VecMplsLabel, MplsLabel, RouteAddress,
-    RouteCacheInfo, RouteCacheInfoBuffer, RouteLwEnCapType, RouteLwTunnelEncap,
-    RouteMetric, RouteMfcStats, RouteMfcStatsBuffer, RouteMplsTtlPropagation,
-    RouteNextHop, RouteNextHopBuffer, RoutePreference, RouteRealm, RouteType,
-    RouteVia, RouteViaBuffer,
+    metrics::VecRouteMetric, mpls::VecMplsLabel,
+    next_hops::parse_multipath_next_hops, MplsLabel, RouteAddress,
+    RouteCacheInfo, RouteLwEnCapType, RouteLwTunnelEncap, RouteMetric,
+    RouteMfcStats, RouteMplsTtlPropagation, RouteNextHop, RoutePreference,
+    RouteRealm, RouteType, RouteVia,
 };
 
 const RTA_DST: u16 = 1;
@@ -242,12 +242,8 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
                 Self::PrefSource(RouteAddress::parse(address_family, payload)?)
             }
             RTA_VIA => Self::Via(
-                RouteVia::parse(
-                    &RouteViaBuffer::new_checked(payload).context(format!(
-                        "Invalid RTA_VIA value {payload:?}"
-                    ))?,
-                )
-                .context(format!("Invalid RTA_VIA value {payload:?}"))?,
+                RouteVia::parse(payload)
+                    .context(format!("Invalid RTA_VIA value {payload:?}"))?,
             ),
             RTA_NEWDST => Self::NewDestination(
                 VecMplsLabel::parse(payload)
@@ -304,44 +300,25 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
             ),
 
             RTA_CACHEINFO => Self::CacheInfo(
-                RouteCacheInfo::parse(
-                    &RouteCacheInfoBuffer::new_checked(payload)
-                        .context("invalid RTA_CACHEINFO value")?,
-                )
-                .context("invalid RTA_CACHEINFO value")?,
+                RouteCacheInfo::parse(payload)
+                    .context("invalid RTA_CACHEINFO value")?,
             ),
             RTA_MFC_STATS => Self::MfcStats(
-                RouteMfcStats::parse(
-                    &RouteMfcStatsBuffer::new_checked(payload)
-                        .context("invalid RTA_MFC_STATS value")?,
-                )
-                .context("invalid RTA_MFC_STATS value")?,
+                RouteMfcStats::parse(payload)
+                    .context("invalid RTA_MFC_STATS value")?,
             ),
             RTA_METRICS => Self::Metrics(
                 VecRouteMetric::parse(payload)
                     .context("invalid RTA_METRICS value")?
                     .0,
             ),
-            RTA_MULTIPATH => {
-                let mut next_hops = vec![];
-                let mut buf = payload;
-                loop {
-                    let nh_buf = RouteNextHopBuffer::new_checked(&buf)
-                        .context("invalid RTA_MULTIPATH value")?;
-                    let len = nh_buf.length() as usize;
-                    let nh = RouteNextHop::parse_with_param(
-                        &nh_buf,
-                        (address_family, route_type, encap_type),
-                    )
-                    .context("invalid RTA_MULTIPATH value")?;
-                    next_hops.push(nh);
-                    if buf.len() == len {
-                        break;
-                    }
-                    buf = &buf[len..];
-                }
-                Self::MultiPath(next_hops)
-            }
+            RTA_MULTIPATH => Self::MultiPath(
+                parse_multipath_next_hops(
+                    payload,
+                    (address_family, route_type, encap_type),
+                )
+                .context("invalid RTA_MULTIPATH value")?,
+            ),
             RTA_IP_PROTO => Self::IpProto(
                 parse_u8(payload).context("invalid RTA_IP_PROTO value")?,
             ),
@@ -361,5 +338,67 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
                 DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?,
             ),
         })
+    }
+}
+
+pub(crate) struct VecRouteAttribute(pub(crate) Vec<RouteAttribute>);
+
+impl ParseableParametrized<[u8], (AddressFamily, RouteType)>
+    for VecRouteAttribute
+{
+    fn parse_with_param(
+        buf: &[u8],
+        (address_family, route_type): (AddressFamily, RouteType),
+    ) -> Result<Self, DecodeError> {
+        let mut encap_type = RouteLwEnCapType::None;
+        // The RTA_ENCAP_TYPE is provided __after__ RTA_ENCAP, we should find
+        // RTA_ENCAP_TYPE first.
+        for nla_buf in NlasIterator::new(buf) {
+            let nla = match nla_buf {
+                Ok(n) => n,
+                Err(_) => continue,
+            };
+            if nla.kind() == RTA_ENCAP_TYPE {
+                if let Ok(RouteAttribute::EncapType(v)) =
+                    RouteAttribute::parse_with_param(
+                        &nla,
+                        (address_family, route_type, encap_type),
+                    )
+                {
+                    encap_type = v;
+                    break;
+                }
+            }
+        }
+        let mut attributes = vec![];
+        for nla_buf in NlasIterator::new(buf) {
+            attributes.push(RouteAttribute::parse_with_param(
+                &nla_buf?,
+                (address_family, route_type, encap_type),
+            )?);
+        }
+        Ok(Self(attributes))
+    }
+}
+
+impl ParseableParametrized<[u8], (AddressFamily, RouteType, RouteLwEnCapType)>
+    for VecRouteAttribute
+{
+    fn parse_with_param(
+        buf: &[u8],
+        (address_family, route_type, encap_type): (
+            AddressFamily,
+            RouteType,
+            RouteLwEnCapType,
+        ),
+    ) -> Result<Self, DecodeError> {
+        let mut nlas = vec![];
+        for nla_buf in NlasIterator::new(buf) {
+            nlas.push(RouteAttribute::parse_with_param(
+                &nla_buf?,
+                (address_family, route_type, encap_type),
+            )?);
+        }
+        Ok(Self(nlas))
     }
 }

--- a/src/route/cache_info.rs
+++ b/src/route/cache_info.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{DecodeError, Emitable, Parseable};
+use std::mem::size_of;
+
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 #[non_exhaustive]
@@ -15,48 +18,73 @@ pub struct RouteCacheInfo {
     pub ts_age: u32,
 }
 
-const CACHE_INFO_LEN: usize = 32;
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct RouteCacheInfoBuffer {
+    clntref: u32,
+    last_use: u32,
+    expires: u32,
+    error: u32,
+    used: u32,
+    id: u32,
+    ts: u32,
+    ts_age: u32,
+}
 
-buffer!(RouteCacheInfoBuffer(CACHE_INFO_LEN) {
-    clntref: (u32, 0..4),
-    last_use: (u32, 4..8),
-    expires: (u32, 8..12),
-    error: (u32, 12..16),
-    used: (u32, 16..20),
-    id: (u32, 20..24),
-    ts: (u32, 24..28),
-    ts_age: (u32, 28..32),
-});
-
-impl<T: AsRef<[u8]>> Parseable<RouteCacheInfoBuffer<T>> for RouteCacheInfo {
-    fn parse(buf: &RouteCacheInfoBuffer<T>) -> Result<Self, DecodeError> {
+impl RouteCacheInfo {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) =
+            RouteCacheInfoBuffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    size_of::<RouteCacheInfoBuffer>(),
+                )
+            })?;
         Ok(Self {
-            clntref: buf.clntref(),
-            last_use: buf.last_use(),
-            expires: buf.expires(),
-            error: buf.error(),
-            used: buf.used(),
-            id: buf.id(),
-            ts: buf.ts(),
-            ts_age: buf.ts_age(),
+            clntref: raw.clntref,
+            last_use: raw.last_use,
+            expires: raw.expires,
+            error: raw.error,
+            used: raw.used,
+            id: raw.id,
+            ts: raw.ts,
+            ts_age: raw.ts_age,
         })
+    }
+}
+
+impl From<&RouteCacheInfo> for RouteCacheInfoBuffer {
+    fn from(value: &RouteCacheInfo) -> Self {
+        Self {
+            clntref: value.clntref,
+            last_use: value.last_use,
+            expires: value.expires,
+            error: value.error,
+            used: value.used,
+            id: value.id,
+            ts: value.ts,
+            ts_age: value.ts_age,
+        }
     }
 }
 
 impl Emitable for RouteCacheInfo {
     fn buffer_len(&self) -> usize {
-        CACHE_INFO_LEN
+        size_of::<RouteCacheInfoBuffer>()
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buffer = RouteCacheInfoBuffer::new(buffer);
-        buffer.set_clntref(self.clntref);
-        buffer.set_last_use(self.last_use);
-        buffer.set_expires(self.expires);
-        buffer.set_error(self.error);
-        buffer.set_used(self.used);
-        buffer.set_id(self.id);
-        buffer.set_ts(self.ts);
-        buffer.set_ts_age(self.ts_age);
+        let raw = RouteCacheInfoBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/route/header.rs
+++ b/src/route/header.rs
@@ -1,32 +1,34 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{
-    DecodeError, Emitable, NlaBuffer, NlasIterator, Parseable,
-};
+use netlink_packet_core::{DecodeError, Emitable, Parseable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use super::{super::AddressFamily, flags::RouteFlags};
 
-const ROUTE_HEADER_LEN: usize = 12;
+pub(crate) const ROUTE_HEADER_LEN: usize = 12;
 
-buffer!(RouteMessageBuffer(ROUTE_HEADER_LEN) {
-    address_family: (u8, 0),
-    destination_prefix_length: (u8, 1),
-    source_prefix_length: (u8, 2),
-    tos: (u8, 3),
-    table: (u8, 4),
-    protocol: (u8, 5),
-    scope: (u8, 6),
-    kind: (u8, 7),
-    flags: (u32, 8..ROUTE_HEADER_LEN),
-    payload: (slice, ROUTE_HEADER_LEN..),
-});
-
-impl<'a, T: AsRef<[u8]> + ?Sized> RouteMessageBuffer<&'a T> {
-    pub fn attributes(
-        &self,
-    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
-        NlasIterator::new(self.payload())
-    }
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct RouteMessageBuffer {
+    address_family: u8,
+    destination_prefix_length: u8,
+    source_prefix_length: u8,
+    tos: u8,
+    table: u8,
+    protocol: u8,
+    scope: u8,
+    kind: u8,
+    flags: u32,
 }
 
 /// High level representation of `RTM_GETROUTE`, `RTM_ADDROUTE`, `RTM_DELROUTE`
@@ -59,20 +61,22 @@ impl RouteHeader {
     pub const RT_TABLE_UNSPEC: u8 = 0;
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<RouteMessageBuffer<&'a T>>
-    for RouteHeader
-{
-    fn parse(buf: &RouteMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl RouteHeader {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) =
+            RouteMessageBuffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(payload.len(), ROUTE_HEADER_LEN)
+            })?;
         Ok(RouteHeader {
-            address_family: buf.address_family().into(),
-            destination_prefix_length: buf.destination_prefix_length(),
-            source_prefix_length: buf.source_prefix_length(),
-            tos: buf.tos(),
-            table: buf.table(),
-            protocol: buf.protocol().into(),
-            scope: buf.scope().into(),
-            kind: buf.kind().into(),
-            flags: RouteFlags::from_bits_retain(buf.flags()),
+            address_family: raw.address_family.into(),
+            destination_prefix_length: raw.destination_prefix_length,
+            source_prefix_length: raw.source_prefix_length,
+            tos: raw.tos,
+            table: raw.table,
+            protocol: raw.protocol.into(),
+            scope: raw.scope.into(),
+            kind: raw.kind.into(),
+            flags: RouteFlags::from_bits_retain(raw.flags),
         })
     }
 }
@@ -83,16 +87,24 @@ impl Emitable for RouteHeader {
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buffer = RouteMessageBuffer::new(buffer);
-        buffer.set_address_family(self.address_family.into());
-        buffer.set_destination_prefix_length(self.destination_prefix_length);
-        buffer.set_source_prefix_length(self.source_prefix_length);
-        buffer.set_tos(self.tos);
-        buffer.set_table(self.table);
-        buffer.set_protocol(self.protocol.into());
-        buffer.set_scope(self.scope.into());
-        buffer.set_kind(self.kind.into());
-        buffer.set_flags(self.flags.bits());
+        let raw = RouteMessageBuffer::from(self);
+        buffer[..ROUTE_HEADER_LEN].copy_from_slice(raw.as_bytes());
+    }
+}
+
+impl From<&RouteHeader> for RouteMessageBuffer {
+    fn from(header: &RouteHeader) -> Self {
+        Self {
+            address_family: header.address_family.into(),
+            destination_prefix_length: header.destination_prefix_length,
+            source_prefix_length: header.source_prefix_length,
+            tos: header.tos,
+            table: header.table,
+            protocol: header.protocol.into(),
+            scope: header.scope.into(),
+            kind: header.kind.into(),
+            flags: header.flags.bits(),
+        }
     }
 }
 

--- a/src/route/message.rs
+++ b/src/route/message.rs
@@ -5,8 +5,8 @@ use netlink_packet_core::{
 };
 
 use super::{
-    super::AddressFamily, attribute::RTA_ENCAP_TYPE, RouteAttribute,
-    RouteHeader, RouteLwEnCapType, RouteMessageBuffer, RouteType,
+    attribute::VecRouteAttribute, header::ROUTE_HEADER_LEN, RouteAttribute,
+    RouteHeader,
 };
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
@@ -29,60 +29,20 @@ impl Emitable for RouteMessage {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<RouteMessageBuffer<&'a T>>
-    for RouteMessage
-{
-    fn parse(buf: &RouteMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl Parseable<[u8]> for RouteMessage {
+    fn parse(buf: &[u8]) -> Result<Self, DecodeError> {
         let header = RouteHeader::parse(buf)
             .context("failed to parse route message header")?;
         let address_family = header.address_family;
         let route_type = header.kind;
         Ok(RouteMessage {
             header,
-            attributes: Vec::<RouteAttribute>::parse_with_param(
-                buf,
+            attributes: VecRouteAttribute::parse_with_param(
+                &buf[ROUTE_HEADER_LEN..],
                 (address_family, route_type),
             )
-            .context("failed to parse route message NLAs")?,
+            .context("failed to parse route message NLAs")?
+            .0,
         })
-    }
-}
-
-impl<'a, T: AsRef<[u8]> + 'a>
-    ParseableParametrized<RouteMessageBuffer<&'a T>, (AddressFamily, RouteType)>
-    for Vec<RouteAttribute>
-{
-    fn parse_with_param(
-        buf: &RouteMessageBuffer<&'a T>,
-        (address_family, route_type): (AddressFamily, RouteType),
-    ) -> Result<Self, DecodeError> {
-        let mut attributes = vec![];
-        let mut encap_type = RouteLwEnCapType::None;
-        // The RTA_ENCAP_TYPE is provided __after__ RTA_ENCAP, we should find
-        // RTA_ENCAP_TYPE first.
-        for nla_buf in buf.attributes() {
-            let nla = match nla_buf {
-                Ok(n) => n,
-                Err(_) => continue,
-            };
-            if nla.kind() == RTA_ENCAP_TYPE {
-                if let Ok(RouteAttribute::EncapType(v)) =
-                    RouteAttribute::parse_with_param(
-                        &nla,
-                        (address_family, route_type, encap_type),
-                    )
-                {
-                    encap_type = v;
-                    break;
-                }
-            }
-        }
-        for nla_buf in buf.attributes() {
-            attributes.push(RouteAttribute::parse_with_param(
-                &nla_buf?,
-                (address_family, route_type, encap_type),
-            )?);
-        }
-        Ok(attributes)
     }
 }

--- a/src/route/mfc_stats.rs
+++ b/src/route/mfc_stats.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{DecodeError, Emitable, Parseable};
+use std::mem::size_of;
+
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 #[non_exhaustive]
@@ -10,35 +13,58 @@ pub struct RouteMfcStats {
     pub wrong_if: u64,
 }
 
-const MFC_STATS_LEN: usize = 24;
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct RouteMfcStatsBuffer {
+    packets: u64,
+    bytes: u64,
+    wrong_if: u64,
+}
 
-buffer!(RouteMfcStatsBuffer(MFC_STATS_LEN) {
-    packets: (u64, 0..8),
-    bytes: (u64, 8..16),
-    wrong_if: (u64, 16..24),
-});
-
-impl<T: AsRef<[u8]>> Parseable<RouteMfcStatsBuffer<T>> for RouteMfcStats {
-    fn parse(
-        buf: &RouteMfcStatsBuffer<T>,
-    ) -> Result<RouteMfcStats, DecodeError> {
-        Ok(RouteMfcStats {
-            packets: buf.packets(),
-            bytes: buf.bytes(),
-            wrong_if: buf.wrong_if(),
+impl RouteMfcStats {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) =
+            RouteMfcStatsBuffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    size_of::<RouteMfcStatsBuffer>(),
+                )
+            })?;
+        Ok(Self {
+            packets: raw.packets,
+            bytes: raw.bytes,
+            wrong_if: raw.wrong_if,
         })
+    }
+}
+
+impl From<&RouteMfcStats> for RouteMfcStatsBuffer {
+    fn from(value: &RouteMfcStats) -> Self {
+        Self {
+            packets: value.packets,
+            bytes: value.bytes,
+            wrong_if: value.wrong_if,
+        }
     }
 }
 
 impl Emitable for RouteMfcStats {
     fn buffer_len(&self) -> usize {
-        MFC_STATS_LEN
+        size_of::<RouteMfcStatsBuffer>()
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buffer = RouteMfcStatsBuffer::new(buffer);
-        buffer.set_packets(self.packets);
-        buffer.set_bytes(self.bytes);
-        buffer.set_wrong_if(self.wrong_if);
+        let raw = RouteMfcStatsBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/route/next_hops.rs
+++ b/src/route/next_hops.rs
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: MIT
 
+use std::mem::size_of;
+
 use netlink_packet_core::{
-    DecodeError, Emitable, ErrorContext, NlaBuffer, NlasIterator,
-    ParseableParametrized,
+    DecodeError, Emitable, ErrorContext, ParseableParametrized,
 };
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use super::{
-    super::AddressFamily, RouteAttribute, RouteLwEnCapType, RouteType,
+    super::AddressFamily, attribute::VecRouteAttribute, RouteAttribute,
+    RouteLwEnCapType, RouteType,
 };
 
 pub(crate) const RTNH_F_DEAD: u8 = 1;
@@ -84,58 +87,52 @@ impl std::fmt::Display for RouteNextHopFlags {
     }
 }
 
-const PAYLOAD_OFFSET: usize = 8;
-
-buffer!(RouteNextHopBuffer {
-    length: (u16, 0..2),
-    flags: (u8, 2),
-    hops: (u8, 3),
-    interface_index: (u32, 4..8),
-    payload: (slice, PAYLOAD_OFFSET..),
-});
-
-impl<T: AsRef<[u8]>> RouteNextHopBuffer<T> {
-    pub fn new_checked(buffer: T) -> Result<Self, DecodeError> {
-        let packet = Self::new(buffer);
-        packet.check_buffer_length()?;
-        Ok(packet)
-    }
-
-    fn check_buffer_length(&self) -> Result<(), DecodeError> {
-        let len = self.buffer.as_ref().len();
-        if len < PAYLOAD_OFFSET {
-            return Err(format!(
-                "invalid RouteNextHopBuffer: length {len} < {PAYLOAD_OFFSET}"
-            )
-            .into());
-        }
-        if len < self.length() as usize {
-            return Err(format!(
-                "invalid RouteNextHopBuffer: length {} < {}",
-                len,
-                self.length(),
-            )
-            .into());
-        }
-        if (self.length() as usize) < PAYLOAD_OFFSET {
-            return Err(format!(
-                "invalid RouteNextHopBuffer: length {} < {}",
-                self.length(),
-                PAYLOAD_OFFSET
-            )
-            .into());
-        }
-        Ok(())
-    }
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct RouteNextHopBuffer {
+    length: u16,
+    flags: u8,
+    hops: u8,
+    interface_index: u32,
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> RouteNextHopBuffer<&'a T> {
-    pub fn attributes(
-        &self,
-    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
-        NlasIterator::new(
-            &self.payload()[..(self.length() as usize - PAYLOAD_OFFSET)],
-        )
+impl RouteNextHopBuffer {
+    pub fn new_checked(buffer: &[u8]) -> Result<&Self, DecodeError> {
+        let len = buffer.len();
+        let header_len = size_of::<Self>();
+        if len < header_len {
+            return Err(format!(
+                "invalid RouteNextHopBuffer: length {len} < {header_len}"
+            )
+            .into());
+        }
+        let raw = Self::ref_from_prefix(buffer)
+            .map_err(|_| DecodeError::buffer_too_small(len, header_len))?
+            .0;
+        let length = raw.length;
+        if len < length as usize {
+            return Err(format!(
+                "invalid RouteNextHopBuffer: length {len} < {length}"
+            )
+            .into());
+        }
+        if (length as usize) < header_len {
+            return Err(format!(
+                "invalid RouteNextHopBuffer: length {length} < {header_len}"
+            )
+            .into());
+        }
+        Ok(raw)
     }
 }
 
@@ -152,72 +149,85 @@ pub struct RouteNextHop {
     pub attributes: Vec<RouteAttribute>,
 }
 
-impl<T: AsRef<[u8]>>
-    ParseableParametrized<
-        RouteNextHopBuffer<&T>,
-        (AddressFamily, RouteType, RouteLwEnCapType),
-    > for RouteNextHop
+impl ParseableParametrized<[u8], (AddressFamily, RouteType, RouteLwEnCapType)>
+    for RouteNextHop
 {
     fn parse_with_param(
-        buf: &RouteNextHopBuffer<&T>,
+        buf: &[u8],
         (address_family, route_type, encap_type): (
             AddressFamily,
             RouteType,
             RouteLwEnCapType,
         ),
     ) -> Result<RouteNextHop, DecodeError> {
-        let attributes = Vec::<RouteAttribute>::parse_with_param(
-            &RouteNextHopBuffer::new_checked(buf.buffer)
-                .context("cannot parse route attributes in next-hop")?,
+        let err = "cannot parse route attributes in next-hop";
+        let nh_buf = RouteNextHopBuffer::new_checked(buf).context(err)?;
+        let length = nh_buf.length as usize;
+        let attributes = VecRouteAttribute::parse_with_param(
+            &buf[size_of::<RouteNextHopBuffer>()..length],
             (address_family, route_type, encap_type),
         )
-        .context("cannot parse route attributes in next-hop")?;
+        .context(err)?
+        .0;
         Ok(RouteNextHop {
-            flags: RouteNextHopFlags::from_bits_retain(buf.flags()),
-            hops: buf.hops(),
-            interface_index: buf.interface_index(),
+            flags: RouteNextHopFlags::from_bits_retain(nh_buf.flags),
+            hops: nh_buf.hops,
+            interface_index: nh_buf.interface_index,
             attributes,
         })
-    }
-}
-
-impl<'a, T: AsRef<[u8]> + 'a>
-    ParseableParametrized<
-        RouteNextHopBuffer<&'a T>,
-        (AddressFamily, RouteType, RouteLwEnCapType),
-    > for Vec<RouteAttribute>
-{
-    fn parse_with_param(
-        buf: &RouteNextHopBuffer<&'a T>,
-        (address_family, route_type, encap_type): (
-            AddressFamily,
-            RouteType,
-            RouteLwEnCapType,
-        ),
-    ) -> Result<Self, DecodeError> {
-        let mut nlas = vec![];
-        for nla_buf in buf.attributes() {
-            nlas.push(RouteAttribute::parse_with_param(
-                &nla_buf?,
-                (address_family, route_type, encap_type),
-            )?);
-        }
-        Ok(nlas)
     }
 }
 
 impl Emitable for RouteNextHop {
     fn buffer_len(&self) -> usize {
         // len, flags, hops and interface id fields
-        PAYLOAD_OFFSET + self.attributes.as_slice().buffer_len()
+        size_of::<RouteNextHopBuffer>()
+            + self.attributes.as_slice().buffer_len()
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut nh_buffer = RouteNextHopBuffer::new(buffer);
-        nh_buffer.set_length(self.buffer_len() as u16);
-        nh_buffer.set_flags(self.flags.bits());
-        nh_buffer.set_hops(self.hops);
-        nh_buffer.set_interface_index(self.interface_index);
-        self.attributes.as_slice().emit(nh_buffer.payload_mut())
+        let raw = RouteNextHopBuffer::from(self);
+        buffer[..size_of::<RouteNextHopBuffer>()]
+            .copy_from_slice(raw.as_bytes());
+        self.attributes
+            .as_slice()
+            .emit(&mut buffer[size_of::<RouteNextHopBuffer>()..]);
     }
+}
+
+impl From<&RouteNextHop> for RouteNextHopBuffer {
+    fn from(nh: &RouteNextHop) -> Self {
+        Self {
+            length: nh.buffer_len() as u16,
+            flags: nh.flags.bits(),
+            hops: nh.hops,
+            interface_index: nh.interface_index,
+        }
+    }
+}
+
+// Parse a `RTA_MULTIPATH` attribute value: a sequence of variable-length
+// `rtnexthop` entries, each carrying its own total length.
+pub(crate) fn parse_multipath_next_hops(
+    buf: &[u8],
+    (address_family, route_type, encap_type): (
+        AddressFamily,
+        RouteType,
+        RouteLwEnCapType,
+    ),
+) -> Result<Vec<RouteNextHop>, DecodeError> {
+    let mut next_hops = vec![];
+    let mut buf = buf;
+    loop {
+        let length = RouteNextHopBuffer::new_checked(buf)?.length as usize;
+        next_hops.push(RouteNextHop::parse_with_param(
+            buf,
+            (address_family, route_type, encap_type),
+        )?);
+        if buf.len() == length {
+            break;
+        }
+        buf = &buf[length..];
+    }
+    Ok(next_hops)
 }

--- a/src/route/seg6.rs
+++ b/src/route/seg6.rs
@@ -5,6 +5,7 @@ use std::net::{IpAddr, Ipv6Addr};
 use netlink_packet_core::{
     DecodeError, DefaultNla, ErrorContext, Nla, NlaBuffer, Parseable,
 };
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use crate::ip::{emit_ip_addr, parse_ipv6_addr};
 
@@ -85,24 +86,30 @@ impl Nla for RouteSeg6IpTunnel {
 
 const SEG6_HEADER_LEN: usize = 12;
 
-buffer!(Seg6MessageBuffer(SEG6_HEADER_LEN) {
-    mode: (u32, 0..4),
-    nexthdr: (u8, 4),
-    hdrlen: (u8, 5),
-    seg_type: (u8, 6),
-    segments_left: (u8, 7),
-    first_segment: (u8, 8),
-    flags: (u8, 9),
-    tag: (u16, 10..12),
-    segments: (slice, SEG6_HEADER_LEN..),
-});
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct Seg6MessageBuffer {
+    mode: u32,
+    nexthdr: u8,
+    hdrlen: u8,
+    seg_type: u8,
+    segments_left: u8,
+    first_segment: u8,
+    flags: u8,
+    tag: u16,
+}
 
 const SEG6_SEGMENT_LEN: usize = 16;
-
-buffer!(Seg6SegmentBuffer(SEG6_SEGMENT_LEN) {
-    segment: (slice, 0..SEG6_SEGMENT_LEN),
-    rest: (slice, SEG6_SEGMENT_LEN..)
-});
 
 /// Netlink attributes for `RTA_ENCAP` with `RTA_ENCAP_TYPE` set to
 /// `LWTUNNEL_ENCAP_SEG6`.
@@ -118,9 +125,8 @@ pub struct Seg6Header {
 impl Seg6Header {
     fn push_segments(buf: &mut [u8], mut segments: Vec<Ipv6Addr>) {
         if let Some(segment) = segments.pop() {
-            let mut segment_buffer = Seg6SegmentBuffer::new(buf);
-            emit_ip_addr(&IpAddr::V6(segment), segment_buffer.segment_mut());
-            Self::push_segments(segment_buffer.rest_mut(), segments);
+            emit_ip_addr(&IpAddr::V6(segment), &mut buf[..SEG6_SEGMENT_LEN]);
+            Self::push_segments(&mut buf[SEG6_SEGMENT_LEN..], segments);
         }
     }
 
@@ -130,10 +136,9 @@ impl Seg6Header {
     ) -> Result<(), DecodeError> {
         // are there any remaining segments ?
         if buf.len() >= SEG6_SEGMENT_LEN {
-            let segment_buffer = Seg6SegmentBuffer::new(buf);
-            let segment = parse_ipv6_addr(segment_buffer.segment())?;
+            let segment = parse_ipv6_addr(&buf[..SEG6_SEGMENT_LEN])?;
             segments.push(segment);
-            Self::get_segments(segment_buffer.rest(), segments)?;
+            Self::get_segments(&buf[SEG6_SEGMENT_LEN..], segments)?;
         }
         Ok(())
     }
@@ -166,8 +171,6 @@ impl Nla for Seg6Header {
         // iproute2/iproute2
         //      ip/iproute_lwtunnel.c parse_encap_seg6()
 
-        let mut seg6_header = Seg6MessageBuffer::new(buffer);
-
         let mut number_segments = self.segments.len();
         if matches!(self.mode, Seg6Mode::Inline) {
             number_segments += 1 // last segment (::) added
@@ -175,14 +178,17 @@ impl Nla for Seg6Header {
 
         let srhlen = 8 + 16 * number_segments;
 
-        seg6_header.set_mode(self.mode.into());
-        seg6_header.set_nexthdr(0);
-        seg6_header.set_hdrlen(((srhlen >> 3) - 1) as u8);
-        seg6_header.set_seg_type(4);
-        seg6_header.set_segments_left((number_segments - 1) as u8);
-        seg6_header.set_first_segment((number_segments - 1) as u8);
-        seg6_header.set_flags(0);
-        seg6_header.set_tag(0);
+        let raw = Seg6MessageBuffer {
+            mode: self.mode.into(),
+            nexthdr: 0,
+            hdrlen: ((srhlen >> 3) - 1) as u8,
+            seg_type: 4,
+            segments_left: (number_segments - 1) as u8,
+            first_segment: (number_segments - 1) as u8,
+            flags: 0,
+            tag: 0,
+        };
+        buffer[..SEG6_HEADER_LEN].copy_from_slice(raw.as_bytes());
 
         let mut segments = self.segments.clone();
 
@@ -191,7 +197,7 @@ impl Nla for Seg6Header {
             segments.push("::".parse().expect("Impossible error"))
         }
 
-        Seg6Header::push_segments(seg6_header.segments_mut(), segments);
+        Seg6Header::push_segments(&mut buffer[SEG6_HEADER_LEN..], segments);
     }
 }
 
@@ -204,25 +210,28 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
         let payload = buf.value();
         Ok(match buf.kind() {
             SEG6_IPTUNNEL_SRH => {
-                let seg6_header = Seg6MessageBuffer::new(payload);
+                let (raw, segments_buf) = Seg6MessageBuffer::ref_from_prefix(
+                    payload,
+                )
+                .map_err(|_| {
+                    DecodeError::buffer_too_small(
+                        payload.len(),
+                        SEG6_HEADER_LEN,
+                    )
+                })?;
 
                 let mut segments: Vec<Ipv6Addr> = vec![];
-                Seg6Header::get_segments(
-                    seg6_header.segments(),
-                    &mut segments,
-                )?;
+                Seg6Header::get_segments(segments_buf, &mut segments)?;
 
                 let mut segments: Vec<Ipv6Addr> =
                     segments.into_iter().rev().collect();
 
-                if matches!(seg6_header.mode().into(), Seg6Mode::Inline) {
+                let mode = Seg6Mode::from(raw.mode);
+                if matches!(mode, Seg6Mode::Inline) {
                     segments.pop(); // remove last inline segment
                 }
 
-                RouteSeg6IpTunnel::Seg6(Seg6Header {
-                    mode: seg6_header.mode().into(),
-                    segments,
-                })
+                RouteSeg6IpTunnel::Seg6(Seg6Header { mode, segments })
             }
             _ => Self::Other(
                 DefaultNla::parse(buf)

--- a/src/route/tests/cache_info.rs
+++ b/src/route/tests/cache_info.rs
@@ -7,8 +7,8 @@ use netlink_packet_core::{Emitable, Parseable};
 use crate::{
     route::{
         flags::RouteFlags, RouteAttribute, RouteCacheInfo, RouteHeader,
-        RouteMessage, RouteMessageBuffer, RouteMetric, RoutePreference,
-        RouteProtocol, RouteScope, RouteType,
+        RouteMessage, RouteMetric, RoutePreference, RouteProtocol, RouteScope,
+        RouteType,
     },
     AddressFamily,
 };
@@ -103,10 +103,7 @@ fn test_ipv6_route_cache_info() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        RouteMessage::parse(&RouteMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, RouteMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/route/tests/expires.rs
+++ b/src/route/tests/expires.rs
@@ -7,7 +7,7 @@ use netlink_packet_core::{Emitable, Parseable};
 use crate::{
     route::{
         flags::RouteFlags, RouteAttribute, RouteHeader, RouteMessage,
-        RouteMessageBuffer, RouteProtocol, RouteScope, RouteType,
+        RouteProtocol, RouteScope, RouteType,
     },
     AddressFamily,
 };
@@ -44,10 +44,7 @@ fn test_ipv6_route_expires() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        RouteMessage::parse(&RouteMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, RouteMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/route/tests/ip6_tunnel.rs
+++ b/src/route/tests/ip6_tunnel.rs
@@ -11,7 +11,7 @@ use crate::{
     route::{
         lwtunnel::RouteIp6TunnelFlags, RouteAttribute, RouteFlags, RouteHeader,
         RouteIp6Tunnel, RouteLwEnCapType, RouteLwTunnelEncap, RouteMessage,
-        RouteMessageBuffer, RouteProtocol, RouteScope, RouteType,
+        RouteProtocol, RouteScope, RouteType,
     },
     AddressFamily,
 };
@@ -76,10 +76,7 @@ fn test_ip6_tunnel() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        RouteMessage::parse(&RouteMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, RouteMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/route/tests/loopback.rs
+++ b/src/route/tests/loopback.rs
@@ -7,8 +7,7 @@ use netlink_packet_core::{Emitable, Parseable};
 use crate::{
     route::{
         flags::RouteFlags, RouteAttribute, RouteCacheInfo, RouteHeader,
-        RouteMessage, RouteMessageBuffer, RoutePreference, RouteProtocol,
-        RouteScope, RouteType,
+        RouteMessage, RoutePreference, RouteProtocol, RouteScope, RouteType,
     },
     AddressFamily,
 };
@@ -46,10 +45,7 @@ fn test_ipv4_route_loopback() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        RouteMessage::parse(&RouteMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, RouteMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -91,10 +87,7 @@ fn test_ipv4_route_loopback_broadcast() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        RouteMessage::parse(&RouteMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, RouteMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -150,10 +143,7 @@ fn test_ipv6_route_loopback() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        RouteMessage::parse(&RouteMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, RouteMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/route/tests/metrics.rs
+++ b/src/route/tests/metrics.rs
@@ -7,7 +7,7 @@ use netlink_packet_core::{Emitable, Parseable};
 use crate::{
     route::{
         flags::RouteFlags, RouteAttribute, RouteHeader, RouteMessage,
-        RouteMessageBuffer, RouteMetric, RouteProtocol, RouteScope, RouteType,
+        RouteMetric, RouteProtocol, RouteScope, RouteType,
     },
     AddressFamily,
 };
@@ -64,10 +64,7 @@ fn test_route_metrics_mtu_window_rtt_hoplimit() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        RouteMessage::parse(&RouteMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, RouteMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
     expected.emit(&mut buf);
@@ -128,10 +125,7 @@ fn test_route_metrics_advmss_ssthresh_cwnd_initcwnd_initrwnd() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        RouteMessage::parse(&RouteMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, RouteMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
     expected.emit(&mut buf);
@@ -190,10 +184,7 @@ fn test_route_metrics_reordering_rto_min_quickack_fastopen() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        RouteMessage::parse(&RouteMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, RouteMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
     expected.emit(&mut buf);
@@ -239,10 +230,7 @@ fn test_route_metrics_features_ecn() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        RouteMessage::parse(&RouteMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, RouteMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
     expected.emit(&mut buf);

--- a/src/route/tests/mpls.rs
+++ b/src/route/tests/mpls.rs
@@ -11,9 +11,8 @@ use crate::{
     route::{
         flags::RouteFlags, MplsLabel, RouteAddress, RouteAttribute,
         RouteCacheInfo, RouteHeader, RouteLwEnCapType, RouteLwTunnelEncap,
-        RouteMessage, RouteMessageBuffer, RouteMplsIpTunnel,
-        RouteMplsTtlPropagation, RoutePreference, RouteProtocol, RouteScope,
-        RouteType,
+        RouteMessage, RouteMplsIpTunnel, RouteMplsTtlPropagation,
+        RoutePreference, RouteProtocol, RouteScope, RouteType,
     },
     AddressFamily,
 };
@@ -75,10 +74,7 @@ fn test_mpls_route_to_ipv4() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        RouteMessage::parse(&RouteMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, RouteMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -159,10 +155,7 @@ fn test_ipv6_to_mpls_route() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        RouteMessage::parse(&RouteMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, RouteMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -216,10 +209,7 @@ fn test_mpls_route_to_ipv6() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        RouteMessage::parse(&RouteMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, RouteMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -279,10 +269,7 @@ fn test_mpls_route_relable_new_dst() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        RouteMessage::parse(&RouteMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, RouteMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -345,10 +332,7 @@ fn test_mpls_ttl_propagate() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        RouteMessage::parse(&RouteMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, RouteMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/route/tests/multipath.rs
+++ b/src/route/tests/multipath.rs
@@ -7,8 +7,7 @@ use netlink_packet_core::{Emitable, Parseable};
 use crate::{
     route::{
         flags::RouteFlags, RouteAttribute, RouteHeader, RouteMessage,
-        RouteMessageBuffer, RouteNextHop, RouteNextHopFlags, RouteProtocol,
-        RouteScope, RouteType,
+        RouteNextHop, RouteNextHopFlags, RouteProtocol, RouteScope, RouteType,
     },
     AddressFamily,
 };
@@ -73,10 +72,7 @@ fn test_route_multipath_two_nexthops() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        RouteMessage::parse(&RouteMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, RouteMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
     expected.emit(&mut buf);

--- a/src/route/tests/realm.rs
+++ b/src/route/tests/realm.rs
@@ -7,8 +7,7 @@ use netlink_packet_core::{Emitable, Parseable};
 use crate::{
     route::{
         flags::RouteFlags, RouteAttribute, RouteCacheInfo, RouteHeader,
-        RouteMessage, RouteMessageBuffer, RouteProtocol, RouteRealm,
-        RouteScope, RouteType,
+        RouteMessage, RouteProtocol, RouteRealm, RouteScope, RouteType,
     },
     AddressFamily,
 };
@@ -79,10 +78,7 @@ fn test_ipv4_route_realm() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        RouteMessage::parse(&RouteMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, RouteMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/route/tests/route_flags.rs
+++ b/src/route/tests/route_flags.rs
@@ -7,8 +7,7 @@ use netlink_packet_core::{Emitable, Parseable};
 use crate::{
     route::{
         flags::RouteFlags, RouteAttribute, RouteHeader, RouteMessage,
-        RouteMessageBuffer, RouteNextHopBuffer, RouteProtocol, RouteScope,
-        RouteType,
+        RouteNextHopBuffer, RouteProtocol, RouteScope, RouteType,
     },
     AddressFamily,
 };
@@ -44,10 +43,7 @@ fn test_ipv6_add_route_onlink() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        RouteMessage::parse(&RouteMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, RouteMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -65,7 +61,7 @@ fn test_next_hop_max_buffer_len() {
     // |-----|-----|-----|-----|-----|-----|-----|-----|-------|
     // |  length   |flags|hops |    Interface Index    |Payload|
     let buffer = [0xff, 0xff, 0, 0, 0, 0, 0, 0];
-    assert!(RouteNextHopBuffer::new_checked(buffer).is_err());
+    assert!(RouteNextHopBuffer::new_checked(&buffer).is_err());
 }
 
 #[test]
@@ -77,5 +73,5 @@ fn test_invalid_next_hop() {
         0, 0, 0, 0, // interface index
         0, 0, 0, 0, 0, 0, 0, 0, // payload
     ];
-    assert!(RouteNextHopBuffer::new_checked(buffer).is_err());
+    assert!(RouteNextHopBuffer::new_checked(&buffer).is_err());
 }

--- a/src/route/tests/seg6.rs
+++ b/src/route/tests/seg6.rs
@@ -8,8 +8,8 @@ use crate::{
     route::{
         seg6::{RouteSeg6IpTunnel, Seg6Mode},
         RouteAttribute, RouteFlags, RouteHeader, RouteLwEnCapType,
-        RouteLwTunnelEncap, RouteMessage, RouteMessageBuffer, RouteProtocol,
-        RouteScope, RouteType, Seg6Header,
+        RouteLwTunnelEncap, RouteMessage, RouteProtocol, RouteScope, RouteType,
+        Seg6Header,
     },
     AddressFamily,
 };
@@ -65,10 +65,7 @@ fn test_encap() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        RouteMessage::parse(&RouteMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, RouteMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -129,10 +126,7 @@ fn test_inline() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        RouteMessage::parse(&RouteMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, RouteMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/route/tests/uid.rs
+++ b/src/route/tests/uid.rs
@@ -7,7 +7,7 @@ use netlink_packet_core::{Emitable, Parseable};
 use crate::{
     route::{
         flags::RouteFlags, RouteAttribute, RouteCacheInfo, RouteHeader,
-        RouteMessage, RouteMessageBuffer, RouteProtocol, RouteScope, RouteType,
+        RouteMessage, RouteProtocol, RouteScope, RouteType,
     },
     AddressFamily,
 };
@@ -65,10 +65,7 @@ fn test_ipv4_route_uid() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        RouteMessage::parse(&RouteMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, RouteMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/route/tests/via.rs
+++ b/src/route/tests/via.rs
@@ -10,7 +10,7 @@ use netlink_packet_core::{Emitable, Parseable};
 use crate::{
     route::{
         flags::RouteFlags, RouteAttribute, RouteHeader, RouteMessage,
-        RouteMessageBuffer, RouteProtocol, RouteScope, RouteType, RouteVia,
+        RouteProtocol, RouteScope, RouteType, RouteVia,
     },
     AddressFamily,
 };
@@ -53,10 +53,7 @@ fn test_ipv4_route_via() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        RouteMessage::parse(&RouteMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, RouteMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/route/via.rs
+++ b/src/route/via.rs
@@ -2,7 +2,8 @@
 
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-use netlink_packet_core::{DecodeError, Emitable, Parseable};
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use crate::{
     ip::{parse_ipv4_addr, parse_ipv6_addr, IPV4_ADDR_LEN, IPV6_ADDR_LEN},
@@ -25,24 +26,35 @@ pub enum RouteVia {
 
 const RTVIA_LEN: usize = 2;
 
-buffer!(RouteViaBuffer(RTVIA_LEN) {
-    address_family: (u16, 0..2),
-    address: (slice, RTVIA_LEN..),
-});
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct RouteViaBuffer {
+    address_family: u16,
+}
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<RouteViaBuffer<&'a T>>
-    for RouteVia
-{
-    fn parse(buf: &RouteViaBuffer<&'a T>) -> Result<Self, DecodeError> {
-        let address_family: AddressFamily = (buf.address_family() as u8).into();
+impl RouteVia {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, address) =
+            RouteViaBuffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(payload.len(), RTVIA_LEN)
+            })?;
+        let address_family: AddressFamily = (raw.address_family as u8).into();
         Ok(match address_family {
-            AddressFamily::Inet => Self::Inet(parse_ipv4_addr(buf.address())?),
-            AddressFamily::Inet6 => {
-                Self::Inet6(parse_ipv6_addr(buf.address())?)
-            }
+            AddressFamily::Inet => Self::Inet(parse_ipv4_addr(address)?),
+            AddressFamily::Inet6 => Self::Inet6(parse_ipv6_addr(address)?),
             #[cfg(any(target_os = "linux", target_os = "fuchsia"))]
-            AddressFamily::Packet => Self::Packet(buf.address().to_vec()),
-            _ => Self::Other((address_family, buf.address().to_vec())),
+            AddressFamily::Packet => Self::Packet(address.to_vec()),
+            _ => Self::Other((address_family, address.to_vec())),
         })
     }
 }
@@ -59,7 +71,6 @@ impl Emitable for RouteVia {
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buffer = RouteViaBuffer::new(buffer);
         let (address_family, addr) = match self {
             Self::Inet(ip) => (AddressFamily::Inet, ip.octets().to_vec()),
             Self::Inet6(ip) => (AddressFamily::Inet6, ip.octets().to_vec()),
@@ -67,8 +78,11 @@ impl Emitable for RouteVia {
             Self::Packet(a) => (AddressFamily::Packet, a.to_vec()),
             Self::Other((f, a)) => (*f, a.to_vec()),
         };
-        buffer.set_address_family(u8::from(address_family).into());
-        buffer.address_mut().copy_from_slice(addr.as_slice());
+        let raw = RouteViaBuffer {
+            address_family: u16::from(u8::from(address_family)),
+        };
+        buffer[..RTVIA_LEN].copy_from_slice(raw.as_bytes());
+        buffer[RTVIA_LEN..].copy_from_slice(addr.as_slice());
     }
 }
 


### PR DESCRIPTION
Replace `buffer!()` macro with `zerocopy` crate, following the link
buffer conversion.

`VecRouteAttribute` is introduced to satisfy the orphan rule on
parametrized attribute parsing, and the `RTA_MULTIPATH` walk moves to
`parse_multipath_next_hops()` so `RouteNextHopBuffer` keeps private
fields.

Existing test cases cover the changes.