### PR TITLE
API break: address: use zerocopy for address buffer parsing

### DIFF
--- a/src/address/attribute.rs
+++ b/src/address/attribute.rs
@@ -4,10 +4,11 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use netlink_packet_core::{
     emit_i32, emit_u32, parse_i32, parse_string, parse_u32, parse_u8,
-    DecodeError, DefaultNla, Emitable, ErrorContext, Nla, NlaBuffer, Parseable,
+    DecodeError, DefaultNla, Emitable, ErrorContext, Nla, NlaBuffer,
+    NlasIterator, Parseable,
 };
 
-use crate::address::{AddressFlags, CacheInfo, CacheInfoBuffer};
+use crate::address::{AddressFlags, CacheInfo};
 
 const IFA_ADDRESS: u16 = 1;
 const IFA_LOCAL: u16 = 2;
@@ -176,7 +177,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                 }
             }
             IFA_CACHEINFO => Self::CacheInfo(
-                CacheInfo::parse(&CacheInfoBuffer::new(payload))
+                CacheInfo::parse(payload)
                     .context(format!("Invalid IFA_CACHEINFO {payload:?}"))?,
             ),
             IFA_MULTICAST => {
@@ -209,6 +210,18 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                     .context(format!("unknown NLA type {kind}"))?,
             ),
         })
+    }
+}
+
+pub(crate) struct VecAddressAttribute(pub(crate) Vec<AddressAttribute>);
+
+impl Parseable<[u8]> for VecAddressAttribute {
+    fn parse(buf: &[u8]) -> Result<Self, DecodeError> {
+        let mut attributes = vec![];
+        for nla_buf in NlasIterator::new(buf) {
+            attributes.push(AddressAttribute::parse(&nla_buf?)?);
+        }
+        Ok(Self(attributes))
     }
 }
 

--- a/src/address/cache_info.rs
+++ b/src/address/cache_info.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{DecodeError, Emitable, Parseable};
+use std::mem::size_of;
+
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
 #[non_exhaustive]
@@ -11,36 +14,61 @@ pub struct CacheInfo {
     pub tstamp: u32,
 }
 
-const ADDRESSS_CACHE_INFO_LEN: usize = 16;
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct CacheInfoBuffer {
+    ifa_preferred: u32,
+    ifa_valid: u32,
+    cstamp: u32,
+    tstamp: u32,
+}
 
