### PR TITLE
API break: tc: use zerocopy for tc buffer parsing

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -15,7 +15,7 @@ use crate::{
     route::{RouteHeader, RouteMessage},
     rule::{RuleMessage, RuleMessageBuffer},
     stats::{StatsMessage, StatsMessageBuffer},
-    tc::{TcActionMessage, TcActionMessageBuffer, TcMessage, TcMessageBuffer},
+    tc::{TcActionMessage, TcMessage},
 };
 
 const RTM_NEWLINK: u16 = 16;
@@ -237,10 +237,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
             | RTM_DELTFILTER | RTM_GETTFILTER | RTM_NEWCHAIN | RTM_DELCHAIN
             | RTM_GETCHAIN => {
                 let err = "invalid tc message";
-                let msg = TcMessage::parse(
-                    &TcMessageBuffer::new_checked(&buf.inner()).context(err)?,
-                )
-                .context(err)?;
+                let msg = TcMessage::parse(buf.inner()).context(err)?;
                 match message_type {
                     RTM_NEWQDISC => {
                         RouteNetlinkMessage::NewQueueDiscipline(msg)
@@ -272,11 +269,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
 
             RTM_NEWACTION | RTM_DELACTION | RTM_GETACTION => {
                 let err = "invalid tc action message";
-                let msg = TcActionMessage::parse(
-                    &TcActionMessageBuffer::new_checked(&buf.inner())
-                        .context(err)?,
-                )
-                .context(err)?;
+                let msg = TcActionMessage::parse(buf.inner()).context(err)?;
                 match message_type {
                     RTM_NEWACTION => RouteNetlinkMessage::NewTrafficAction(msg),
                     RTM_DELACTION => RouteNetlinkMessage::DelTrafficAction(msg),

--- a/src/tc/actions/action.rs
+++ b/src/tc/actions/action.rs
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: MIT
 
+use std::mem::size_of;
+
 use netlink_packet_core::{
     emit_u32, parse_string, parse_u32, DecodeError, DefaultNla, Emitable,
     ErrorContext, Nla, NlaBuffer, NlasIterator, Parseable,
     ParseableParametrized, NLA_F_NESTED,
 };
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use super::{
     TcActionMirror, TcActionMirrorOption, TcActionNat, TcActionNatOption,
@@ -419,41 +422,65 @@ pub struct TcActionGeneric {
 }
 
 impl TcActionGeneric {
-    pub(crate) const BUF_LEN: usize = 20;
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) = TcActionGenericBuffer::ref_from_prefix(payload)
+            .map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    size_of::<TcActionGenericBuffer>(),
+                )
+            })?;
+        Ok(Self {
+            index: raw.index,
+            capab: raw.capab,
+            action: raw.action.into(),
+            refcnt: raw.refcnt,
+            bindcnt: raw.bindcnt,
+        })
+    }
 }
 
-buffer!(TcActionGenericBuffer(TcActionGeneric::BUF_LEN) {
-    index: (u32, 0..4),
-    capab: (u32, 4..8),
-    action: (i32, 8..12),
-    refcnt: (i32, 12..16),
-    bindcnt: (i32, 16..20),
-});
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    Copy,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct TcActionGenericBuffer {
+    index: u32,
+    capab: u32,
+    action: i32,
+    refcnt: i32,
+    bindcnt: i32,
+}
+
+impl From<&TcActionGeneric> for TcActionGenericBuffer {
+    fn from(action: &TcActionGeneric) -> Self {
+        Self {
+            index: action.index,
+            capab: action.capab,
+            action: action.action.into(),
+            refcnt: action.refcnt,
+            bindcnt: action.bindcnt,
+        }
+    }
+}
 
 impl Emitable for TcActionGeneric {
     fn buffer_len(&self) -> usize {
-        Self::BUF_LEN
+        size_of::<TcActionGenericBuffer>()
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut packet = TcActionGenericBuffer::new(buffer);
-        packet.set_index(self.index);
-        packet.set_capab(self.capab);
-        packet.set_action(self.action.into());
-        packet.set_refcnt(self.refcnt);
-        packet.set_bindcnt(self.bindcnt);
-    }
-}
-
-impl<T: AsRef<[u8]>> Parseable<TcActionGenericBuffer<T>> for TcActionGeneric {
-    fn parse(buf: &TcActionGenericBuffer<T>) -> Result<Self, DecodeError> {
-        Ok(Self {
-            index: buf.index(),
-            capab: buf.capab(),
-            action: buf.action().into(),
-            refcnt: buf.refcnt(),
-            bindcnt: buf.bindcnt(),
-        })
+        let raw = TcActionGenericBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }
 
@@ -556,8 +583,6 @@ impl From<TcActionType> for i32 {
     }
 }
 
-pub const TC_TCF_BUF_LEN: usize = 32;
-
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub struct Tcf {
     pub install: u64,
@@ -567,34 +592,57 @@ pub struct Tcf {
 }
 
 // kernel struct `tcf_t`
-buffer!(TcfBuffer(TC_TCF_BUF_LEN) {
-    install: (u64, 0..8),
-    lastuse: (u64, 8..16),
-    expires: (u64, 16..24),
-    firstuse: (u64, 24..32),
-});
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct TcfBuffer {
+    install: u64,
+    lastuse: u64,
+    expires: u64,
+    firstuse: u64,
+}
 
-impl<T: AsRef<[u8]> + ?Sized> Parseable<TcfBuffer<&T>> for Tcf {
-    fn parse(buf: &TcfBuffer<&T>) -> Result<Self, DecodeError> {
+impl Tcf {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) = TcfBuffer::ref_from_prefix(payload).map_err(|_| {
+            DecodeError::buffer_too_small(payload.len(), size_of::<TcfBuffer>())
+        })?;
         Ok(Self {
-            install: buf.install(),
-            lastuse: buf.lastuse(),
-            expires: buf.expires(),
-            firstuse: buf.firstuse(),
+            install: raw.install,
+            lastuse: raw.lastuse,
+            expires: raw.expires,
+            firstuse: raw.firstuse,
         })
+    }
+}
+
+impl From<&Tcf> for TcfBuffer {
+    fn from(tcf: &Tcf) -> Self {
+        Self {
+            install: tcf.install,
+            lastuse: tcf.lastuse,
+            expires: tcf.expires,
+            firstuse: tcf.firstuse,
+        }
     }
 }
 
 impl Emitable for Tcf {
     fn buffer_len(&self) -> usize {
-        TC_TCF_BUF_LEN
+        size_of::<TcfBuffer>()
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut packet = TcfBuffer::new(buffer);
-        packet.set_install(self.install);
-        packet.set_lastuse(self.lastuse);
-        packet.set_expires(self.expires);
-        packet.set_firstuse(self.firstuse);
+        let raw = TcfBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/tc/actions/header.rs
+++ b/src/tc/actions/header.rs
@@ -1,27 +1,28 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{
-    DecodeError, Emitable, NlaBuffer, NlasIterator, Parseable,
-};
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use crate::AddressFamily;
 
-const TCA_HEADER_LEN: usize = 4;
+pub(crate) const TCA_HEADER_LEN: usize = 4;
 
-buffer!(TcActionMessageBuffer(TCA_HEADER_LEN) {
-    family: (u8, 0),
-    pad1: (u8, 1),
-    pad2: (u16, 2..TCA_HEADER_LEN),
-    payload: (slice, TCA_HEADER_LEN..),
-});
-
-impl<'a, T: AsRef<[u8]> + ?Sized> TcActionMessageBuffer<&'a T> {
-    /// Returns an iterator over the attributes of a `TcActionMessageBuffer`.
-    pub fn attributes(
-        &self,
-    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
-        NlasIterator::new(self.payload())
-    }
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct TcActionMessageBuffer {
+    family: u8,
+    pad1: u8,
+    pad2: u16,
 }
 
 /// Header for a traffic control action message.
@@ -31,23 +32,35 @@ pub struct TcActionMessageHeader {
     pub family: AddressFamily,
 }
 
+impl TcActionMessageHeader {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) = TcActionMessageBuffer::ref_from_prefix(payload)
+            .map_err(|_| {
+                DecodeError::buffer_too_small(payload.len(), TCA_HEADER_LEN)
+            })?;
+        Ok(Self {
+            family: raw.family.into(),
+        })
+    }
+}
+
+impl From<&TcActionMessageHeader> for TcActionMessageBuffer {
+    fn from(header: &TcActionMessageHeader) -> Self {
+        Self {
+            family: header.family.into(),
+            pad1: 0,
+            pad2: 0,
+        }
+    }
+}
+
 impl Emitable for TcActionMessageHeader {
     fn buffer_len(&self) -> usize {
         TCA_HEADER_LEN
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut packet = TcActionMessageBuffer::new(buffer);
-        packet.set_family(self.family.into());
-    }
-}
-
-impl<T: AsRef<[u8]>> Parseable<TcActionMessageBuffer<T>>
-    for TcActionMessageHeader
-{
-    fn parse(buf: &TcActionMessageBuffer<T>) -> Result<Self, DecodeError> {
-        Ok(TcActionMessageHeader {
-            family: buf.family().into(),
-        })
+        let raw = TcActionMessageBuffer::from(self);
+        buffer[..TCA_HEADER_LEN].copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/tc/actions/message.rs
+++ b/src/tc/actions/message.rs
@@ -6,7 +6,7 @@ use netlink_packet_core::{
 };
 
 use crate::tc::{
-    actions::{TcActionMessageBuffer, TcActionMessageHeader},
+    actions::{header::TCA_HEADER_LEN, TcActionMessageHeader},
     TcAction,
 };
 
@@ -228,20 +228,15 @@ impl Nla for TcActionMessageAttribute {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + 'a + ?Sized> Parseable<TcActionMessageBuffer<&'a T>>
-    for TcActionMessage
-{
-    fn parse(buf: &TcActionMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
-        let attrs: Result<Vec<_>, DecodeError> = buf
-            .attributes()
+impl Parseable<[u8]> for TcActionMessage {
+    fn parse(buf: &[u8]) -> Result<Self, DecodeError> {
+        let header = TcActionMessageHeader::parse(buf)
+            .context("failed to parse tc message header")?;
+        let attributes = NlasIterator::new(&buf[TCA_HEADER_LEN..])
             .map(|attr| TcActionMessageAttribute::parse(&attr?))
-            .collect::<Result<Vec<_>, _>>();
-
-        Ok(Self {
-            header: TcActionMessageHeader::parse(buf)
-                .context("failed to parse tc message header")?,
-            attributes: attrs?,
-        })
+            .collect::<Result<Vec<_>, _>>()
+            .context("failed to parse tc action message NLAs")?;
+        Ok(Self { header, attributes })
     }
 }
 

--- a/src/tc/actions/mirror.rs
+++ b/src/tc/actions/mirror.rs
@@ -6,13 +6,14 @@
 /// redirecting (stealing) the packet it receives. Mirroring is what
 /// is sometimes referred to as Switch Port Analyzer (SPAN) and is
 /// commonly used to analyze and/or debug flows.
+use std::mem::size_of;
+
 use netlink_packet_core::{
     DecodeError, DefaultNla, Emitable, Nla, NlaBuffer, Parseable,
 };
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
-use super::{
-    TcActionGeneric, TcActionGenericBuffer, Tcf, TcfBuffer, TC_TCF_BUF_LEN,
-};
+use super::{TcActionGeneric, TcActionGenericBuffer, Tcf, TcfBuffer};
 
 /// Traffic control action used to mirror or redirect packets.
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -41,8 +42,8 @@ pub enum TcActionMirrorOption {
 impl Nla for TcActionMirrorOption {
     fn value_len(&self) -> usize {
         match self {
-            Self::Tm(_) => TC_TCF_BUF_LEN,
-            Self::Parms(_) => TC_MIRRED_BUF_LEN,
+            Self::Tm(_) => size_of::<TcfBuffer>(),
+            Self::Parms(_) => size_of::<TcMirrorBuffer>(),
             Self::Other(attr) => attr.value_len(),
         }
     }
@@ -69,18 +70,12 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();
         Ok(match buf.kind() {
-            TCA_MIRRED_TM => {
-                Self::Tm(Tcf::parse(&TcfBuffer::new_checked(payload)?)?)
-            }
-            TCA_MIRRED_PARMS => Self::Parms(TcMirror::parse(
-                &TcMirrorBuffer::new_checked(payload)?,
-            )?),
+            TCA_MIRRED_TM => Self::Tm(Tcf::parse(payload)?),
+            TCA_MIRRED_PARMS => Self::Parms(TcMirror::parse(payload)?),
             _ => Self::Other(DefaultNla::parse(buf)?),
         })
     }
 }
-
-const TC_MIRRED_BUF_LEN: usize = TcActionGeneric::BUF_LEN + 8;
 
 /// Parameters for the mirred action.
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
@@ -95,34 +90,61 @@ pub struct TcMirror {
 }
 
 // kernel struct `tc_mirred`
-buffer!(TcMirrorBuffer(TC_MIRRED_BUF_LEN) {
-    generic: (slice, 0..20),
-    eaction: (i32, 20..24),
-    ifindex: (u32, 24..28),
-});
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct TcMirrorBuffer {
+    generic: TcActionGenericBuffer,
+    eaction: i32,
+    ifindex: u32,
+}
 
-impl Emitable for TcMirror {
-    fn buffer_len(&self) -> usize {
-        TC_MIRRED_BUF_LEN
-    }
-
-    fn emit(&self, buffer: &mut [u8]) {
-        let mut packet = TcMirrorBuffer::new(buffer);
-        self.generic.emit(packet.generic_mut());
-        packet.set_eaction(self.eaction.into());
-        packet.set_ifindex(self.ifindex);
+impl TcMirror {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) =
+            TcMirrorBuffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    size_of::<TcMirrorBuffer>(),
+                )
+            })?;
+        Ok(Self {
+            generic: TcActionGeneric::parse(
+                &payload[..size_of::<TcActionGenericBuffer>()],
+            )?,
+            eaction: raw.eaction.into(),
+            ifindex: raw.ifindex,
+        })
     }
 }
 
-impl<T: AsRef<[u8]> + ?Sized> Parseable<TcMirrorBuffer<&T>> for TcMirror {
-    fn parse(buf: &TcMirrorBuffer<&T>) -> Result<Self, DecodeError> {
-        Ok(Self {
-            generic: TcActionGeneric::parse(&TcActionGenericBuffer::new(
-                buf.generic(),
-            ))?,
-            eaction: buf.eaction().into(),
-            ifindex: buf.ifindex(),
-        })
+impl From<&TcMirror> for TcMirrorBuffer {
+    fn from(mirror: &TcMirror) -> Self {
+        Self {
+            generic: TcActionGenericBuffer::from(&mirror.generic),
+            eaction: mirror.eaction.into(),
+            ifindex: mirror.ifindex,
+        }
+    }
+}
+
+impl Emitable for TcMirror {
+    fn buffer_len(&self) -> usize {
+        size_of::<TcMirrorBuffer>()
+    }
+
+    fn emit(&self, buffer: &mut [u8]) {
+        let raw = TcMirrorBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }
 

--- a/src/tc/actions/mod.rs
+++ b/src/tc/actions/mod.rs
@@ -5,7 +5,7 @@ pub use nat_flag::TcNatFlags;
 pub use self::{
     action::{
         TcAction, TcActionAttribute, TcActionGeneric, TcActionGenericBuffer,
-        TcActionOption, TcActionType, Tcf, TcfBuffer, TC_TCF_BUF_LEN,
+        TcActionOption, TcActionType, Tcf, TcfBuffer,
     },
     header::{TcActionMessageBuffer, TcActionMessageHeader},
     message::{

--- a/src/tc/actions/nat.rs
+++ b/src/tc/actions/nat.rs
@@ -3,15 +3,17 @@
 /// Nat action
 ///
 /// The nat action maps one IP prefix to another
+use std::mem::size_of;
 use std::net::Ipv4Addr;
 
 use netlink_packet_core::{
     DecodeError, DefaultNla, Emitable, Nla, NlaBuffer, Parseable,
 };
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use super::{
     nat_flag::TcNatFlags, TcActionGeneric, TcActionGenericBuffer, Tcf,
-    TcfBuffer, TC_TCF_BUF_LEN,
+    TcfBuffer,
 };
 
 const TCA_NAT_PARMS: u16 = 1;
@@ -41,7 +43,7 @@ pub enum TcActionNatOption {
 impl Nla for TcActionNatOption {
     fn value_len(&self) -> usize {
         match self {
-            Self::Tm(_) => TC_TCF_BUF_LEN,
+            Self::Tm(_) => size_of::<TcfBuffer>(),
             Self::Parms(v) => v.buffer_len(),
             Self::Other(attr) => attr.value_len(),
         }
@@ -69,18 +71,12 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();
         Ok(match buf.kind() {
-            TCA_NAT_TM => {
-                Self::Tm(Tcf::parse(&TcfBuffer::new_checked(payload)?)?)
-            }
-            TCA_NAT_PARMS => {
-                Self::Parms(TcNat::parse(&TcNatBuffer::new_checked(payload)?)?)
-            }
+            TCA_NAT_TM => Self::Tm(Tcf::parse(payload)?),
+            TCA_NAT_PARMS => Self::Parms(TcNat::parse(payload)?),
             _ => Self::Other(DefaultNla::parse(buf)?),
         })
     }
 }
-
-const TC_NAT_BUF_LEN: usize = TcActionGeneric::BUF_LEN + 16;
 
 /// Network address translation action.
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -110,54 +106,65 @@ impl Default for TcNat {
     }
 }
 
-buffer!(TcNatBuffer(TC_NAT_BUF_LEN) {
-    generic: (slice, 0..TcActionGeneric::BUF_LEN),
-    old_addr: (slice, TcActionGeneric::BUF_LEN..(TcActionGeneric::BUF_LEN+4)),
-    new_addr: (slice, (TcActionGeneric::BUF_LEN+4)..(TcActionGeneric::BUF_LEN+8)),
-    mask: (slice, (TcActionGeneric::BUF_LEN+8)..(TcActionGeneric::BUF_LEN+12)),
-    flags: (u32, (TcActionGeneric::BUF_LEN+12)..TC_NAT_BUF_LEN),
-});
-
-impl Emitable for TcNat {
-    fn buffer_len(&self) -> usize {
-        TC_NAT_BUF_LEN
-    }
-
-    fn emit(&self, buffer: &mut [u8]) {
-        let mut packet = TcNatBuffer::new(buffer);
-        self.generic.emit(packet.generic_mut());
-        packet
-            .old_addr_mut()
-            .copy_from_slice(&self.old_addr.octets());
-        packet
-            .new_addr_mut()
-            .copy_from_slice(&self.new_addr.octets());
-        packet.mask_mut().copy_from_slice(&self.mask.octets());
-        packet.set_flags(self.flags.bits());
-    }
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct TcNatBuffer {
+    generic: TcActionGenericBuffer,
+    old_addr: [u8; 4],
+    new_addr: [u8; 4],
+    mask: [u8; 4],
+    flags: u32,
 }
 
-impl<T: AsRef<[u8]> + ?Sized> Parseable<TcNatBuffer<&T>> for TcNat {
-    fn parse(buf: &TcNatBuffer<&T>) -> Result<Self, DecodeError> {
+impl TcNat {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) = TcNatBuffer::ref_from_prefix(payload).map_err(|_| {
+            DecodeError::buffer_too_small(
+                payload.len(),
+                size_of::<TcNatBuffer>(),
+            )
+        })?;
         Ok(Self {
-            generic: TcActionGeneric::parse(&TcActionGenericBuffer::new(
-                buf.generic(),
-            ))?,
-            old_addr: parse_ipv4(buf.old_addr())?,
-            new_addr: parse_ipv4(buf.new_addr())?,
-            mask: parse_ipv4(buf.mask())?,
-            flags: TcNatFlags::from_bits_retain(buf.flags()),
+            generic: TcActionGeneric::parse(
+                &payload[..size_of::<TcActionGenericBuffer>()],
+            )?,
+            old_addr: Ipv4Addr::from(raw.old_addr),
+            new_addr: Ipv4Addr::from(raw.new_addr),
+            mask: Ipv4Addr::from(raw.mask),
+            flags: TcNatFlags::from_bits_retain(raw.flags),
         })
     }
 }
 
-fn parse_ipv4(data: &[u8]) -> Result<Ipv4Addr, DecodeError> {
-    if data.len() != 4 {
-        Err(DecodeError::from(format!(
-            "Invalid length of IPv4 Address, expecting 4 bytes, but got \
-             {data:?}"
-        )))
-    } else {
-        Ok(Ipv4Addr::new(data[0], data[1], data[2], data[3]))
+impl From<&TcNat> for TcNatBuffer {
+    fn from(nat: &TcNat) -> Self {
+        Self {
+            generic: TcActionGenericBuffer::from(&nat.generic),
+            old_addr: nat.old_addr.octets(),
+            new_addr: nat.new_addr.octets(),
+            mask: nat.mask.octets(),
+            flags: nat.flags.bits(),
+        }
+    }
+}
+
+impl Emitable for TcNat {
+    fn buffer_len(&self) -> usize {
+        size_of::<TcNatBuffer>()
+    }
+
+    fn emit(&self, buffer: &mut [u8]) {
+        let raw = TcNatBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/tc/actions/tests/action.rs
+++ b/src/tc/actions/tests/action.rs
@@ -3,8 +3,8 @@
 use netlink_packet_core::{Emitable, NlaBuffer, Parseable};
 
 use crate::tc::{
-    TcAction, TcActionAttribute, TcActionGeneric, TcActionGenericBuffer,
-    TcActionType, TcStats2, TcStatsBasic,
+    TcAction, TcActionAttribute, TcActionGeneric, TcActionType, TcStats2,
+    TcStatsBasic,
 };
 
 #[test]
@@ -18,10 +18,7 @@ fn tc_action_generic_parse_back() {
     };
     let mut buffer = vec![0; orig.buffer_len()];
     orig.emit(&mut buffer);
-    let parsed = TcActionGeneric::parse(
-        &TcActionGenericBuffer::new_checked(buffer).unwrap(),
-    )
-    .unwrap();
+    let parsed = TcActionGeneric::parse(&buffer).unwrap();
     assert_eq!(orig, parsed);
 }
 

--- a/src/tc/actions/tests/header.rs
+++ b/src/tc/actions/tests/header.rs
@@ -1,11 +1,8 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{Emitable, Parseable};
+use netlink_packet_core::Emitable;
 
-use crate::{
-    tc::actions::{TcActionMessageBuffer, TcActionMessageHeader},
-    AddressFamily,
-};
+use crate::{tc::actions::TcActionMessageHeader, AddressFamily};
 
 #[test]
 fn tc_action_message_header_parse_back_all_known_families() {
@@ -62,10 +59,7 @@ fn tc_action_message_header_parse_back_all_known_families() {
         let orig = TcActionMessageHeader { family };
         let mut buffer = vec![0; orig.buffer_len()];
         orig.emit(&mut buffer);
-        let parsed = TcActionMessageHeader::parse(
-            &TcActionMessageBuffer::new_checked(&buffer).unwrap(),
-        )
-        .unwrap();
+        let parsed = TcActionMessageHeader::parse(&buffer).unwrap();
         assert_eq!(orig, parsed);
     }
 }
@@ -77,9 +71,6 @@ fn tc_action_message_header_parse_back_other() {
     };
     let mut buffer = vec![0; orig.buffer_len()];
     orig.emit(&mut buffer);
-    let parsed = TcActionMessageHeader::parse(
-        &TcActionMessageBuffer::new_checked(&buffer).unwrap(),
-    )
-    .unwrap();
+    let parsed = TcActionMessageHeader::parse(&buffer).unwrap();
     assert_eq!(orig, parsed);
 }

--- a/src/tc/actions/tests/message.rs
+++ b/src/tc/actions/tests/message.rs
@@ -12,7 +12,7 @@ use crate::{
                 },
                 TcActionMessageFlags, TcActionMessageFlagsWithSelector,
             },
-            TcActionMessageBuffer, TcActionMessageHeader,
+            TcActionMessageHeader,
         },
         TcAction,
         TcActionAttribute::{Cookie, Index, Kind},
@@ -30,7 +30,7 @@ mod mirror {
                     TcActionMessage,
                     TcActionMessageAttribute::{Actions, RootCount},
                 },
-                TcActionMessageBuffer, TcActionMessageHeader,
+                TcActionMessageHeader,
             },
             TcAction,
             TcActionAttribute::{InHwCount, Kind, Options, Other, Stats},
@@ -144,10 +144,7 @@ mod mirror {
             }])],
         };
 
-        let parsed = TcActionMessage::parse(
-            &TcActionMessageBuffer::new_checked(&message::CREATE1).unwrap(),
-        )
-        .unwrap();
+        let parsed = TcActionMessage::parse(message::CREATE1).unwrap();
         assert_eq!(parsed, expected);
     }
 
@@ -177,10 +174,7 @@ mod mirror {
         };
 
         let buf = message::CREATE2;
-        let parsed = TcActionMessage::parse(
-            &TcActionMessageBuffer::new_checked(&buf).unwrap(),
-        )
-        .unwrap();
+        let parsed = TcActionMessage::parse(buf).unwrap();
         assert_eq!(parsed, expected);
     }
 
@@ -291,10 +285,7 @@ mod mirror {
                 ]),
             ],
         };
-        let parsed = TcActionMessage::parse(
-            &TcActionMessageBuffer::new_checked(&message::LIST).unwrap(),
-        )
-        .unwrap();
+        let parsed = TcActionMessage::parse(message::LIST).unwrap();
         assert_eq!(parsed, expected);
     }
 }