-buffer!(CacheInfoBuffer(ADDRESSS_CACHE_INFO_LEN) {
-    ifa_preferred: (u32, 0..4),
-    ifa_valid: (u32, 4..8),
-    cstamp: (u32, 8..12),
-    tstamp: (u32, 12..16),
-});
-
-impl<T: AsRef<[u8]>> Parseable<CacheInfoBuffer<T>> for CacheInfo {
-    fn parse(buf: &CacheInfoBuffer<T>) -> Result<Self, DecodeError> {
-        Ok(CacheInfo {
-            ifa_preferred: buf.ifa_preferred(),
-            ifa_valid: buf.ifa_valid(),
-            cstamp: buf.cstamp(),
-            tstamp: buf.tstamp(),
+impl CacheInfo {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) =
+            CacheInfoBuffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    size_of::<CacheInfoBuffer>(),
+                )
+            })?;
+        Ok(Self {
+            ifa_preferred: raw.ifa_preferred,
+            ifa_valid: raw.ifa_valid,
+            cstamp: raw.cstamp,
+            tstamp: raw.tstamp,
         })
+    }
+}
+
+impl From<&CacheInfo> for CacheInfoBuffer {
+    fn from(value: &CacheInfo) -> Self {
+        Self {
+            ifa_preferred: value.ifa_preferred,
+            ifa_valid: value.ifa_valid,
+            cstamp: value.cstamp,
+            tstamp: value.tstamp,
+        }
     }
 }
 
 impl Emitable for CacheInfo {
     fn buffer_len(&self) -> usize {
-        ADDRESSS_CACHE_INFO_LEN
+        size_of::<CacheInfoBuffer>()
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buffer = CacheInfoBuffer::new(buffer);
-        buffer.set_ifa_preferred(self.ifa_preferred);
-        buffer.set_ifa_valid(self.ifa_valid);
-        buffer.set_cstamp(self.cstamp);
-        buffer.set_tstamp(self.tstamp);
+        let raw = CacheInfoBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/address/message.rs
+++ b/src/address/message.rs
@@ -1,31 +1,36 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{
-    DecodeError, Emitable, ErrorContext, NlaBuffer, NlasIterator, Parseable,
-};
+use netlink_packet_core::{DecodeError, Emitable, ErrorContext, Parseable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use crate::{
-    address::{AddressAttribute, AddressHeaderFlags, AddressScope},
+    address::{
+        attribute::VecAddressAttribute, AddressAttribute, AddressHeaderFlags,
+        AddressScope,
+    },
     AddressFamily,
 };
 
 const ADDRESS_HEADER_LEN: usize = 8;
 
-buffer!(AddressMessageBuffer(ADDRESS_HEADER_LEN) {
-    family: (u8, 0),
-    prefix_len: (u8, 1),
-    flags: (u8, 2),
-    scope: (u8, 3),
-    index: (u32, 4..ADDRESS_HEADER_LEN),
-    payload: (slice, ADDRESS_HEADER_LEN..),
-});
-
-impl<'a, T: AsRef<[u8]> + ?Sized> AddressMessageBuffer<&'a T> {
-    pub fn attributes(
-        &self,
-    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
-        NlasIterator::new(self.payload())
-    }
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct AddressMessageBuffer {
+    family: u8,
+    prefix_len: u8,
+    flags: u8,
+    scope: u8,
+    index: u32,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
@@ -44,18 +49,42 @@ pub struct AddressHeader {
     pub index: u32,
 }
 
+impl AddressHeader {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) =
+            AddressMessageBuffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(payload.len(), ADDRESS_HEADER_LEN)
+            })?;
+        Ok(Self {
+            family: raw.family.into(),
+            prefix_len: raw.prefix_len,
+            flags: AddressHeaderFlags::from_bits_retain(raw.flags),
+            scope: raw.scope.into(),
+            index: raw.index,
+        })
+    }
+}
+
+impl From<&AddressHeader> for AddressMessageBuffer {
+    fn from(header: &AddressHeader) -> Self {
+        Self {
+            family: header.family.into(),
+            prefix_len: header.prefix_len,
+            flags: header.flags.bits(),
+            scope: header.scope.into(),
+            index: header.index,
+        }
+    }
+}
+
 impl Emitable for AddressHeader {
     fn buffer_len(&self) -> usize {
         ADDRESS_HEADER_LEN
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut packet = AddressMessageBuffer::new(buffer);
-        packet.set_family(self.family.into());
-        packet.set_prefix_len(self.prefix_len);
-        packet.set_flags(self.flags.bits());
-        packet.set_scope(self.scope.into());
-        packet.set_index(self.index);
+        let raw = AddressMessageBuffer::from(self);
+        buffer[..ADDRESS_HEADER_LEN].copy_from_slice(raw.as_bytes());
     }
 }
 
@@ -72,39 +101,15 @@ impl Emitable for AddressMessage {
     }
 }
 