@@ -384,10 +375,7 @@ fn tc_action_message_parse_back_default() {
     let orig = TcActionMessage::default();
     let mut buffer = vec![0; orig.buffer_len()];
     orig.emit(&mut buffer);
-    let parsed = TcActionMessage::parse(
-        &TcActionMessageBuffer::new_checked(buffer.as_slice()).unwrap(),
-    )
-    .unwrap();
+    let parsed = TcActionMessage::parse(buffer.as_slice()).unwrap();
     assert_eq!(orig, parsed);
 }
 
@@ -413,10 +401,7 @@ fn tc_action_message_parse_back_example_value() {
     };
     let mut buffer = vec![0; orig.buffer_len()];
     orig.emit(&mut buffer);
-    let parsed = TcActionMessage::parse(
-        &TcActionMessageBuffer::new_checked(buffer.as_slice()).unwrap(),
-    )
-    .unwrap();
+    let parsed = TcActionMessage::parse(buffer.as_slice()).unwrap();
     assert_eq!(orig, parsed);
 }
 

--- a/src/tc/actions/tests/mirror.rs
+++ b/src/tc/actions/tests/mirror.rs
@@ -3,10 +3,9 @@
 use netlink_packet_core::{Emitable, NlaBuffer, Parseable};
 
 use crate::tc::{
-    TcAction, TcActionAttribute, TcActionGeneric, TcActionGenericBuffer,
-    TcActionMirrorOption, TcActionOption, TcActionType, TcMirror,
-    TcMirrorActionType, TcMirrorBuffer, TcStats2, TcStatsBasic, TcStatsQueue,
-    Tcf,
+    TcAction, TcActionAttribute, TcActionGeneric, TcActionMirrorOption,
+    TcActionOption, TcActionType, TcMirror, TcMirrorActionType, TcStats2,
+    TcStatsBasic, TcStatsQueue, Tcf,
 };
 
 #[test]
@@ -20,10 +19,7 @@ fn tc_action_generic_parse_back() {
     };
     let mut buffer = vec![0; orig.buffer_len()];
     orig.emit(&mut buffer);
-    let parsed = TcActionGeneric::parse(
-        &TcActionGenericBuffer::new_checked(buffer).unwrap(),
-    )
-    .unwrap();
+    let parsed = TcActionGeneric::parse(&buffer).unwrap();
     assert_eq!(orig, parsed);
 }
 
@@ -36,10 +32,7 @@ fn tc_mirror_default_parse_back() {
     };
     let mut buffer = vec![0; orig.buffer_len()];
     orig.emit(&mut buffer);
-    let parsed = TcMirror::parse(
-        &TcMirrorBuffer::new_checked(buffer.as_slice()).unwrap(),
-    )
-    .unwrap();
+    let parsed = TcMirror::parse(buffer.as_slice()).unwrap();
     assert_eq!(orig, parsed);
 }
 
@@ -58,10 +51,7 @@ fn tc_mirror_example_parse_back() {
     };
     let mut buffer = vec![0; orig.buffer_len()];
     orig.emit(&mut buffer);
-    let parsed = TcMirror::parse(
-        &TcMirrorBuffer::new_checked(buffer.as_slice()).unwrap(),
-    )
-    .unwrap();
+    let parsed = TcMirror::parse(buffer.as_slice()).unwrap();
     assert_eq!(orig, parsed);
 }
 