-impl<T: AsRef<[u8]>> Parseable<AddressMessageBuffer<T>> for AddressHeader {
-    fn parse(buf: &AddressMessageBuffer<T>) -> Result<Self, DecodeError> {
-        Ok(Self {
-            family: buf.family().into(),
-            prefix_len: buf.prefix_len(),
-            flags: AddressHeaderFlags::from_bits_retain(buf.flags()),
-            scope: buf.scope().into(),
-            index: buf.index(),
-        })
-    }
-}
-
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<AddressMessageBuffer<&'a T>>
-    for AddressMessage
-{
-    fn parse(buf: &AddressMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl Parseable<[u8]> for AddressMessage {
+    fn parse(buf: &[u8]) -> Result<Self, DecodeError> {
+        let header = AddressHeader::parse(buf)
+            .context("failed to parse address message header")?;
         Ok(AddressMessage {
-            header: AddressHeader::parse(buf)
-                .context("failed to parse address message header")?,
-            attributes: Vec::<AddressAttribute>::parse(buf)
-                .context("failed to parse address message NLAs")?,
+            header,
+            attributes: VecAddressAttribute::parse(&buf[ADDRESS_HEADER_LEN..])
+                .context("failed to parse address message NLAs")?
+                .0,
         })
-    }
-}
-
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<AddressMessageBuffer<&'a T>>
-    for Vec<AddressAttribute>
-{
-    fn parse(buf: &AddressMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
-        let mut attributes = vec![];
-        for nla_buf in buf.attributes() {
-            attributes.push(AddressAttribute::parse(&nla_buf?)?);
-        }
-        Ok(attributes)
     }
 }

--- a/src/address/tests/ipv4.rs
+++ b/src/address/tests/ipv4.rs
@@ -7,7 +7,7 @@ use netlink_packet_core::{Emitable, Parseable};
 use crate::{
     address::{
         AddressAttribute, AddressFlags, AddressHeader, AddressHeaderFlags,
-        AddressMessage, AddressMessageBuffer, AddressScope, CacheInfo,
+        AddressMessage, AddressScope, CacheInfo,
     },
     AddressFamily,
 };
@@ -46,10 +46,7 @@ fn test_ipv4_get_loopback_address() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        AddressMessage::parse(&AddressMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, AddressMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/address/tests/ipv6.rs
+++ b/src/address/tests/ipv6.rs
@@ -10,8 +10,7 @@ use netlink_packet_core::{Emitable, NlaBuffer, Parseable};
 use crate::{
     address::{
         AddressAttribute, AddressFlags, AddressHeader, AddressHeaderFlags,
-        AddressMessage, AddressMessageBuffer, AddressProtocol, AddressScope,
-        CacheInfo,
+        AddressMessage, AddressProtocol, AddressScope, CacheInfo,
     },
     AddressFamily,
 };
@@ -73,10 +72,7 @@ fn test_get_loopback_ipv6_addr() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        AddressMessage::parse(&AddressMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, AddressMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -119,10 +115,7 @@ fn test_get_ipv6_address_ra_protocol() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        AddressMessage::parse(&AddressMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, AddressMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -6,7 +6,7 @@ use netlink_packet_core::{
 };
 
 use crate::{
-    address::{AddressHeader, AddressMessage, AddressMessageBuffer},
+    address::{AddressHeader, AddressMessage},
     link::LinkMessage,
     neighbour::{NeighbourMessage, NeighbourMessageBuffer},
     neighbour_table::{NeighbourTableMessage, NeighbourTableMessageBuffer},
@@ -112,27 +112,21 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
 
             // Address messages
             RTM_NEWADDR | RTM_GETADDR | RTM_DELADDR => {
-                let msg = match AddressMessageBuffer::new_checked(&buf.inner())
-                {
-                    Ok(buf) => AddressMessage::parse(&buf)
-                        .context("invalid link message")?,
-                    // HACK: iproute2 sends invalid RTM_GETADDR message, where
-                    // the header is limited to the
-                    // interface family (1 byte) and 3 bytes of padding.
-                    Err(e) => {
-                        if buf.inner().len() == 4 && message_type == RTM_GETADDR
-                        {
-                            let mut msg = AddressMessage {
-                                header: AddressHeader::default(),
-                                attributes: vec![],
-                            };
-                            msg.header.family = buf.inner()[0].into();
-                            msg
-                        } else {
-                            return Err(e);
-                        }
-                    }
-                };
+                // HACK: iproute2 sends invalid RTM_GETADDR message, where
+                // the header is limited to the interface family (1 byte) and
+                // 3 bytes of padding.
+                let msg =
+                    if buf.inner().len() == 4 && message_type == RTM_GETADDR {
+                        let mut msg = AddressMessage {
+                            header: AddressHeader::default(),
+                            attributes: vec![],
+                        };
+                        msg.header.family = buf.inner()[0].into();
+                        msg
+                    } else {
+                        AddressMessage::parse(buf.inner())
+                            .context("invalid address message")?
+                    };
                 match message_type {
                     RTM_NEWADDR => RouteNetlinkMessage::NewAddress(msg),
                     RTM_GETADDR => RouteNetlinkMessage::GetAddress(msg),


### PR DESCRIPTION
Replace `buffer!()` macro with `zerocopy` crate, following the link
buffer conversion.

`VecAddressAttribute` is introduced to satisfy the orphan rule on
parsing `Vec<AddressAttribute>`, whose param-less `Parseable<[u8]>`
impl has no local type. This also fixes the `RTM_GETADDR` error
context wrongly reading "invalid link message".

Existing test cases cover the changes.