--- a/src/tc/actions/tests/nat.rs
+++ b/src/tc/actions/tests/nat.rs
@@ -8,7 +8,7 @@ use crate::{
     tc::{
         actions::{
             message::{TcActionMessage, TcActionMessageAttribute::Actions},
-            TcActionMessageBuffer, TcActionMessageHeader,
+            TcActionMessageHeader,
         },
         TcAction,
         TcActionAttribute::{InHwCount, Kind, Options, Stats},
@@ -66,10 +66,7 @@ fn tc_action_message_nat_example1() -> TcActionMessage {
 #[test]
 fn parse_tc_action_nat_example1() {
     let buf = TC_ACTION_NAT_EXAMPLE1;
-    let parsed = TcActionMessage::parse(
-        &TcActionMessageBuffer::new_checked(&buf).unwrap(),
-    )
-    .unwrap();
+    let parsed = TcActionMessage::parse(buf).unwrap();
     assert_eq!(parsed, tc_action_message_nat_example1());
 }
 
@@ -125,10 +122,7 @@ fn tc_action_message_nat_example2() -> TcActionMessage {
 #[test]
 fn parse_tc_action_nat_example2() {
     let buf = TC_ACTION_NAT_EXAMPLE2;
-    let parsed = TcActionMessage::parse(
-        &TcActionMessageBuffer::new_checked(&buf).unwrap(),
-    )
-    .unwrap();
+    let parsed = TcActionMessage::parse(buf).unwrap();
     assert_eq!(parsed, tc_action_message_nat_example2());
 }
 
@@ -184,10 +178,7 @@ fn tc_action_message_nat_example3() -> TcActionMessage {
 #[test]
 fn parse_tc_action_nat_example3() {
     let buf = TC_ACTION_NAT_EXAMPLE3;
-    let parsed = TcActionMessage::parse(
-        &TcActionMessageBuffer::new_checked(&buf).unwrap(),
-    )
-    .unwrap();
+    let parsed = TcActionMessage::parse(buf).unwrap();
     assert_eq!(parsed, tc_action_message_nat_example3());
 }
 
@@ -339,10 +330,7 @@ fn test_get_filter_nat() {
         }])],
     };
 
-    assert_eq!(
-        expected,
-        TcActionMessage::parse(&TcActionMessageBuffer::new(&RAW)).unwrap()
-    );
+    assert_eq!(expected, TcActionMessage::parse(RAW).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/tc/actions/tunnel_key.rs
+++ b/src/tc/actions/tunnel_key.rs
@@ -1,15 +1,17 @@
 // SPDX-License-Identifier: MIT
 
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::{
+    mem::size_of,
+    net::{Ipv4Addr, Ipv6Addr},
+};
 
 use netlink_packet_core::{
     emit_u16_be, emit_u32_be, parse_u16_be, parse_u32_be, parse_u8,
     DecodeError, DefaultNla, Emitable, ErrorContext, Nla, NlaBuffer, Parseable,
 };
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
-use super::{
-    TcActionGeneric, TcActionGenericBuffer, Tcf, TcfBuffer, TC_TCF_BUF_LEN,
-};
+use super::{TcActionGeneric, TcActionGenericBuffer, Tcf, TcfBuffer};
 /// set tunnel key
 ///
 /// The set_tunnel action allows to set tunnel encap applied
@@ -58,8 +60,8 @@ pub enum TcActionTunnelKeyOption {
 impl Nla for TcActionTunnelKeyOption {
     fn value_len(&self) -> usize {
         match self {
-            Self::Tm(_) => TC_TCF_BUF_LEN,
-            Self::Parms(_) => TC_TUNNEL_KEY_BUF_LEN,
+            Self::Tm(_) => size_of::<TcfBuffer>(),
+            Self::Parms(_) => size_of::<TcTunnelKeyBuffer>(),
             Self::EncIpv4Src(_) | Self::EncIpv4Dst(_) => 4,
             Self::EncIpv6Src(_) | Self::EncIpv6Dst(_) => 16,
             Self::EncKeyId(_) => 4,
@@ -112,12 +114,8 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
         let payload = buf.value();
         Ok(match buf.kind() {
-            TCA_TUNNEL_KEY_TM => {
-                Self::Tm(Tcf::parse(&TcfBuffer::new_checked(payload)?)?)
-            }
-            TCA_TUNNEL_KEY_PARMS => Self::Parms(TcTunnelKey::parse(
-                &TcTunnelKeyBuffer::new_checked(payload)?,
-            )?),
+            TCA_TUNNEL_KEY_TM => Self::Tm(Tcf::parse(payload)?),
+            TCA_TUNNEL_KEY_PARMS => Self::Parms(TcTunnelKey::parse(payload)?),
             TCA_TUNNEL_KEY_ENC_IPV4_SRC => Self::EncIpv4Src(
                 parse_ipv4_addr(payload)
                     .context("failed to parse TCA_TUNNEL_KEY_ENC_IPV4_SRC")?,
@@ -160,8 +158,6 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
     }
 }
 
-const TC_TUNNEL_KEY_BUF_LEN: usize = TcActionGeneric::BUF_LEN + 4;
-
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub struct TcTunnelKey {
     pub generic: TcActionGeneric,
@@ -169,30 +165,57 @@ pub struct TcTunnelKey {
 }
 
 // kernel struct `tc_tunnel_key`
-buffer!(TcTunnelKeyBuffer(TC_TUNNEL_KEY_BUF_LEN) {
-    generic: (slice, 0..20),
-    t_action: (i32, 20..24),
-});
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct TcTunnelKeyBuffer {
+    generic: TcActionGenericBuffer,
+    t_action: i32,
+}
 
-impl Emitable for TcTunnelKey {
-    fn buffer_len(&self) -> usize {
-        TC_TUNNEL_KEY_BUF_LEN
-    }
-
-    fn emit(&self, buffer: &mut [u8]) {
-        let mut packet = TcTunnelKeyBuffer::new(buffer);
-        self.generic.emit(packet.generic_mut());
-        packet.set_t_action(self.t_action);
+impl TcTunnelKey {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) =
+            TcTunnelKeyBuffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    size_of::<TcTunnelKeyBuffer>(),
+                )
+            })?;
+        Ok(Self {
+            generic: TcActionGeneric::parse(
+                &payload[..size_of::<TcActionGenericBuffer>()],
+            )?,
+            t_action: raw.t_action,
+        })
     }
 }
 
-impl<T: AsRef<[u8]> + ?Sized> Parseable<TcTunnelKeyBuffer<&T>> for TcTunnelKey {
-    fn parse(buf: &TcTunnelKeyBuffer<&T>) -> Result<Self, DecodeError> {
-        Ok(Self {
-            generic: TcActionGeneric::parse(&TcActionGenericBuffer::new(
-                buf.generic(),
-            ))?,
-            t_action: buf.t_action(),
-        })
+impl From<&TcTunnelKey> for TcTunnelKeyBuffer {
+    fn from(key: &TcTunnelKey) -> Self {
+        Self {
+            generic: TcActionGenericBuffer::from(&key.generic),
+            t_action: key.t_action,
+        }
+    }
+}
+
+impl Emitable for TcTunnelKey {
+    fn buffer_len(&self) -> usize {
+        size_of::<TcTunnelKeyBuffer>()
+    }
+
+    fn emit(&self, buffer: &mut [u8]) {
+        let raw = TcTunnelKeyBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/tc/attribute.rs
+++ b/src/tc/attribute.rs
@@ -6,9 +6,7 @@ use netlink_packet_core::{
     ParseableParametrized,
 };
 
-use super::{
-    TcOption, TcStats, TcStats2, TcStatsBuffer, TcXstats, VecTcOption,
-};
+use super::{TcOption, TcStats, TcStats2, TcXstats, VecTcOption};
 
 const TCA_KIND: u16 = 1;
 const TCA_OPTIONS: u16 = 2;
@@ -121,11 +119,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> ParseableParametrized<NlaBuffer<&'a T>, &str>
                     .0,
             ),
             TCA_STATS => TcAttribute::Stats(
-                TcStats::parse(
-                    &TcStatsBuffer::new_checked(payload)
-                        .context("invalid TCA_STATS")?,
-                )
-                .context("failed to parse TCA_STATS")?,
+                TcStats::parse(payload).context("failed to parse TCA_STATS")?,
             ),
             TCA_XSTATS => TcAttribute::Xstats(
                 TcXstats::parse_with_param(buf, kind)
@@ -155,5 +149,24 @@ impl<'a, T: AsRef<[u8]> + ?Sized> ParseableParametrized<NlaBuffer<&'a T>, &str>
                 DefaultNla::parse(buf).context("failed to parse tc nla")?,
             ),
         })
+    }
+}
+
+pub(crate) struct VecTcAttribute(pub(crate) Vec<TcAttribute>);
+
+impl Parseable<[u8]> for VecTcAttribute {
+    fn parse(buf: &[u8]) -> Result<Self, DecodeError> {
+        let mut attributes = vec![];
+        let mut kind = String::new();
+
+        for nla_buf in NlasIterator::new(buf) {
+            let attribute =
+                TcAttribute::parse_with_param(&nla_buf?, kind.as_str())?;
+            if let TcAttribute::Kind(s) = &attribute {
+                kind = s.to_string();
+            }
+            attributes.push(attribute)
+        }
+        Ok(Self(attributes))
     }
 }

--- a/src/tc/filters/cls_u32.rs
+++ b/src/tc/filters/cls_u32.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 
+use std::mem::size_of;
+
 use netlink_packet_core::ErrorContext;
 /// U32 filter
 ///
@@ -12,12 +14,10 @@ use netlink_packet_core::{
     emit_u32, parse_u32, DecodeError, Emitable, Parseable,
     {DefaultNla, Nla, NlaBuffer, NlasIterator},
 };
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use super::u32_flags::{TcU32OptionFlags, TcU32SelectorFlags};
 use crate::tc::{TcAction, TcHandle};
-
-const TC_U32_SEL_BUF_LEN: usize = 16;
-const TC_U32_KEY_BUF_LEN: usize = 16;
 
 const TCA_U32_CLASSID: u16 = 1;
 const TCA_U32_HASH: u16 = 2;
@@ -130,11 +130,8 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                     .context("failed to parse TCA_U32_DIVISOR")?,
             ),
             TCA_U32_SEL => Self::Selector(
-                TcU32Selector::parse(
-                    &TcU32SelectorBuffer::new_checked(payload)
-                        .context("invalid TCA_U32_SEL")?,
-                )
-                .context("failed to parse TCA_U32_SEL")?,
+                TcU32Selector::parse(payload)
+                    .context("failed to parse TCA_U32_SEL")?,
             ),
             TCA_U32_POLICE => Self::Police(payload.to_vec()),
             TCA_U32_ACT => {
@@ -175,102 +172,119 @@ pub struct TcU32Selector {
     pub keys: Vec<TcU32Key>,
 }
 
-buffer!(TcU32SelectorBuffer {
-    flags: (u8, 0),
-    offshift: (u8, 1),
-    nkeys: (u8, 2),
-    //pad: (u8, 3),
-    offmask: (u16, 4..6),
-    off: (u16, 6..8),
-    offoff: (u16, 8..10),
-    hoff: (u16, 10..12),
-    hmask: (u32, 12..TC_U32_SEL_BUF_LEN),
-    keys: (slice, TC_U32_SEL_BUF_LEN..),
-});
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct TcU32SelectorBuffer {
+    flags: u8,
+    offshift: u8,
+    nkeys: u8,
+    _pad: u8,
+    offmask: u16,
+    off: u16,
+    offoff: u16,
+    hoff: u16,
+    hmask: u32,
+}
 
-impl<T: AsRef<[u8]>> TcU32SelectorBuffer<T> {
-    pub fn new_checked(buffer: T) -> Result<Self, DecodeError> {
-        let packet = Self::new(buffer);
-        packet.check_buffer_length()?;
-        Ok(packet)
-    }
-
-    fn check_buffer_length(&self) -> Result<(), DecodeError> {
-        let len = self.buffer.as_ref().len();
-        if len < TC_U32_SEL_BUF_LEN {
+impl TcU32SelectorBuffer {
+    pub fn new_checked(buffer: &[u8]) -> Result<&Self, DecodeError> {
+        let len = buffer.len();
+        let sel_len = size_of::<Self>();
+        if len < sel_len {
             return Err(format!(
-                "invalid TcU32SelectorBuffer: length {len} < \
-                 {TC_U32_SEL_BUF_LEN}"
+                "invalid TcU32SelectorBuffer: length {len} < {sel_len}"
             )
             .into());
         }
+        let raw = Self::ref_from_prefix(buffer)
+            .map_err(|_| DecodeError::buffer_too_small(len, sel_len))?
+            .0;
+        let nkeys = raw.nkeys;
         // Expect the buffer to be large enough to hold `nkeys`.
         let expected_len =
-            ((self.nkeys() as usize) * TC_U32_KEY_BUF_LEN) + TC_U32_SEL_BUF_LEN;
+            (nkeys as usize * size_of::<TcU32KeyBuffer>()) + sel_len;
         if len < expected_len {
             return Err(format!(
-                "invalid RouteNextHopBuffer: length {len} < {expected_len}",
+                "invalid TcU32SelectorBuffer: length {len} < {expected_len}",
             )
             .into());
         }
-        Ok(())
+        Ok(raw)
+    }
+}
+
+impl From<&TcU32Selector> for TcU32SelectorBuffer {
+    fn from(selector: &TcU32Selector) -> Self {
+        Self {
+            flags: selector.flags.bits(),
+            offshift: selector.offshift,
+            nkeys: selector.nkeys,
+            _pad: 0,
+            offmask: selector.offmask,
+            off: selector.off,
+            offoff: selector.offoff,
+            hoff: selector.hoff,
+            hmask: selector.hmask,
+        }
     }
 }
 
 impl Emitable for TcU32Selector {
     fn buffer_len(&self) -> usize {
-        TC_U32_SEL_BUF_LEN + (self.nkeys as usize * TC_U32_KEY_BUF_LEN)
+        size_of::<TcU32SelectorBuffer>()
+            + (self.nkeys as usize * size_of::<TcU32KeyBuffer>())
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut packet = TcU32SelectorBuffer::new(buffer);
-        packet.set_flags(self.flags.bits());
-        packet.set_offshift(self.offshift);
-        packet.set_offmask(self.offmask);
-        packet.set_off(self.off);
-        packet.set_offoff(self.offoff);
-        packet.set_hoff(self.hoff);
-        packet.set_hmask(self.hmask);
-        packet.set_nkeys(self.nkeys);
-
-        let key_buf = packet.keys_mut();
+        let raw = TcU32SelectorBuffer::from(self);
+        let sel_len = size_of::<TcU32SelectorBuffer>();
+        let key_len = size_of::<TcU32KeyBuffer>();
+        buffer[..sel_len].copy_from_slice(raw.as_bytes());
         for (i, k) in self.keys.iter().enumerate() {
             k.emit(
-                &mut key_buf
-                    [(i * TC_U32_KEY_BUF_LEN)..((i + 1) * TC_U32_KEY_BUF_LEN)],
+                &mut buffer
+                    [(sel_len + i * key_len)..(sel_len + (i + 1) * key_len)],
             );
         }
     }
 }
 
-impl<T: AsRef<[u8]> + ?Sized> Parseable<TcU32SelectorBuffer<&T>>
-    for TcU32Selector
-{
-    fn parse(buf: &TcU32SelectorBuffer<&T>) -> Result<Self, DecodeError> {
-        let nkeys = buf.nkeys();
+impl TcU32Selector {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let raw = TcU32SelectorBuffer::new_checked(payload)?;
+        let nkeys = raw.nkeys;
+        let key_len = size_of::<TcU32KeyBuffer>();
+        let key_payload = &payload[size_of::<TcU32SelectorBuffer>()..];
         let mut keys = Vec::<TcU32Key>::with_capacity(nkeys.into());
-        let key_payload = buf.keys();
         for i in 0..nkeys {
             let i = i as usize;
-            let keybuf = TcU32KeyBuffer::new_checked(
-                &key_payload
-                    [(i * TC_U32_KEY_BUF_LEN)..(i + 1) * TC_U32_KEY_BUF_LEN],
-            )
-            .context("invalid u32 key")?;
             keys.push(
-                TcU32Key::parse(&keybuf).context("failed to parse u32 key")?,
+                TcU32Key::parse(
+                    &key_payload[(i * key_len)..((i + 1) * key_len)],
+                )
+                .context("failed to parse u32 key")?,
             );
         }
 
         Ok(Self {
-            flags: TcU32SelectorFlags::from_bits_retain(buf.flags()),
-            offshift: buf.offshift(),
+            flags: TcU32SelectorFlags::from_bits_retain(raw.flags),
+            offshift: raw.offshift,
             nkeys,
-            offmask: buf.offmask(),
-            off: buf.off(),
-            offoff: buf.offoff(),
-            hoff: buf.hoff(),
-            hmask: buf.hmask(),
+            offmask: raw.offmask,
+            off: raw.off,
+            offoff: raw.offoff,
+            hoff: raw.hoff,
+            hmask: raw.hmask,
             keys,
         })
     }
@@ -285,33 +299,60 @@ pub struct TcU32Key {
     pub offmask: i32,
 }
 
-buffer!(TcU32KeyBuffer(TC_U32_KEY_BUF_LEN) {
-    mask: (u32, 0..4),
-    val: (u32, 4..8),
-    off: (i32, 8..12),
-    offmask: (i32, 12..TC_U32_KEY_BUF_LEN),
-});
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct TcU32KeyBuffer {
+    mask: u32,
+    val: u32,
+    off: i32,
+    offmask: i32,
+}
 
-impl Emitable for TcU32Key {
-    fn buffer_len(&self) -> usize {
-        TC_U32_KEY_BUF_LEN
-    }
-    fn emit(&self, buffer: &mut [u8]) {
-        let mut packet = TcU32KeyBuffer::new(buffer);
-        packet.set_mask(self.mask);
-        packet.set_val(self.val);
-        packet.set_off(self.off);
-        packet.set_offmask(self.offmask);
+impl From<&TcU32Key> for TcU32KeyBuffer {
+    fn from(key: &TcU32Key) -> Self {
+        Self {
+            mask: key.mask,
+            val: key.val,
+            off: key.off,
+            offmask: key.offmask,
+        }
     }
 }
 
-impl<T: AsRef<[u8]>> Parseable<TcU32KeyBuffer<T>> for TcU32Key {
-    fn parse(buf: &TcU32KeyBuffer<T>) -> Result<Self, DecodeError> {
+impl Emitable for TcU32Key {
+    fn buffer_len(&self) -> usize {
+        size_of::<TcU32KeyBuffer>()
+    }
+    fn emit(&self, buffer: &mut [u8]) {
+        let raw = TcU32KeyBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
+    }
+}
+
+impl TcU32Key {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) =
+            TcU32KeyBuffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    size_of::<TcU32KeyBuffer>(),
+                )
+            })?;
         Ok(Self {
-            mask: buf.mask(),
-            val: buf.val(),
-            off: buf.off(),
-            offmask: buf.offmask(),
+            mask: raw.mask,
+            val: raw.val,
+            off: raw.off,
+            offmask: raw.offmask,
         })
     }
 }

--- a/src/tc/header.rs
+++ b/src/tc/header.rs
@@ -1,30 +1,32 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{
-    DecodeError, Emitable, NlaBuffer, NlasIterator, Parseable,
-};
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use crate::AddressFamily;
 
-const TC_HEADER_LEN: usize = 20;
+pub(crate) const TC_HEADER_LEN: usize = 20;
 
-buffer!(TcMessageBuffer(TC_HEADER_LEN) {
-    family: (u8, 0),
-    pad1: (u8, 1),
-    pad2: (u16, 2..4),
-    index: (i32, 4..8),
-    handle: (u32, 8..12),
-    parent: (u32, 12..16),
-    info: (u32, 16..TC_HEADER_LEN),
-    payload: (slice, TC_HEADER_LEN..),
-});
-
-impl<'a, T: AsRef<[u8]> + ?Sized> TcMessageBuffer<&'a T> {
-    pub fn attributes(
-        &self,
-    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
-        NlasIterator::new(self.payload())
-    }
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct TcMessageBuffer {
+    family: u8,
+    pad1: u8,
+    pad2: u16,
+    index: i32,
+    handle: u32,
+    parent: u32,
+    info: u32,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
@@ -41,6 +43,34 @@ pub struct TcHeader {
 
 impl TcHeader {
     pub const TCM_IFINDEX_MAGIC_BLOCK: u32 = 0xFFFFFFFF;
+
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) =
+            TcMessageBuffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(payload.len(), TC_HEADER_LEN)
+            })?;
+        Ok(Self {
+            family: raw.family.into(),
+            index: raw.index,
+            handle: raw.handle.into(),
+            parent: raw.parent.into(),
+            info: raw.info,
+        })
+    }
+}
+
+impl From<&TcHeader> for TcMessageBuffer {
+    fn from(header: &TcHeader) -> Self {
+        Self {
+            family: header.family.into(),
+            pad1: 0,
+            pad2: 0,
+            index: header.index,
+            handle: header.handle.into(),
+            parent: header.parent.into(),
+            info: header.info,
+        }
+    }
 }
 
 impl Emitable for TcHeader {
@@ -49,24 +79,8 @@ impl Emitable for TcHeader {
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut packet = TcMessageBuffer::new(buffer);
-        packet.set_family(self.family.into());
-        packet.set_index(self.index);
-        packet.set_handle(self.handle.into());
-        packet.set_parent(self.parent.into());
-        packet.set_info(self.info);
-    }
-}
-
-impl<T: AsRef<[u8]>> Parseable<TcMessageBuffer<T>> for TcHeader {
-    fn parse(buf: &TcMessageBuffer<T>) -> Result<Self, DecodeError> {
-        Ok(Self {
-            family: buf.family().into(),
-            index: buf.index(),
-            handle: buf.handle().into(),
-            parent: buf.parent().into(),
-            info: buf.info(),
-        })
+        let raw = TcMessageBuffer::from(self);
+        buffer[..TC_HEADER_LEN].copy_from_slice(raw.as_bytes());
     }
 }
 

--- a/src/tc/message.rs
+++ b/src/tc/message.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{
-    DecodeError, Emitable, ErrorContext, Parseable, ParseableParametrized,
-};
+use netlink_packet_core::{DecodeError, Emitable, ErrorContext, Parseable};
 
-use super::{TcAttribute, TcHeader, TcMessageBuffer};
+use super::{
+    attribute::VecTcAttribute, header::TC_HEADER_LEN, TcAttribute, TcHeader,
+};
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
@@ -34,33 +34,16 @@ impl TcMessage {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<TcMessageBuffer<&'a T>> for TcMessage {
-    fn parse(buf: &TcMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl Parseable<[u8]> for TcMessage {
+    fn parse(buf: &[u8]) -> Result<Self, DecodeError> {
+        let header = TcHeader::parse(buf)
+            .context("failed to parse tc message header")?;
         Ok(Self {
-            header: TcHeader::parse(buf)
-                .context("failed to parse tc message header")?,
-            attributes: Vec::<TcAttribute>::parse(buf)
-                .context("failed to parse tc message NLAs")?,
+            header,
+            attributes: VecTcAttribute::parse(&buf[TC_HEADER_LEN..])
+                .context("failed to parse tc message NLAs")?
+                .0,
         })
-    }
-}
-
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<TcMessageBuffer<&'a T>>
-    for Vec<TcAttribute>
-{
-    fn parse(buf: &TcMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
-        let mut attributes = vec![];
-        let mut kind = String::new();
-
-        for nla_buf in buf.attributes() {
-            let attribute =
-                TcAttribute::parse_with_param(&nla_buf?, kind.as_str())?;
-            if let TcAttribute::Kind(s) = &attribute {
-                kind = s.to_string();
-            }
-            attributes.push(attribute)
-        }
-        Ok(attributes)
     }
 }
 

--- a/src/tc/qdiscs/fq_codel.rs
+++ b/src/tc/qdiscs/fq_codel.rs
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: MIT
 
+use std::mem::size_of;
+
 use netlink_packet_core::{
     emit_u32, parse_u32, parse_u8, DecodeError, DefaultNla, Emitable,
     ErrorContext, Nla, NlaBuffer, Parseable,
 };
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[non_exhaustive]
@@ -12,9 +15,6 @@ pub struct TcQdiscFqCodel {}
 impl TcQdiscFqCodel {
     pub(crate) const KIND: &'static str = "fq_codel";
 }
-
-const TC_FQ_CODEL_QD_STATS_LEN: usize = 36;
-const TC_FQ_CODEL_CL_STATS_LEN: usize = 24;
 
 const TCA_FQ_CODEL_XSTATS_QDISC: u32 = 0;
 const TCA_FQ_CODEL_XSTATS_CLASS: u32 = 1;
@@ -42,14 +42,10 @@ impl<T: AsRef<[u8]> + ?Sized> Parseable<T> for TcFqCodelXstats {
 
         match buf_type {
             TCA_FQ_CODEL_XSTATS_QDISC => {
-                Ok(Self::Qdisc(TcFqCodelQdStats::parse(
-                    &TcFqCodelQdStatsBuffer::new(&buf.as_ref()[4..]),
-                )?))
+                Ok(Self::Qdisc(TcFqCodelQdStats::parse(&buf.as_ref()[4..])?))
             }
             TCA_FQ_CODEL_XSTATS_CLASS => {
-                Ok(Self::Class(TcFqCodelClStats::parse(
-                    &TcFqCodelClStatsBuffer::new(&buf.as_ref()[4..]),
-                )?))
+                Ok(Self::Class(TcFqCodelClStats::parse(&buf.as_ref()[4..])?))
             }
             _ => Ok(Self::Other(buf.as_ref().to_vec())),
         }
@@ -60,10 +56,10 @@ impl Emitable for TcFqCodelXstats {
     fn buffer_len(&self) -> usize {
         match self {
             Self::Qdisc(_) => {
-                TC_FQ_CODEL_QD_STATS_LEN + std::mem::size_of::<u32>()
+                size_of::<TcFqCodelQdStatsBuffer>() + size_of::<u32>()
             }
             Self::Class(_) => {
-                TC_FQ_CODEL_CL_STATS_LEN + std::mem::size_of::<u32>()
+                size_of::<TcFqCodelClStatsBuffer>() + size_of::<u32>()
             }
             Self::Other(v) => v.len(),
         }
@@ -100,50 +96,78 @@ pub struct TcFqCodelQdStats {
     pub drop_overmemory: u32,
 }
 
-buffer!(TcFqCodelQdStatsBuffer(TC_FQ_CODEL_QD_STATS_LEN) {
-    maxpacket: (u32, 0..4),
-    drop_overlimit: (u32, 4..8),
-    ecn_mark: (u32, 8..12),
-    new_flow_count: (u32, 12..16),
-    new_flows_len: (u32, 16..20),
-    old_flows_len: (u32, 20..24),
-    ce_mark: (u32, 24..28),
-    memory_usage: (u32, 28..32),
-    drop_overmemory: (u32,32..36),
-});
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct TcFqCodelQdStatsBuffer {
+    maxpacket: u32,
+    drop_overlimit: u32,
+    ecn_mark: u32,
+    new_flow_count: u32,
+    new_flows_len: u32,
+    old_flows_len: u32,
+    ce_mark: u32,
+    memory_usage: u32,
+    drop_overmemory: u32,
+}
 
-impl<T: AsRef<[u8]>> Parseable<TcFqCodelQdStatsBuffer<T>> for TcFqCodelQdStats {
-    fn parse(buf: &TcFqCodelQdStatsBuffer<T>) -> Result<Self, DecodeError> {
+impl TcFqCodelQdStats {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) = TcFqCodelQdStatsBuffer::ref_from_prefix(payload)
+            .map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    size_of::<TcFqCodelQdStatsBuffer>(),
+                )
+            })?;
         Ok(Self {
-            maxpacket: buf.maxpacket(),
-            drop_overlimit: buf.drop_overlimit(),
-            ecn_mark: buf.ecn_mark(),
-            new_flow_count: buf.new_flow_count(),
-            new_flows_len: buf.new_flows_len(),
-            old_flows_len: buf.old_flows_len(),
-            ce_mark: buf.ce_mark(),
-            memory_usage: buf.memory_usage(),
-            drop_overmemory: buf.drop_overmemory(),
+            maxpacket: raw.maxpacket,
+            drop_overlimit: raw.drop_overlimit,
+            ecn_mark: raw.ecn_mark,
+            new_flow_count: raw.new_flow_count,
+            new_flows_len: raw.new_flows_len,
+            old_flows_len: raw.old_flows_len,
+            ce_mark: raw.ce_mark,
+            memory_usage: raw.memory_usage,
+            drop_overmemory: raw.drop_overmemory,
         })
+    }
+}
+
+impl From<&TcFqCodelQdStats> for TcFqCodelQdStatsBuffer {
+    fn from(value: &TcFqCodelQdStats) -> Self {
+        Self {
+            maxpacket: value.maxpacket,
+            drop_overlimit: value.drop_overlimit,
+            ecn_mark: value.ecn_mark,
+            new_flow_count: value.new_flow_count,
+            new_flows_len: value.new_flows_len,
+            old_flows_len: value.old_flows_len,
+            ce_mark: value.ce_mark,
+            memory_usage: value.memory_usage,
+            drop_overmemory: value.drop_overmemory,
+        }
     }
 }
 
 impl Emitable for TcFqCodelQdStats {
     fn buffer_len(&self) -> usize {
-        TC_FQ_CODEL_QD_STATS_LEN + std::mem::size_of::<u32>()
+        size_of::<TcFqCodelQdStatsBuffer>() + size_of::<u32>()
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buffer = TcFqCodelQdStatsBuffer::new(buffer);
-        buffer.set_maxpacket(self.maxpacket);
-        buffer.set_drop_overlimit(self.drop_overlimit);
-        buffer.set_ecn_mark(self.ecn_mark);
-        buffer.set_new_flow_count(self.new_flow_count);
-        buffer.set_new_flows_len(self.new_flows_len);
-        buffer.set_old_flows_len(self.old_flows_len);
-        buffer.set_ce_mark(self.ce_mark);
-        buffer.set_memory_usage(self.memory_usage);
-        buffer.set_drop_overmemory(self.drop_overmemory);
+        let raw = TcFqCodelQdStatsBuffer::from(self);
+        buffer[..size_of::<TcFqCodelQdStatsBuffer>()]
+            .copy_from_slice(raw.as_bytes());
     }
 }
 
@@ -158,41 +182,69 @@ pub struct TcFqCodelClStats {
     drop_next: i32,
 }
 
-buffer!(TcFqCodelClStatsBuffer(TC_FQ_CODEL_CL_STATS_LEN) {
-    deficit: (i32, 0..4),
-    ldelay: (u32,4..8),
-    count: (u32, 8..12),
-    lastcount: (u32, 12..16),
-    dropping: (u32, 16..20),
-    drop_next: (i32, 20..24),
-});
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct TcFqCodelClStatsBuffer {
+    deficit: i32,
+    ldelay: u32,
+    count: u32,
+    lastcount: u32,
+    dropping: u32,
+    drop_next: i32,
+}
 
-impl<T: AsRef<[u8]>> Parseable<TcFqCodelClStatsBuffer<T>> for TcFqCodelClStats {
-    fn parse(buf: &TcFqCodelClStatsBuffer<T>) -> Result<Self, DecodeError> {
+impl TcFqCodelClStats {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) = TcFqCodelClStatsBuffer::ref_from_prefix(payload)
+            .map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    size_of::<TcFqCodelClStatsBuffer>(),
+                )
+            })?;
         Ok(Self {
-            deficit: buf.deficit(),
-            ldelay: buf.ldelay(),
-            count: buf.count(),
-            lastcount: buf.lastcount(),
-            dropping: buf.dropping(),
-            drop_next: buf.drop_next(),
+            deficit: raw.deficit,
+            ldelay: raw.ldelay,
+            count: raw.count,
+            lastcount: raw.lastcount,
+            dropping: raw.dropping,
+            drop_next: raw.drop_next,
         })
+    }
+}
+
+impl From<&TcFqCodelClStats> for TcFqCodelClStatsBuffer {
+    fn from(value: &TcFqCodelClStats) -> Self {
+        Self {
+            deficit: value.deficit,
+            ldelay: value.ldelay,
+            count: value.count,
+            lastcount: value.lastcount,
+            dropping: value.dropping,
+            drop_next: value.drop_next,
+        }
     }
 }
 
 impl Emitable for TcFqCodelClStats {
     fn buffer_len(&self) -> usize {
-        TC_FQ_CODEL_CL_STATS_LEN + std::mem::size_of::<u32>()
+        size_of::<TcFqCodelClStatsBuffer>() + size_of::<u32>()
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buffer = TcFqCodelClStatsBuffer::new(buffer);
-        buffer.set_deficit(self.deficit);
-        buffer.set_ldelay(self.ldelay);
-        buffer.set_count(self.count);
-        buffer.set_lastcount(self.lastcount);
-        buffer.set_dropping(self.dropping);
-        buffer.set_drop_next(self.drop_next);
+        let raw = TcFqCodelClStatsBuffer::from(self);
+        buffer[..size_of::<TcFqCodelClStatsBuffer>()]
+            .copy_from_slice(raw.as_bytes());
     }
 }
 

--- a/src/tc/stats/basic.rs
+++ b/src/tc/stats/basic.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{DecodeError, Emitable, Parseable};
+use std::mem::size_of;
+
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 /// Byte/Packet throughput statistics
 #[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
@@ -12,31 +15,59 @@ pub struct TcStatsBasic {
     pub packets: u32,
 }
 
-// real size is 12, but kernel is align to 64bits(8 bytes)
-const STATS_BASIC_LEN: usize = 16;
+// The real size is 12, but kernel aligns to 64 bits (8 bytes), hence the
+// trailing padding.
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct TcStatsBasicBuffer {
+    bytes: u64,
+    packets: u32,
+    _padding: [u8; 4],
+}
 
-buffer!(TcStatsBasicBuffer(STATS_BASIC_LEN) {
-    bytes: (u64, 0..8),
-    packets: (u32, 8..12),
-});
-
-impl<T: AsRef<[u8]>> Parseable<TcStatsBasicBuffer<T>> for TcStatsBasic {
-    fn parse(buf: &TcStatsBasicBuffer<T>) -> Result<Self, DecodeError> {
-        Ok(TcStatsBasic {
-            bytes: buf.bytes(),
-            packets: buf.packets(),
+impl TcStatsBasic {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) =
+            TcStatsBasicBuffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    size_of::<TcStatsBasicBuffer>(),
+                )
+            })?;
+        Ok(Self {
+            bytes: raw.bytes,
+            packets: raw.packets,
         })
+    }
+}
+
+impl From<&TcStatsBasic> for TcStatsBasicBuffer {
+    fn from(value: &TcStatsBasic) -> Self {
+        Self {
+            bytes: value.bytes,
+            packets: value.packets,
+            _padding: [0; 4],
+        }
     }
 }
 
 impl Emitable for TcStatsBasic {
     fn buffer_len(&self) -> usize {
-        STATS_BASIC_LEN
+        size_of::<TcStatsBasicBuffer>()
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buffer = TcStatsBasicBuffer::new(buffer);
-        buffer.set_bytes(self.bytes);
-        buffer.set_packets(self.packets);
+        let raw = TcStatsBasicBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/tc/stats/compat.rs
+++ b/src/tc/stats/compat.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{DecodeError, Emitable, Parseable};
+use std::mem::size_of;
+
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 /// Generic queue statistics
 #[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
@@ -23,49 +26,77 @@ pub struct TcStats {
     pub backlog: u32,
 }
 
-// real size is 36, but kernel is align to 64bits(8 bytes)
-const STATS_LEN: usize = 40;
+// The real size is 36, but kernel aligns to 64 bits (8 bytes), hence the
+// trailing padding.
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct TcStatsBuffer {
+    bytes: u64,
+    packets: u32,
+    drops: u32,
+    overlimits: u32,
+    bps: u32,
+    pps: u32,
+    qlen: u32,
+    backlog: u32,
+    _padding: [u8; 4],
+}
 
-buffer!(TcStatsBuffer(STATS_LEN) {
-    bytes: (u64, 0..8),
-    packets: (u32, 8..12),
-    drops: (u32, 12..16),
-    overlimits: (u32, 16..20),
-    bps: (u32, 20..24),
-    pps: (u32, 24..28),
-    qlen: (u32, 28..32),
-    backlog: (u32, 32..36),
-});
-
-impl<T: AsRef<[u8]>> Parseable<TcStatsBuffer<T>> for TcStats {
-    fn parse(buf: &TcStatsBuffer<T>) -> Result<Self, DecodeError> {
+impl TcStats {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) =
+            TcStatsBuffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    size_of::<TcStatsBuffer>(),
+                )
+            })?;
         Ok(Self {
-            bytes: buf.bytes(),
-            packets: buf.packets(),
-            drops: buf.drops(),
-            overlimits: buf.overlimits(),
-            bps: buf.bps(),
-            pps: buf.pps(),
-            qlen: buf.qlen(),
-            backlog: buf.backlog(),
+            bytes: raw.bytes,
+            packets: raw.packets,
+            drops: raw.drops,
+            overlimits: raw.overlimits,
+            bps: raw.bps,
+            pps: raw.pps,
+            qlen: raw.qlen,
+            backlog: raw.backlog,
         })
+    }
+}
+
+impl From<&TcStats> for TcStatsBuffer {
+    fn from(value: &TcStats) -> Self {
+        Self {
+            bytes: value.bytes,
+            packets: value.packets,
+            drops: value.drops,
+            overlimits: value.overlimits,
+            bps: value.bps,
+            pps: value.pps,
+            qlen: value.qlen,
+            backlog: value.backlog,
+            _padding: [0; 4],
+        }
     }
 }
 
 impl Emitable for TcStats {
     fn buffer_len(&self) -> usize {
-        STATS_LEN
+        size_of::<TcStatsBuffer>()
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buffer = TcStatsBuffer::new(buffer);
-        buffer.set_bytes(self.bytes);
-        buffer.set_packets(self.packets);
-        buffer.set_drops(self.drops);
-        buffer.set_overlimits(self.overlimits);
-        buffer.set_bps(self.bps);
-        buffer.set_pps(self.pps);
-        buffer.set_qlen(self.qlen);
-        buffer.set_backlog(self.backlog);
+        let raw = TcStatsBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/tc/stats/queue.rs
+++ b/src/tc/stats/queue.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{DecodeError, Emitable, Parseable};
+use std::mem::size_of;
+
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 /// Queuing statistics
 #[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
@@ -18,39 +21,64 @@ pub struct TcStatsQueue {
     pub overlimits: u32,
 }
 
-const STATS_QUEUE_LEN: usize = 20;
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct TcStatsQueueBuffer {
+    qlen: u32,
+    backlog: u32,
+    drops: u32,
+    requeues: u32,
+    overlimits: u32,
+}
 
-buffer!(TcStatsQueueBuffer( STATS_QUEUE_LEN) {
-    qlen: (u32, 0..4),
-    backlog: (u32, 4..8),
-    drops: (u32, 8..12),
-    requeues: (u32, 12..16),
-    overlimits: (u32, 16..20),
-});
-
-impl<T: AsRef<[u8]>> Parseable<TcStatsQueueBuffer<T>> for TcStatsQueue {
-    fn parse(buf: &TcStatsQueueBuffer<T>) -> Result<Self, DecodeError> {
+impl TcStatsQueue {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) =
+            TcStatsQueueBuffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    size_of::<TcStatsQueueBuffer>(),
+                )
+            })?;
         Ok(Self {
-            qlen: buf.qlen(),
-            backlog: buf.backlog(),
-            drops: buf.drops(),
-            requeues: buf.requeues(),
-            overlimits: buf.overlimits(),
+            qlen: raw.qlen,
+            backlog: raw.backlog,
+            drops: raw.drops,
+            requeues: raw.requeues,
+            overlimits: raw.overlimits,
         })
+    }
+}
+
+impl From<&TcStatsQueue> for TcStatsQueueBuffer {
+    fn from(value: &TcStatsQueue) -> Self {
+        Self {
+            qlen: value.qlen,
+            backlog: value.backlog,
+            drops: value.drops,
+            requeues: value.requeues,
+            overlimits: value.overlimits,
+        }
     }
 }
 
 impl Emitable for TcStatsQueue {
     fn buffer_len(&self) -> usize {
-        STATS_QUEUE_LEN
+        size_of::<TcStatsQueueBuffer>()
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buffer = TcStatsQueueBuffer::new(buffer);
-        buffer.set_qlen(self.qlen);
-        buffer.set_backlog(self.backlog);
-        buffer.set_drops(self.drops);
-        buffer.set_requeues(self.requeues);
-        buffer.set_overlimits(self.overlimits);
+        let raw = TcStatsQueueBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/tc/stats/stats2.rs
+++ b/src/tc/stats/stats2.rs
@@ -5,10 +5,7 @@ use netlink_packet_core::{
     ParseableParametrized,
 };
 
-use super::{
-    TcStatsBasic, TcStatsBasicBuffer, TcStatsQueue, TcStatsQueueBuffer,
-    TcXstats,
-};
+use super::{TcStatsBasic, TcStatsQueue, TcXstats};
 
 const TCA_STATS_BASIC: u16 = 1;
 // const TCA_STATS_RATE_EST: u16 = 2; // TODO
@@ -71,15 +68,9 @@ where
         let payload = buf.value();
         Ok(match buf.kind() {
             TCA_STATS_APP => Self::App(TcXstats::parse_with_param(buf, kind)?),
-            TCA_STATS_BASIC => Self::Basic(TcStatsBasic::parse(
-                &TcStatsBasicBuffer::new(payload),
-            )?),
-            TCA_STATS_QUEUE => Self::Queue(TcStatsQueue::parse(
-                &TcStatsQueueBuffer::new(payload),
-            )?),
-            TCA_STATS_BASIC_HW => Self::BasicHw(TcStatsBasic::parse(
-                &TcStatsBasicBuffer::new(payload),
-            )?),
+            TCA_STATS_BASIC => Self::Basic(TcStatsBasic::parse(payload)?),
+            TCA_STATS_QUEUE => Self::Queue(TcStatsQueue::parse(payload)?),
+            TCA_STATS_BASIC_HW => Self::BasicHw(TcStatsBasic::parse(payload)?),
             _ => Self::Other(DefaultNla::parse(buf)?),
         })
     }

--- a/src/tc/tests/filter_bpf.rs
+++ b/src/tc/tests/filter_bpf.rs
@@ -5,7 +5,7 @@ use netlink_packet_core::{Emitable, Parseable as _};
 use crate::{
     tc::{
         TcAttribute, TcBpfFlags, TcFilterBpfOption, TcHandle, TcHeader,
-        TcMessage, TcMessageBuffer, TcOption, TcU32OptionFlags,
+        TcMessage, TcOption, TcU32OptionFlags,
     },
     AddressFamily,
 };
@@ -105,10 +105,7 @@ fn test_get_filter_bpf() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        TcMessage::parse(&TcMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, TcMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
     expected.emit(&mut buf);

--- a/src/tc/tests/filter_flower.rs
+++ b/src/tc/tests/filter_flower.rs
@@ -9,8 +9,8 @@ use crate::{
         TcAction, TcActionAttribute, TcActionGeneric, TcActionMirrorOption,
         TcActionOption, TcActionType, TcAttribute, TcFilterFlowerMplsLseOption,
         TcFilterFlowerMplsOption, TcFilterFlowerOption, TcHandle, TcHeader,
-        TcMessage, TcMessageBuffer, TcMirror, TcMirrorActionType, TcOption,
-        TcStats2, TcStatsBasic, TcStatsQueue, Tcf,
+        TcMessage, TcMirror, TcMirrorActionType, TcOption, TcStats2,
+        TcStatsBasic, TcStatsQueue, Tcf,
     },
     AddressFamily,
 };
@@ -252,10 +252,7 @@ fn test_get_filter_flower_mac_ipv4() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        TcMessage::parse(&TcMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, TcMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -353,10 +350,7 @@ fn test_get_filter_flower_ipv6_ports() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        TcMessage::parse(&TcMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, TcMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -417,10 +411,7 @@ fn test_get_filter_flower_ipv4_tcp_portrange() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        TcMessage::parse(&TcMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, TcMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -477,10 +468,7 @@ fn test_get_filter_flower_ipv4_icmp() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        TcMessage::parse(&TcMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, TcMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -537,10 +525,7 @@ fn test_get_filter_flower_ipv6_icmp() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        TcMessage::parse(&TcMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, TcMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -611,10 +596,7 @@ fn test_get_filter_flower_ct() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        TcMessage::parse(&TcMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, TcMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -698,10 +680,7 @@ fn test_get_filter_flower_arp() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        TcMessage::parse(&TcMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, TcMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -760,10 +739,7 @@ fn test_get_filter_flower_vlan() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        TcMessage::parse(&TcMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, TcMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -818,10 +794,7 @@ fn test_get_filter_flower_mpls_uc_single() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        TcMessage::parse(&TcMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, TcMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -894,10 +867,7 @@ fn test_get_filter_flower_mpls_uc_lse() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        TcMessage::parse(&TcMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, TcMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -992,10 +962,7 @@ fn test_get_filter_flower_ipv4_enc() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        TcMessage::parse(&TcMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, TcMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -1094,10 +1061,7 @@ fn test_get_filter_flower_ipv6_enc() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        TcMessage::parse(&TcMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, TcMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/tc/tests/filter_matchall.rs
+++ b/src/tc/tests/filter_matchall.rs
@@ -6,9 +6,8 @@ use crate::{
     tc::{
         TcAction, TcActionAttribute, TcActionGeneric, TcActionMirrorOption,
         TcActionOption, TcActionType, TcAttribute, TcFilterMatchAllOption,
-        TcHandle, TcHeader, TcMessage, TcMessageBuffer, TcMirror,
-        TcMirrorActionType, TcOption, TcStats2, TcStatsBasic, TcStatsQueue,
-        Tcf,
+        TcHandle, TcHeader, TcMessage, TcMirror, TcMirrorActionType, TcOption,
+        TcStats2, TcStatsBasic, TcStatsQueue, Tcf,
     },
     AddressFamily,
 };
@@ -171,10 +170,7 @@ fn test_get_filter_matchall() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        TcMessage::parse(&TcMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, TcMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/tc/tests/filter_u32.rs
+++ b/src/tc/tests/filter_u32.rs
@@ -8,8 +8,7 @@ use crate::{
     tc::{
         filters::{TcU32OptionFlags, TcU32SelectorFlags},
         TcAttribute, TcFilterU32Option, TcHandle, TcHeader, TcMessage,
-        TcMessageBuffer, TcOption, TcU32Key, TcU32Selector,
-        TcU32SelectorBuffer,
+        TcOption, TcU32Key, TcU32Selector, TcU32SelectorBuffer,
     },
     AddressFamily,
 };
@@ -102,10 +101,7 @@ fn test_get_filter_u32() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        TcMessage::parse(&TcMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, TcMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -131,5 +127,5 @@ fn test_tcu32_selector_invalid_nkeys() {
         0x00, 0x00, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00,
     ];
-    assert!(TcU32SelectorBuffer::new_checked(buffer).is_err());
+    assert!(TcU32SelectorBuffer::new_checked(&buffer).is_err());
 }

--- a/src/tc/tests/qdisc_fq_codel.rs
+++ b/src/tc/tests/qdisc_fq_codel.rs
@@ -5,8 +5,8 @@ use netlink_packet_core::{Emitable, Parseable};
 use crate::{
     tc::{
         TcAttribute, TcFqCodelQdStats, TcFqCodelXstats, TcHandle, TcHeader,
-        TcMessage, TcMessageBuffer, TcOption, TcQdiscFqCodelOption, TcStats,
-        TcStats2, TcStatsBasic, TcStatsQueue, TcXstats,
+        TcMessage, TcOption, TcQdiscFqCodelOption, TcStats, TcStats2,
+        TcStatsBasic, TcStatsQueue, TcXstats,
     },
     AddressFamily,
 };
@@ -186,10 +186,7 @@ fn test_get_qdisc_fq_codel() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        TcMessage::parse(&TcMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, TcMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/tc/tests/qdisc_ingress.rs
+++ b/src/tc/tests/qdisc_ingress.rs
@@ -4,8 +4,8 @@ use netlink_packet_core::{Emitable, Parseable};
 
 use crate::{
     tc::{
-        TcAttribute, TcHandle, TcHeader, TcMessage, TcMessageBuffer, TcStats,
-        TcStats2, TcStatsBasic, TcStatsQueue,
+        TcAttribute, TcHandle, TcHeader, TcMessage, TcStats, TcStats2,
+        TcStatsBasic, TcStatsQueue,
     },
     AddressFamily,
 };
@@ -83,10 +83,7 @@ fn test_get_qdisc_ingress() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        TcMessage::parse(&TcMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, TcMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 


### PR DESCRIPTION
Replace `buffer!()` macro with `zerocopy` crate, following the link
buffer conversion.

`VecTcAttribute` is introduced to satisfy the orphan rule on parsing
`Vec<TcAttribute>`, which threads the attribute `kind`. The mirror,
nat and tunnel-key buffers embed `TcActionGenericBuffer`, made `Copy`
so the packed wrappers can derive `Debug`/`PartialEq`/`Clone`. The
redundant `BUF_LEN`/`TC_*_BUF_LEN` constants are dropped in favor of
`size_of()`.

Existing test cases cover the changes.