### PR TITLE
API break: use zerocopy for remaining buffer parsing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,13 +73,7 @@ pub use netlink_packet_core::EthernetProtocol;
     target_os = "android",
 )))]
 pub use self::address_family_fallback::AddressFamily;
-pub use self::{
-    ip::IpProtocol,
-    message::{RouteNetlinkMessage, RouteNetlinkMessageBuffer},
-};
-
-#[macro_use]
-extern crate netlink_packet_core;
+pub use self::{ip::IpProtocol, message::RouteNetlinkMessage};
 
 #[cfg(test)]
 #[macro_use]

--- a/src/message.rs
+++ b/src/message.rs
@@ -8,13 +8,13 @@ use netlink_packet_core::{
 use crate::{
     address::{AddressHeader, AddressMessage},
     link::LinkMessage,
-    neighbour::{NeighbourMessage, NeighbourMessageBuffer},
-    neighbour_table::{NeighbourTableMessage, NeighbourTableMessageBuffer},
-    nsid::{NsidMessage, NsidMessageBuffer},
-    prefix::{PrefixMessage, PrefixMessageBuffer},
+    neighbour::NeighbourMessage,
+    neighbour_table::NeighbourTableMessage,
+    nsid::NsidMessage,
+    prefix::PrefixMessage,
     route::{RouteHeader, RouteMessage},
-    rule::{RuleMessage, RuleMessageBuffer},
-    stats::{StatsMessage, StatsMessageBuffer},
+    rule::RuleMessage,
+    stats::StatsMessage,
     tc::{TcActionMessage, TcMessage},
 };
 
@@ -76,14 +76,9 @@ const RTM_GETCHAIN: u16 = 102;
 const RTM_NEWLINKPROP: u16 = 108;
 const RTM_DELLINKPROP: u16 = 109;
 
-buffer!(RouteNetlinkMessageBuffer);
-
-impl<'a, T: AsRef<[u8]> + ?Sized>
-    ParseableParametrized<RouteNetlinkMessageBuffer<&'a T>, u16>
-    for RouteNetlinkMessage
-{
+impl ParseableParametrized<[u8], u16> for RouteNetlinkMessage {
     fn parse_with_param(
-        buf: &RouteNetlinkMessageBuffer<&'a T>,
+        buf: &[u8],
         message_type: u16,
     ) -> Result<Self, DecodeError> {
         let message = match message_type {
@@ -92,15 +87,13 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
                 // HACK: iproute2 sends invalid RTM_GETLINK message, where
                 // the header is limited to the interface family (1 byte) and
                 // 3 bytes of padding.
-                let msg =
-                    if buf.inner().len() == 4 && message_type == RTM_GETLINK {
-                        let mut msg = LinkMessage::default();
-                        msg.header.interface_family = buf.inner()[0].into();
-                        msg
-                    } else {
-                        LinkMessage::parse(buf.inner())
-                            .context("invalid link message")?
-                    };
+                let msg = if buf.len() == 4 && message_type == RTM_GETLINK {
+                    let mut msg = LinkMessage::default();
+                    msg.header.interface_family = buf[0].into();
+                    msg
+                } else {
+                    LinkMessage::parse(buf).context("invalid link message")?
+                };
                 match message_type {
                     RTM_NEWLINK => RouteNetlinkMessage::NewLink(msg),
                     RTM_GETLINK => RouteNetlinkMessage::GetLink(msg),
@@ -115,18 +108,17 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
                 // HACK: iproute2 sends invalid RTM_GETADDR message, where
                 // the header is limited to the interface family (1 byte) and
                 // 3 bytes of padding.
-                let msg =
-                    if buf.inner().len() == 4 && message_type == RTM_GETADDR {
-                        let mut msg = AddressMessage {
-                            header: AddressHeader::default(),
-                            attributes: vec![],
-                        };
-                        msg.header.family = buf.inner()[0].into();
-                        msg
-                    } else {
-                        AddressMessage::parse(buf.inner())
-                            .context("invalid address message")?
+                let msg = if buf.len() == 4 && message_type == RTM_GETADDR {
+                    let mut msg = AddressMessage {
+                        header: AddressHeader::default(),
+                        attributes: vec![],
                     };
+                    msg.header.family = buf[0].into();
+                    msg
+                } else {
+                    AddressMessage::parse(buf)
+                        .context("invalid address message")?
+                };
                 match message_type {
                     RTM_NEWADDR => RouteNetlinkMessage::NewAddress(msg),
                     RTM_GETADDR => RouteNetlinkMessage::GetAddress(msg),
@@ -138,11 +130,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
             // Neighbour messages
             RTM_NEWNEIGH | RTM_GETNEIGH | RTM_DELNEIGH => {
                 let err = "invalid neighbour message";
-                let msg = NeighbourMessage::parse(
-                    &NeighbourMessageBuffer::new_checked(&buf.inner())
-                        .context(err)?,
-                )
-                .context(err)?;
+                let msg = NeighbourMessage::parse(buf).context(err)?;
                 match message_type {
                     RTM_GETNEIGH => RouteNetlinkMessage::GetNeighbour(msg),
                     RTM_NEWNEIGH => RouteNetlinkMessage::NewNeighbour(msg),
@@ -154,11 +142,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
             // Neighbour table messages
             RTM_NEWNEIGHTBL | RTM_GETNEIGHTBL | RTM_SETNEIGHTBL => {
                 let err = "invalid neighbour table message";
-                let msg = NeighbourTableMessage::parse(
-                    &NeighbourTableMessageBuffer::new_checked(&buf.inner())
-                        .context(err)?,
-                )
-                .context(err)?;
+                let msg = NeighbourTableMessage::parse(buf).context(err)?;
                 match message_type {
                     RTM_GETNEIGHTBL => {
                         RouteNetlinkMessage::GetNeighbourTable(msg)
@@ -184,18 +168,17 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
                 // length advertised in the netlink header includes the 3 bytes
                 // of padding but it does not seem to be the case for the route
                 // message, hence the buf.length() == 1 check.
-                let msg = if (buf.inner().len() == 4 || buf.inner().len() == 1)
+                let msg = if (buf.len() == 4 || buf.len() == 1)
                     && message_type == RTM_GETROUTE
                 {
                     let mut msg = RouteMessage {
                         header: RouteHeader::default(),
                         attributes: vec![],
                     };
-                    msg.header.address_family = buf.inner()[0].into();
+                    msg.header.address_family = buf[0].into();
                     msg
                 } else {
-                    RouteMessage::parse(buf.inner())
-                        .context("invalid route message")?
+                    RouteMessage::parse(buf).context("invalid route message")?
                 };
                 match message_type {
                     RTM_NEWROUTE => RouteNetlinkMessage::NewRoute(msg),
@@ -209,21 +192,13 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
             RTM_NEWPREFIX => {
                 let err = "invalid prefix message";
                 RouteNetlinkMessage::NewPrefix(
-                    PrefixMessage::parse(
-                        &PrefixMessageBuffer::new_checked(&buf.inner())
-                            .context(err)?,
-                    )
-                    .context(err)?,
+                    PrefixMessage::parse(buf).context(err)?,
                 )
             }
 
             RTM_NEWRULE | RTM_GETRULE | RTM_DELRULE => {
                 let err = "invalid fib rule message";
-                let msg = RuleMessage::parse(
-                    &RuleMessageBuffer::new_checked(&buf.inner())
-                        .context(err)?,
-                )
-                .context(err)?;
+                let msg = RuleMessage::parse(buf).context(err)?;
                 match message_type {
                     RTM_NEWRULE => RouteNetlinkMessage::NewRule(msg),
                     RTM_DELRULE => RouteNetlinkMessage::DelRule(msg),
@@ -237,7 +212,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
             | RTM_DELTFILTER | RTM_GETTFILTER | RTM_NEWCHAIN | RTM_DELCHAIN
             | RTM_GETCHAIN => {
                 let err = "invalid tc message";
-                let msg = TcMessage::parse(buf.inner()).context(err)?;
+                let msg = TcMessage::parse(buf).context(err)?;
                 match message_type {
                     RTM_NEWQDISC => {
                         RouteNetlinkMessage::NewQueueDiscipline(msg)
@@ -269,7 +244,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
 
             RTM_NEWACTION | RTM_DELACTION | RTM_GETACTION => {
                 let err = "invalid tc action message";
-                let msg = TcActionMessage::parse(buf.inner()).context(err)?;
+                let msg = TcActionMessage::parse(buf).context(err)?;
                 match message_type {
                     RTM_NEWACTION => RouteNetlinkMessage::NewTrafficAction(msg),
                     RTM_DELACTION => RouteNetlinkMessage::DelTrafficAction(msg),
@@ -281,11 +256,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
             // Stats messages
             RTM_NEWSTATS | RTM_GETSTATS => {
                 let err = "invalid stats message";
-                let msg = StatsMessage::parse(
-                    &StatsMessageBuffer::new_checked(&buf.inner())
-                        .context(err)?,
-                )
-                .context(err)?;
+                let msg = StatsMessage::parse(buf).context(err)?;
                 match message_type {
                     RTM_NEWSTATS => RouteNetlinkMessage::NewStats(msg),
                     RTM_GETSTATS => RouteNetlinkMessage::GetStats(msg),
@@ -296,11 +267,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
             // ND ID Messages
             RTM_NEWNSID | RTM_GETNSID | RTM_DELNSID => {
                 let err = "invalid nsid message";
-                let msg = NsidMessage::parse(
-                    &NsidMessageBuffer::new_checked(&buf.inner())
-                        .context(err)?,
-                )
-                .context(err)?;
+                let msg = NsidMessage::parse(buf).context(err)?;
                 match message_type {
                     RTM_NEWNSID => RouteNetlinkMessage::NewNsId(msg),
                     RTM_DELNSID => RouteNetlinkMessage::DelNsId(msg),
@@ -709,11 +676,7 @@ impl NetlinkDeserializable for RouteNetlinkMessage {
         header: &NetlinkHeader,
         payload: &[u8],
     ) -> Result<Self, Self::Error> {
-        let buf = RouteNetlinkMessageBuffer::new(payload);
-        match RouteNetlinkMessage::parse_with_param(&buf, header.message_type) {
-            Err(e) => Err(e),
-            Ok(message) => Ok(message),
-        }
+        RouteNetlinkMessage::parse_with_param(payload, header.message_type)
     }
 }
 

--- a/src/neighbour/attribute.rs
+++ b/src/neighbour/attribute.rs
@@ -6,10 +6,7 @@ use netlink_packet_core::{
     ParseableParametrized,
 };
 
-use super::{
-    NeighbourAddress, NeighbourCacheInfo, NeighbourCacheInfoBuffer,
-    NeighbourExtFlags,
-};
+use super::{NeighbourAddress, NeighbourCacheInfo, NeighbourExtFlags};
 use crate::{route::RouteProtocol, AddressFamily};
 
 const NDA_DST: u16 = 1;
@@ -123,14 +120,11 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
                     .context(format!("invalid NDA_DST value {payload:?}"))?,
             ),
             NDA_LLADDR => Self::LinkLayerAddress(payload.to_vec()),
-            NDA_CACHEINFO => Self::CacheInfo(
-                NeighbourCacheInfo::parse(
-                    &NeighbourCacheInfoBuffer::new_checked(payload).context(
-                        format!("invalid NDA_CACHEINFO value {payload:?}"),
-                    )?,
-                )
-                .context(format!("invalid NDA_CACHEINFO value {payload:?}"))?,
-            ),
+            NDA_CACHEINFO => {
+                Self::CacheInfo(NeighbourCacheInfo::parse(payload).context(
+                    format!("invalid NDA_CACHEINFO value {payload:?}"),
+                )?)
+            }
             NDA_PROBES => Self::Probes(
                 parse_u32(payload)
                     .context(format!("invalid NDA_PROBES value {payload:?}"))?,

--- a/src/neighbour/cache_info.rs
+++ b/src/neighbour/cache_info.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{DecodeError, Emitable, Parseable};
+use std::mem::size_of;
+
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 #[non_exhaustive]
@@ -11,38 +14,61 @@ pub struct NeighbourCacheInfo {
     pub refcnt: u32,
 }
 
-const NEIGHBOUR_CACHE_INFO_LEN: usize = 16;
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct NeighbourCacheInfoBuffer {
+    confirmed: u32,
+    used: u32,
+    updated: u32,
+    refcnt: u32,
+}
 
-buffer!(NeighbourCacheInfoBuffer(NEIGHBOUR_CACHE_INFO_LEN) {
-    confirmed: (u32, 0..4),
-    used: (u32, 4..8),
-    updated: (u32, 8..12),
-    refcnt: (u32, 12..16),
-});
-
-impl<T: AsRef<[u8]>> Parseable<NeighbourCacheInfoBuffer<T>>
-    for NeighbourCacheInfo
-{
-    fn parse(buf: &NeighbourCacheInfoBuffer<T>) -> Result<Self, DecodeError> {
+impl NeighbourCacheInfo {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) = NeighbourCacheInfoBuffer::ref_from_prefix(payload)
+            .map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    size_of::<NeighbourCacheInfoBuffer>(),
+                )
+            })?;
         Ok(Self {
-            confirmed: buf.confirmed(),
-            used: buf.used(),
-            updated: buf.updated(),
-            refcnt: buf.refcnt(),
+            confirmed: raw.confirmed,
+            used: raw.used,
+            updated: raw.updated,
+            refcnt: raw.refcnt,
         })
+    }
+}
+
+impl From<&NeighbourCacheInfo> for NeighbourCacheInfoBuffer {
+    fn from(value: &NeighbourCacheInfo) -> Self {
+        Self {
+            confirmed: value.confirmed,
+            used: value.used,
+            updated: value.updated,
+            refcnt: value.refcnt,
+        }
     }
 }
 
 impl Emitable for NeighbourCacheInfo {
     fn buffer_len(&self) -> usize {
-        NEIGHBOUR_CACHE_INFO_LEN
+        size_of::<NeighbourCacheInfoBuffer>()
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buffer = NeighbourCacheInfoBuffer::new(buffer);
-        buffer.set_confirmed(self.confirmed);
-        buffer.set_used(self.used);
-        buffer.set_updated(self.updated);
-        buffer.set_refcnt(self.refcnt);
+        let raw = NeighbourCacheInfoBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/neighbour/header.rs
+++ b/src/neighbour/header.rs
@@ -1,29 +1,32 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{
-    DecodeError, Emitable, NlaBuffer, NlasIterator, Parseable,
-};
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use super::{flags::NeighbourFlags, NeighbourState};
 use crate::{route::RouteType, AddressFamily};
 
-const NEIGHBOUR_HEADER_LEN: usize = 12;
+pub(crate) const NEIGHBOUR_HEADER_LEN: usize = 12;
 
-buffer!(NeighbourMessageBuffer(NEIGHBOUR_HEADER_LEN) {
-    family: (u8, 0),
-    ifindex: (u32, 4..8),
-    state: (u16, 8..10),
-    flags: (u8, 10),
-    kind: (u8, 11),
-    payload:(slice, NEIGHBOUR_HEADER_LEN..),
-});
-
-impl<'a, T: AsRef<[u8]> + ?Sized> NeighbourMessageBuffer<&'a T> {
-    pub fn attributes(
-        &self,
-    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
-        NlasIterator::new(self.payload())
-    }
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct NeighbourMessageBuffer {
+    family: u8,
+    _pad: [u8; 3],
+    ifindex: u32,
+    state: u16,
+    flags: u8,
+    kind: u8,
 }
 
 /// Neighbour headers have the following structure:
@@ -55,15 +58,35 @@ pub struct NeighbourHeader {
     pub kind: RouteType,
 }
 
-impl<T: AsRef<[u8]>> Parseable<NeighbourMessageBuffer<T>> for NeighbourHeader {
-    fn parse(buf: &NeighbourMessageBuffer<T>) -> Result<Self, DecodeError> {
+impl NeighbourHeader {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) = NeighbourMessageBuffer::ref_from_prefix(payload)
+            .map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    NEIGHBOUR_HEADER_LEN,
+                )
+            })?;
         Ok(Self {
-            family: buf.family().into(),
-            ifindex: buf.ifindex(),
-            state: buf.state().into(),
-            flags: NeighbourFlags::from_bits_retain(buf.flags()),
-            kind: buf.kind().into(),
+            family: raw.family.into(),
+            ifindex: raw.ifindex,
+            state: raw.state.into(),
+            flags: NeighbourFlags::from_bits_retain(raw.flags),
+            kind: raw.kind.into(),
         })
+    }
+}
+
+impl From<&NeighbourHeader> for NeighbourMessageBuffer {
+    fn from(header: &NeighbourHeader) -> Self {
+        Self {
+            family: header.family.into(),
+            _pad: [0; 3],
+            ifindex: header.ifindex,
+            state: header.state.into(),
+            flags: header.flags.bits(),
+            kind: header.kind.into(),
+        }
     }
 }
 
@@ -73,11 +96,7 @@ impl Emitable for NeighbourHeader {
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut packet = NeighbourMessageBuffer::new(buffer);
-        packet.set_family(self.family.into());
-        packet.set_ifindex(self.ifindex);
-        packet.set_state(self.state.into());
-        packet.set_flags(self.flags.bits());
-        packet.set_kind(self.kind.into());
+        let raw = NeighbourMessageBuffer::from(self);
+        buffer[..NEIGHBOUR_HEADER_LEN].copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/neighbour/message.rs
+++ b/src/neighbour/message.rs
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: MIT
 
 use netlink_packet_core::{
-    DecodeError, Emitable, ErrorContext, Parseable, ParseableParametrized,
+    DecodeError, Emitable, ErrorContext, NlasIterator, Parseable,
+    ParseableParametrized,
 };
 
 use super::{
-    super::AddressFamily, NeighbourAttribute, NeighbourHeader,
-    NeighbourMessageBuffer,
+    header::NEIGHBOUR_HEADER_LEN, NeighbourAttribute, NeighbourHeader,
 };
+use crate::AddressFamily;
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
@@ -29,38 +30,29 @@ impl Emitable for NeighbourMessage {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<NeighbourMessageBuffer<&'a T>>
-    for NeighbourMessage
-{
-    fn parse(buf: &NeighbourMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl Parseable<[u8]> for NeighbourMessage {
+    fn parse(buf: &[u8]) -> Result<Self, DecodeError> {
         let header = NeighbourHeader::parse(buf)
             .context("failed to parse neighbour message header")?;
         let address_family = header.family;
-        Ok(NeighbourMessage {
-            header,
-            attributes: Vec::<NeighbourAttribute>::parse_with_param(
-                buf,
-                address_family,
-            )
-            .context("failed to parse neighbour message NLAs")?,
-        })
+        let attributes = Vec::<NeighbourAttribute>::parse_with_param(
+            &buf[NEIGHBOUR_HEADER_LEN..],
+            address_family,
+        )
+        .context("failed to parse neighbour message NLAs")?;
+        Ok(NeighbourMessage { header, attributes })
     }
 }
 
-impl<'a, T: AsRef<[u8]> + 'a>
-    ParseableParametrized<NeighbourMessageBuffer<&'a T>, AddressFamily>
-    for Vec<NeighbourAttribute>
-{
+impl ParseableParametrized<[u8], AddressFamily> for Vec<NeighbourAttribute> {
     fn parse_with_param(
-        buf: &NeighbourMessageBuffer<&'a T>,
-        address_family: AddressFamily,
+        buf: &[u8],
+        family: AddressFamily,
     ) -> Result<Self, DecodeError> {
         let mut attributes = vec![];
-        for nla_buf in buf.attributes() {
-            attributes.push(NeighbourAttribute::parse_with_param(
-                &nla_buf?,
-                address_family,
-            )?);
+        for nla_buf in NlasIterator::new(buf) {
+            attributes
+                .push(NeighbourAttribute::parse_with_param(&nla_buf?, family)?);
         }
         Ok(attributes)
     }

--- a/src/neighbour/tests/bridge.rs
+++ b/src/neighbour/tests/bridge.rs
@@ -5,7 +5,7 @@ use netlink_packet_core::{Emitable, Parseable};
 use crate::{
     neighbour::{
         flags::NeighbourFlags, NeighbourAttribute, NeighbourHeader,
-        NeighbourMessage, NeighbourMessageBuffer, NeighbourState,
+        NeighbourMessage, NeighbourState,
     },
     route::RouteType,
     AddressFamily,
@@ -33,10 +33,7 @@ fn test_bridge_neighbour_show() {
         ])],
     };
 
-    assert_eq!(
-        expected,
-        NeighbourMessage::parse(&NeighbourMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, NeighbourMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/neighbour/tests/ip.rs
+++ b/src/neighbour/tests/ip.rs
@@ -10,8 +10,7 @@ use netlink_packet_core::{Emitable, Parseable};
 use crate::{
     neighbour::{
         flags::NeighbourFlags, NeighbourAttribute, NeighbourCacheInfo,
-        NeighbourExtFlags, NeighbourHeader, NeighbourMessage,
-        NeighbourMessageBuffer, NeighbourState,
+        NeighbourExtFlags, NeighbourHeader, NeighbourMessage, NeighbourState,
     },
     route::{RouteProtocol, RouteType},
     AddressFamily,
@@ -54,10 +53,7 @@ fn test_ipv4_neighbour_show() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        NeighbourMessage::parse(&NeighbourMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, NeighbourMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -106,10 +102,7 @@ fn test_ipv6_neighbour_show() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        NeighbourMessage::parse(&NeighbourMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, NeighbourMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -160,10 +153,7 @@ fn test_ipv4_neighbour_protocol_show() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        NeighbourMessage::parse(&NeighbourMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, NeighbourMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -196,10 +186,7 @@ fn test_ipv4_neighbour_add_ext_flags() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        NeighbourMessage::parse(&NeighbourMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, NeighbourMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -243,10 +230,7 @@ fn test_ipv4_neighbour_show_ext_flags() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        NeighbourMessage::parse(&NeighbourMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, NeighbourMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/neighbour_table/attribute.rs
+++ b/src/neighbour_table/attribute.rs
@@ -2,13 +2,13 @@
 
 use netlink_packet_core::{
     emit_u32, emit_u64, parse_string, parse_u32, parse_u64, DecodeError,
-    DefaultNla, Emitable, ErrorContext, Nla, NlaBuffer, Parseable,
+    DefaultNla, Emitable, ErrorContext, Nla, NlaBuffer, NlasIterator,
+    Parseable,
 };
 
 use super::{
     param::VecNeighbourTableParameter, NeighbourTableConfig,
-    NeighbourTableConfigBuffer, NeighbourTableParameter, NeighbourTableStats,
-    NeighbourTableStatsBuffer,
+    NeighbourTableParameter, NeighbourTableStats,
 };
 
 const NDTA_NAME: u16 = 1;
@@ -92,18 +92,12 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                 parse_string(payload).context("invalid NDTA_NAME value")?,
             ),
             NDTA_CONFIG => Self::Config(
-                NeighbourTableConfig::parse(
-                    &NeighbourTableConfigBuffer::new_checked(payload)
-                        .context(format!("invalid NDTA_CONFIG {payload:?}"))?,
-                )
-                .context(format!("invalid NDTA_CONFIG {payload:?}"))?,
+                NeighbourTableConfig::parse(payload)
+                    .context(format!("invalid NDTA_CONFIG {payload:?}"))?,
             ),
             NDTA_STATS => Self::Stats(
-                NeighbourTableStats::parse(
-                    &NeighbourTableStatsBuffer::new_checked(payload)
-                        .context(format!("invalid NDTA_STATS {payload:?}"))?,
-                )
-                .context(format!("invalid NDTA_STATS {payload:?}"))?,
+                NeighbourTableStats::parse(payload)
+                    .context(format!("invalid NDTA_STATS {payload:?}"))?,
             ),
             NDTA_PARMS => {
                 let err = |payload| format!("invalid NDTA_PARMS {payload:?}");
@@ -133,5 +127,19 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                     .context(format!("unknown NLA type {kind}"))?,
             ),
         })
+    }
+}
+
+pub(crate) struct VecNeighbourTableAttribute(
+    pub(crate) Vec<NeighbourTableAttribute>,
+);
+
+impl Parseable<[u8]> for VecNeighbourTableAttribute {
+    fn parse(buf: &[u8]) -> Result<Self, DecodeError> {
+        let mut attributes = vec![];
+        for nla_buf in NlasIterator::new(buf) {
+            attributes.push(NeighbourTableAttribute::parse(&nla_buf?)?);
+        }
+        Ok(Self(attributes))
     }
 }

--- a/src/neighbour_table/config.rs
+++ b/src/neighbour_table/config.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{DecodeError, Emitable, Parseable};
+use std::mem::size_of;
+
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 #[non_exhaustive]
@@ -16,53 +19,76 @@ pub struct NeighbourTableConfig {
     pub proxy_qlen: u32,
 }
 
-pub const CONFIG_LEN: usize = 32;
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct NeighbourTableConfigBuffer {
+    key_len: u16,
+    entry_size: u16,
+    entries: u32,
+    last_flush: u32,
+    last_rand: u32,
+    hash_rand: u32,
+    hash_mask: u32,
+    hash_chain_gc: u32,
+    proxy_qlen: u32,
+}
 
-buffer!(NeighbourTableConfigBuffer(CONFIG_LEN) {
-    key_len: (u16, 0..2),
-    entry_size: (u16, 2..4),
-    entries: (u32, 4..8),
-    last_flush: (u32, 8..12),
-    last_rand: (u32, 12..16),
-    hash_rand: (u32, 16..20),
-    hash_mask: (u32, 20..24),
-    hash_chain_gc: (u32, 24..28),
-    proxy_qlen: (u32, 28..32),
-});
-
-impl<T: AsRef<[u8]>> Parseable<NeighbourTableConfigBuffer<T>>
-    for NeighbourTableConfig
-{
-    fn parse(buf: &NeighbourTableConfigBuffer<T>) -> Result<Self, DecodeError> {
+impl NeighbourTableConfig {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) = NeighbourTableConfigBuffer::ref_from_prefix(payload)
+            .map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    size_of::<NeighbourTableConfigBuffer>(),
+                )
+            })?;
         Ok(Self {
-            key_len: buf.key_len(),
-            entry_size: buf.entry_size(),
-            entries: buf.entries(),
-            last_flush: buf.last_flush(),
-            last_rand: buf.last_rand(),
-            hash_rand: buf.hash_rand(),
-            hash_mask: buf.hash_mask(),
-            hash_chain_gc: buf.hash_chain_gc(),
-            proxy_qlen: buf.proxy_qlen(),
+            key_len: raw.key_len,
+            entry_size: raw.entry_size,
+            entries: raw.entries,
+            last_flush: raw.last_flush,
+            last_rand: raw.last_rand,
+            hash_rand: raw.hash_rand,
+            hash_mask: raw.hash_mask,
+            hash_chain_gc: raw.hash_chain_gc,
+            proxy_qlen: raw.proxy_qlen,
         })
+    }
+}
+
+impl From<&NeighbourTableConfig> for NeighbourTableConfigBuffer {
+    fn from(value: &NeighbourTableConfig) -> Self {
+        Self {
+            key_len: value.key_len,
+            entry_size: value.entry_size,
+            entries: value.entries,
+            last_flush: value.last_flush,
+            last_rand: value.last_rand,
+            hash_rand: value.hash_rand,
+            hash_mask: value.hash_mask,
+            hash_chain_gc: value.hash_chain_gc,
+            proxy_qlen: value.proxy_qlen,
+        }
     }
 }
 
 impl Emitable for NeighbourTableConfig {
     fn buffer_len(&self) -> usize {
-        CONFIG_LEN
+        size_of::<NeighbourTableConfigBuffer>()
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buffer = NeighbourTableConfigBuffer::new(buffer);
-        buffer.set_key_len(self.key_len);
-        buffer.set_entry_size(self.entry_size);
-        buffer.set_entries(self.entries);
-        buffer.set_last_flush(self.last_flush);
-        buffer.set_last_rand(self.last_rand);
-        buffer.set_hash_rand(self.hash_rand);
-        buffer.set_hash_mask(self.hash_mask);
-        buffer.set_hash_chain_gc(self.hash_chain_gc);
-        buffer.set_proxy_qlen(self.proxy_qlen);
+        let raw = NeighbourTableConfigBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/neighbour_table/header.rs
+++ b/src/neighbour_table/header.rs
@@ -1,24 +1,27 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{
-    DecodeError, Emitable, NlaBuffer, NlasIterator, Parseable,
-};
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use crate::AddressFamily;
 
-const NEIGHBOUR_TABLE_HEADER_LEN: usize = 4;
+pub(crate) const NEIGHBOUR_TABLE_HEADER_LEN: usize = 4;
 
-buffer!(NeighbourTableMessageBuffer(NEIGHBOUR_TABLE_HEADER_LEN) {
-    family: (u8, 0),
-    payload: (slice, NEIGHBOUR_TABLE_HEADER_LEN..),
-});
-
-impl<'a, T: AsRef<[u8]> + ?Sized> NeighbourTableMessageBuffer<&'a T> {
-    pub fn attributes(
-        &self,
-    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
-        NlasIterator::new(self.payload())
-    }
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct NeighbourTableMessageBuffer {
+    family: u8,
+    _pad: [u8; 3],
 }
 
 // kernel code is `struct rtgenmsg`
@@ -27,15 +30,27 @@ pub struct NeighbourTableHeader {
     pub family: AddressFamily,
 }
 
-impl<T: AsRef<[u8]>> Parseable<NeighbourTableMessageBuffer<T>>
-    for NeighbourTableHeader
-{
-    fn parse(
-        buf: &NeighbourTableMessageBuffer<T>,
-    ) -> Result<Self, DecodeError> {
+impl NeighbourTableHeader {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) = NeighbourTableMessageBuffer::ref_from_prefix(payload)
+            .map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    NEIGHBOUR_TABLE_HEADER_LEN,
+                )
+            })?;
         Ok(Self {
-            family: buf.family().into(),
+            family: raw.family.into(),
         })
+    }
+}
+
+impl From<&NeighbourTableHeader> for NeighbourTableMessageBuffer {
+    fn from(header: &NeighbourTableHeader) -> Self {
+        Self {
+            family: header.family.into(),
+            _pad: [0; 3],
+        }
     }
 }
 
@@ -45,7 +60,7 @@ impl Emitable for NeighbourTableHeader {
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut packet = NeighbourTableMessageBuffer::new(buffer);
-        packet.set_family(self.family.into());
+        let raw = NeighbourTableMessageBuffer::from(self);
+        buffer[..NEIGHBOUR_TABLE_HEADER_LEN].copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/neighbour_table/message.rs
+++ b/src/neighbour_table/message.rs
@@ -3,7 +3,8 @@
 use netlink_packet_core::{DecodeError, Emitable, ErrorContext, Parseable};
 
 use super::{
-    NeighbourTableAttribute, NeighbourTableHeader, NeighbourTableMessageBuffer,
+    attribute::VecNeighbourTableAttribute, header::NEIGHBOUR_TABLE_HEADER_LEN,
+    NeighbourTableAttribute, NeighbourTableHeader,
 };
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
@@ -26,31 +27,16 @@ impl Emitable for NeighbourTableMessage {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<NeighbourTableMessageBuffer<&'a T>>
-    for NeighbourTableMessage
-{
-    fn parse(
-        buf: &NeighbourTableMessageBuffer<&'a T>,
-    ) -> Result<Self, DecodeError> {
+impl Parseable<[u8]> for NeighbourTableMessage {
+    fn parse(buf: &[u8]) -> Result<Self, DecodeError> {
         Ok(NeighbourTableMessage {
             header: NeighbourTableHeader::parse(buf)
                 .context("failed to parse neighbour table message header")?,
-            attributes: Vec::<NeighbourTableAttribute>::parse(buf)
-                .context("failed to parse neighbour table message NLAs")?,
+            attributes: VecNeighbourTableAttribute::parse(
+                &buf[NEIGHBOUR_TABLE_HEADER_LEN..],
+            )
+            .context("failed to parse neighbour table message NLAs")?
+            .0,
         })
-    }
-}
-
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<NeighbourTableMessageBuffer<&'a T>>
-    for Vec<NeighbourTableAttribute>
-{
-    fn parse(
-        buf: &NeighbourTableMessageBuffer<&'a T>,
-    ) -> Result<Self, DecodeError> {
-        let mut attributes = vec![];
-        for nla_buf in buf.attributes() {
-            attributes.push(NeighbourTableAttribute::parse(&nla_buf?)?);
-        }
-        Ok(attributes)
     }
 }

--- a/src/neighbour_table/stats.rs
+++ b/src/neighbour_table/stats.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{DecodeError, Emitable, Parseable};
+use std::mem::size_of;
+
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 #[non_exhaustive]
@@ -18,58 +21,82 @@ pub struct NeighbourTableStats {
     pub table_fulls: u64,
 }
 
-pub const STATS_LEN: usize = 88;
-buffer!(NeighbourTableStatsBuffer(STATS_LEN) {
-    allocs: (u64, 0..8),
-    destroys: (u64, 8..16),
-    hash_grows: (u64, 16..24),
-    res_failed: (u64, 24..32),
-    lookups: (u64, 32..40),
-    hits: (u64, 40..48),
-    multicast_probes_received: (u64, 48..56),
-    unicast_probes_received: (u64, 56..64),
-    periodic_gc_runs: (u64, 64..72),
-    forced_gc_runs: (u64, 72..80),
-    table_fulls: (u64, 80..88),
-});
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct NeighbourTableStatsBuffer {
+    allocs: u64,
+    destroys: u64,
+    hash_grows: u64,
+    res_failed: u64,
+    lookups: u64,
+    hits: u64,
+    multicast_probes_received: u64,
+    unicast_probes_received: u64,
+    periodic_gc_runs: u64,
+    forced_gc_runs: u64,
+    table_fulls: u64,
+}
 
-impl<T: AsRef<[u8]>> Parseable<NeighbourTableStatsBuffer<T>>
-    for NeighbourTableStats
-{
-    fn parse(buf: &NeighbourTableStatsBuffer<T>) -> Result<Self, DecodeError> {
+impl NeighbourTableStats {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) = NeighbourTableStatsBuffer::ref_from_prefix(payload)
+            .map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    size_of::<NeighbourTableStatsBuffer>(),
+                )
+            })?;
         Ok(Self {
-            allocs: buf.allocs(),
-            destroys: buf.destroys(),
-            hash_grows: buf.hash_grows(),
-            res_failed: buf.res_failed(),
-            lookups: buf.lookups(),
-            hits: buf.hits(),
-            multicast_probes_received: buf.multicast_probes_received(),
-            unicast_probes_received: buf.unicast_probes_received(),
-            periodic_gc_runs: buf.periodic_gc_runs(),
-            forced_gc_runs: buf.forced_gc_runs(),
-            table_fulls: buf.table_fulls(),
+            allocs: raw.allocs,
+            destroys: raw.destroys,
+            hash_grows: raw.hash_grows,
+            res_failed: raw.res_failed,
+            lookups: raw.lookups,
+            hits: raw.hits,
+            multicast_probes_received: raw.multicast_probes_received,
+            unicast_probes_received: raw.unicast_probes_received,
+            periodic_gc_runs: raw.periodic_gc_runs,
+            forced_gc_runs: raw.forced_gc_runs,
+            table_fulls: raw.table_fulls,
         })
+    }
+}
+
+impl From<&NeighbourTableStats> for NeighbourTableStatsBuffer {
+    fn from(value: &NeighbourTableStats) -> Self {
+        Self {
+            allocs: value.allocs,
+            destroys: value.destroys,
+            hash_grows: value.hash_grows,
+            res_failed: value.res_failed,
+            lookups: value.lookups,
+            hits: value.hits,
+            multicast_probes_received: value.multicast_probes_received,
+            unicast_probes_received: value.unicast_probes_received,
+            periodic_gc_runs: value.periodic_gc_runs,
+            forced_gc_runs: value.forced_gc_runs,
+            table_fulls: value.table_fulls,
+        }
     }
 }
 
 impl Emitable for NeighbourTableStats {
     fn buffer_len(&self) -> usize {
-        STATS_LEN
+        size_of::<NeighbourTableStatsBuffer>()
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buffer = NeighbourTableStatsBuffer::new(buffer);
-        buffer.set_allocs(self.allocs);
-        buffer.set_destroys(self.destroys);
-        buffer.set_hash_grows(self.hash_grows);
-        buffer.set_res_failed(self.res_failed);
-        buffer.set_lookups(self.lookups);
-        buffer.set_hits(self.hits);
-        buffer.set_multicast_probes_received(self.multicast_probes_received);
-        buffer.set_unicast_probes_received(self.unicast_probes_received);
-        buffer.set_periodic_gc_runs(self.periodic_gc_runs);
-        buffer.set_forced_gc_runs(self.forced_gc_runs);
-        buffer.set_table_fulls(self.table_fulls);
+        let raw = NeighbourTableStatsBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/neighbour_table/tests.rs
+++ b/src/neighbour_table/tests.rs
@@ -5,8 +5,7 @@ use netlink_packet_core::{Emitable, Parseable};
 use crate::{
     neighbour_table::{
         NeighbourTableAttribute, NeighbourTableConfig, NeighbourTableHeader,
-        NeighbourTableMessage, NeighbourTableMessageBuffer,
-        NeighbourTableParameter, NeighbourTableStats,
+        NeighbourTableMessage, NeighbourTableParameter, NeighbourTableStats,
     },
     AddressFamily,
 };
@@ -66,11 +65,7 @@ fn test_ipv4_neighbour_table() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        NeighbourTableMessage::parse(&NeighbourTableMessageBuffer::new(&raw))
-            .unwrap()
-    );
+    assert_eq!(expected, NeighbourTableMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -171,11 +166,7 @@ fn test_ipv4_neighbour_table_stats_config() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        NeighbourTableMessage::parse(&NeighbourTableMessageBuffer::new(&raw))
-            .unwrap()
-    );
+    assert_eq!(expected, NeighbourTableMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/nsid/attribute.rs
+++ b/src/nsid/attribute.rs
@@ -2,7 +2,7 @@
 
 use netlink_packet_core::{
     emit_i32, emit_u32, parse_i32, parse_u32, DecodeError, DefaultNla,
-    ErrorContext, Nla, NlaBuffer, Parseable,
+    ErrorContext, Nla, NlaBuffer, NlasIterator, Parseable,
 };
 
 const NETNSA_NSID: u16 = 1;
@@ -83,5 +83,17 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                     .context(format!("unknown NLA type {kind}"))?,
             ),
         })
+    }
+}
+
+pub(crate) struct VecNsidAttribute(pub(crate) Vec<NsidAttribute>);
+
+impl Parseable<[u8]> for VecNsidAttribute {
+    fn parse(buf: &[u8]) -> Result<Self, DecodeError> {
+        let mut attributes = vec![];
+        for nla_buf in NlasIterator::new(buf) {
+            attributes.push(NsidAttribute::parse(&nla_buf?)?);
+        }
+        Ok(Self(attributes))
     }
 }

--- a/src/nsid/header.rs
+++ b/src/nsid/header.rs
@@ -1,29 +1,53 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{
-    DecodeError, Emitable, NlaBuffer, NlasIterator, Parseable,
-};
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use crate::AddressFamily;
 
-const NSID_HEADER_LEN: usize = 4;
+pub(crate) const NSID_HEADER_LEN: usize = 4;
 
-buffer!(NsidMessageBuffer(NSID_HEADER_LEN) {
-    family: (u8, 0),
-    payload: (slice, NSID_HEADER_LEN..),
-});
-
-impl<'a, T: AsRef<[u8]> + ?Sized> NsidMessageBuffer<&'a T> {
-    pub fn attributes(
-        &self,
-    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
-        NlasIterator::new(self.payload())
-    }
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct NsidMessageBuffer {
+    family: u8,
+    _pad: [u8; 3],
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub struct NsidHeader {
     pub family: AddressFamily,
+}
+
+impl NsidHeader {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) =
+            NsidMessageBuffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(payload.len(), NSID_HEADER_LEN)
+            })?;
+        Ok(NsidHeader {
+            family: raw.family.into(),
+        })
+    }
+}
+
+impl From<&NsidHeader> for NsidMessageBuffer {
+    fn from(header: &NsidHeader) -> Self {
+        Self {
+            family: header.family.into(),
+            _pad: [0; 3],
+        }
+    }
 }
 
 impl Emitable for NsidHeader {
@@ -32,15 +56,7 @@ impl Emitable for NsidHeader {
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut packet = NsidMessageBuffer::new(buffer);
-        packet.set_family(self.family.into());
-    }
-}
-
-impl<T: AsRef<[u8]>> Parseable<NsidMessageBuffer<T>> for NsidHeader {
-    fn parse(buf: &NsidMessageBuffer<T>) -> Result<Self, DecodeError> {
-        Ok(NsidHeader {
-            family: buf.family().into(),
-        })
+        let raw = NsidMessageBuffer::from(self);
+        buffer[..NSID_HEADER_LEN].copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/nsid/message.rs
+++ b/src/nsid/message.rs
@@ -2,7 +2,10 @@
 
 use netlink_packet_core::{DecodeError, Emitable, ErrorContext, Parseable};
 
-use crate::nsid::{NsidAttribute, NsidHeader, NsidMessageBuffer};
+use super::{
+    attribute::VecNsidAttribute, header::NSID_HEADER_LEN, NsidAttribute,
+    NsidHeader,
+};
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
@@ -11,28 +14,15 @@ pub struct NsidMessage {
     pub attributes: Vec<NsidAttribute>,
 }
 
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<NsidMessageBuffer<&'a T>>
-    for NsidMessage
-{
-    fn parse(buf: &NsidMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl Parseable<[u8]> for NsidMessage {
+    fn parse(buf: &[u8]) -> Result<Self, DecodeError> {
         Ok(Self {
             header: NsidHeader::parse(buf)
                 .context("failed to parse nsid message header")?,
-            attributes: Vec::<NsidAttribute>::parse(buf)
-                .context("failed to parse nsid message NLAs")?,
+            attributes: VecNsidAttribute::parse(&buf[NSID_HEADER_LEN..])
+                .context("failed to parse nsid message NLAs")?
+                .0,
         })
-    }
-}
-
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<NsidMessageBuffer<&'a T>>
-    for Vec<NsidAttribute>
-{
-    fn parse(buf: &NsidMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
-        let mut attributes = vec![];
-        for nla_buf in buf.attributes() {
-            attributes.push(NsidAttribute::parse(&nla_buf?)?);
-        }
-        Ok(attributes)
     }
 }
 

--- a/src/nsid/tests.rs
+++ b/src/nsid/tests.rs
@@ -3,7 +3,7 @@
 use netlink_packet_core::{Emitable, Parseable};
 
 use crate::{
-    nsid::{NsidAttribute, NsidHeader, NsidMessage, NsidMessageBuffer},
+    nsid::{NsidAttribute, NsidHeader, NsidMessage},
     AddressFamily,
 };
 
@@ -25,10 +25,7 @@ fn test_ip_netns_query_reply() {
         attributes: vec![NsidAttribute::Id(99)],
     };
 
-    assert_eq!(
-        expected,
-        NsidMessage::parse(&NsidMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, NsidMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -55,10 +52,7 @@ fn test_ip_netns_query() {
         attributes: vec![NsidAttribute::Fd(6)],
     };
 
-    assert_eq!(
-        expected,
-        NsidMessage::parse(&NsidMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, NsidMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -82,10 +76,7 @@ fn test_ip_netns_query_target_ns_id() {
         attributes: vec![NsidAttribute::TargetNsid(99)],
     };
 
-    assert_eq!(
-        expected,
-        NsidMessage::parse(&NsidMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, NsidMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/prefix/attribute.rs
+++ b/src/prefix/attribute.rs
@@ -3,10 +3,11 @@
 use std::net::Ipv6Addr;
 
 use netlink_packet_core::{
-    DecodeError, DefaultNla, Emitable, ErrorContext, Nla, NlaBuffer, Parseable,
+    DecodeError, DefaultNla, Emitable, ErrorContext, Nla, NlaBuffer,
+    NlasIterator, Parseable,
 };
 
-use super::cache_info::{CacheInfo, CacheInfoBuffer};
+use super::cache_info::CacheInfo;
 
 const PREFIX_ADDRESS: u16 = 1;
 const PREFIX_CACHEINFO: u16 = 2;
@@ -60,12 +61,24 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                     )))
                 }
             }
-            PREFIX_CACHEINFO => Ok(Self::CacheInfo(
-                CacheInfo::parse(&CacheInfoBuffer::new(payload)).context(
+            PREFIX_CACHEINFO => {
+                Ok(Self::CacheInfo(CacheInfo::parse(payload).context(
                     format!("Invalid PREFIX_CACHEINFO: {payload:?}"),
-                )?,
-            )),
+                )?))
+            }
             _ => Ok(Self::Other(DefaultNla::parse(buf)?)),
         }
+    }
+}
+
+pub(crate) struct VecPrefixAttribute(pub(crate) Vec<PrefixAttribute>);
+
+impl Parseable<[u8]> for VecPrefixAttribute {
+    fn parse(buf: &[u8]) -> Result<Self, DecodeError> {
+        let mut nlas = vec![];
+        for nla_buf in NlasIterator::new(buf) {
+            nlas.push(PrefixAttribute::parse(&nla_buf?)?);
+        }
+        Ok(Self(nlas))
     }
 }

--- a/src/prefix/cache_info.rs
+++ b/src/prefix/cache_info.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{DecodeError, Emitable, Parseable};
+use std::mem::size_of;
+
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
 #[non_exhaustive]
@@ -9,30 +12,55 @@ pub struct CacheInfo {
     pub valid_time: u32,
 }
 
-const CACHE_INFO_LEN: usize = 8;
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct CacheInfoBuffer {
+    preferred_time: u32,
+    valid_time: u32,
+}
 
-buffer!(CacheInfoBuffer(CACHE_INFO_LEN) {
-    preferred_time: (u32, 0..4),
-    valid_time: (u32, 4..8),
-});
-
-impl<T: AsRef<[u8]>> Parseable<CacheInfoBuffer<T>> for CacheInfo {
-    fn parse(buf: &CacheInfoBuffer<T>) -> Result<Self, DecodeError> {
+impl CacheInfo {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) =
+            CacheInfoBuffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    size_of::<CacheInfoBuffer>(),
+                )
+            })?;
         Ok(CacheInfo {
-            preferred_time: buf.preferred_time(),
-            valid_time: buf.valid_time(),
+            preferred_time: raw.preferred_time,
+            valid_time: raw.valid_time,
         })
+    }
+}
+
+impl From<&CacheInfo> for CacheInfoBuffer {
+    fn from(value: &CacheInfo) -> Self {
+        Self {
+            preferred_time: value.preferred_time,
+            valid_time: value.valid_time,
+        }
     }
 }
 
 impl Emitable for CacheInfo {
     fn buffer_len(&self) -> usize {
-        CACHE_INFO_LEN
+        size_of::<CacheInfoBuffer>()
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buffer = CacheInfoBuffer::new(buffer);
-        buffer.set_preferred_time(self.preferred_time);
-        buffer.set_valid_time(self.valid_time);
+        let raw = CacheInfoBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/prefix/header.rs
+++ b/src/prefix/header.rs
@@ -1,29 +1,34 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{DecodeError, Emitable, NlaBuffer, NlasIterator};
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
-const PREFIX_HEADER_LEN: usize = 12;
+pub(crate) const PREFIX_HEADER_LEN: usize = 12;
 
-buffer!(PrefixMessageBuffer(PREFIX_HEADER_LEN) {
-    prefix_family: (u8, 0),
-    pad1: (u8, 1),
-    pad2: (u16, 2..4),
-    ifindex: (i32, 4..8),
-    prefix_type: (u8, 8),
-    prefix_len: (u8, 9),
-    flags: (u8, 10),
-    pad3: (u8, 11),
-    payload: (slice, PREFIX_HEADER_LEN..),
-});
-
-impl<'a, T: AsRef<[u8]> + ?Sized> PrefixMessageBuffer<&'a T> {
-    pub fn nlas(
-        &self,
-    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
-        NlasIterator::new(self.payload())
-    }
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct PrefixMessageBuffer {
+    prefix_family: u8,
+    pad1: u8,
+    pad2: u16,
+    ifindex: i32,
+    prefix_type: u8,
+    prefix_len: u8,
+    flags: u8,
+    pad3: u8,
 }
 
+// Linux kernel code `struct prefixmsg`
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub struct PrefixHeader {
     pub prefix_family: u8,
@@ -33,17 +38,44 @@ pub struct PrefixHeader {
     pub flags: u8,
 }
 
+impl PrefixHeader {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) =
+            PrefixMessageBuffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(payload.len(), PREFIX_HEADER_LEN)
+            })?;
+        Ok(Self {
+            prefix_family: raw.prefix_family,
+            ifindex: raw.ifindex,
+            prefix_type: raw.prefix_type,
+            prefix_len: raw.prefix_len,
+            flags: raw.flags,
+        })
+    }
+}
+
+impl From<&PrefixHeader> for PrefixMessageBuffer {
+    fn from(header: &PrefixHeader) -> Self {
+        Self {
+            prefix_family: header.prefix_family,
+            pad1: 0,
+            pad2: 0,
+            ifindex: header.ifindex,
+            prefix_type: header.prefix_type,
+            prefix_len: header.prefix_len,
+            flags: header.flags,
+            pad3: 0,
+        }
+    }
+}
+
 impl Emitable for PrefixHeader {
     fn buffer_len(&self) -> usize {
         PREFIX_HEADER_LEN
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut packet = PrefixMessageBuffer::new(buffer);
-        packet.set_prefix_family(self.prefix_family);
-        packet.set_ifindex(self.ifindex);
-        packet.set_prefix_type(self.prefix_type);
-        packet.set_prefix_len(self.prefix_len);
-        packet.set_flags(self.flags);
+        let raw = PrefixMessageBuffer::from(self);
+        buffer[..PREFIX_HEADER_LEN].copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/prefix/message.rs
+++ b/src/prefix/message.rs
@@ -3,8 +3,8 @@
 use netlink_packet_core::{DecodeError, Emitable, ErrorContext, Parseable};
 
 use super::{
-    attribute::PrefixAttribute,
-    header::{PrefixHeader, PrefixMessageBuffer},
+    attribute::{PrefixAttribute, VecPrefixAttribute},
+    header::{PrefixHeader, PREFIX_HEADER_LEN},
 };
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
@@ -26,39 +26,14 @@ impl Emitable for PrefixMessage {
     }
 }
 
-impl<T: AsRef<[u8]>> Parseable<PrefixMessageBuffer<T>> for PrefixHeader {
-    fn parse(buf: &PrefixMessageBuffer<T>) -> Result<Self, DecodeError> {
-        Ok(Self {
-            prefix_family: buf.prefix_family(),
-            ifindex: buf.ifindex(),
-            prefix_type: buf.prefix_type(),
-            prefix_len: buf.prefix_len(),
-            flags: buf.flags(),
-        })
-    }
-}
-
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<PrefixMessageBuffer<&'a T>>
-    for PrefixMessage
-{
-    fn parse(buf: &PrefixMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl Parseable<[u8]> for PrefixMessage {
+    fn parse(buf: &[u8]) -> Result<Self, DecodeError> {
         Ok(Self {
             header: PrefixHeader::parse(buf)
                 .context("failed to parse prefix message header")?,
-            attributes: Vec::<PrefixAttribute>::parse(buf)
-                .context("failed to parse prefix message attributes")?,
+            attributes: VecPrefixAttribute::parse(&buf[PREFIX_HEADER_LEN..])
+                .context("failed to parse prefix message attributes")?
+                .0,
         })
-    }
-}
-
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<PrefixMessageBuffer<&'a T>>
-    for Vec<PrefixAttribute>
-{
-    fn parse(buf: &PrefixMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
-        let mut nlas = vec![];
-        for nla_buf in buf.nlas() {
-            nlas.push(PrefixAttribute::parse(&nla_buf?)?);
-        }
-        Ok(nlas)
     }
 }

--- a/src/prefix/tests.rs
+++ b/src/prefix/tests.rs
@@ -6,7 +6,7 @@ use netlink_packet_core::{Emitable, Parseable};
 
 use crate::prefix::{
     attribute::PrefixAttribute, cache_info::CacheInfo, header::PrefixHeader,
-    PrefixMessage, PrefixMessageBuffer,
+    PrefixMessage,
 };
 
 #[test]
@@ -29,8 +29,7 @@ fn test_new_prefix() {
         0xff, 0xff, 0xff, 0xfa,
         0xff, 0xff, 0xff, 0xff,
     ];
-    let actual = PrefixMessage::parse(&PrefixMessageBuffer::new(&data))
-        .expect("Generated PrefixMessage");
+    let actual = PrefixMessage::parse(&data).expect("Generated PrefixMessage");
 
     let expected = PrefixMessage {
         header: PrefixHeader {

--- a/src/rule/attribute.rs
+++ b/src/rule/attribute.rs
@@ -4,7 +4,7 @@ use std::net::IpAddr;
 
 use netlink_packet_core::{
     emit_u32, parse_string, parse_u32, parse_u8, DecodeError, DefaultNla,
-    Emitable, ErrorContext, Nla, NlaBuffer, Parseable,
+    Emitable, ErrorContext, Nla, NlaBuffer, NlasIterator, Parseable,
 };
 
 use crate::{
@@ -223,5 +223,17 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                 DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?,
             ),
         })
+    }
+}
+
+pub(crate) struct VecRuleAttribute(pub(crate) Vec<RuleAttribute>);
+
+impl Parseable<[u8]> for VecRuleAttribute {
+    fn parse(buf: &[u8]) -> Result<Self, DecodeError> {
+        let mut attributes = vec![];
+        for nla_buf in NlasIterator::new(buf) {
+            attributes.push(RuleAttribute::parse(&nla_buf?)?);
+        }
+        Ok(Self(attributes))
     }
 }

--- a/src/rule/header.rs
+++ b/src/rule/header.rs
@@ -1,32 +1,34 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{
-    DecodeError, Emitable, NlaBuffer, NlasIterator, Parseable,
-};
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use super::{super::AddressFamily, flags::RuleFlags, RuleAction};
 
-const RULE_HEADER_LEN: usize = 12;
+pub(crate) const RULE_HEADER_LEN: usize = 12;
 
-buffer!(RuleMessageBuffer(RULE_HEADER_LEN) {
-    family: (u8, 0),
-    dst_len: (u8, 1),
-    src_len: (u8, 2),
-    tos: (u8, 3),
-    table: (u8, 4),
-    reserve_1: (u8, 5),
-    reserve_2: (u8, 6),
-    action: (u8, 7),
-    flags: (u32, 8..RULE_HEADER_LEN),
-    payload: (slice, RULE_HEADER_LEN..),
-});
-
-impl<'a, T: AsRef<[u8]> + ?Sized> RuleMessageBuffer<&'a T> {
-    pub fn attributes(
-        &self,
-    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
-        NlasIterator::new(self.payload())
-    }
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct RuleMessageBuffer {
+    family: u8,
+    dst_len: u8,
+    src_len: u8,
+    tos: u8,
+    table: u8,
+    reserve_1: u8,
+    reserve_2: u8,
+    action: u8,
+    flags: u32,
 }
 
 // Linux kernel code `struct fib_rule_hdr`
@@ -47,29 +49,41 @@ impl Emitable for RuleHeader {
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut packet = RuleMessageBuffer::new(buffer);
-        packet.set_family(self.family.into());
-        packet.set_dst_len(self.dst_len);
-        packet.set_src_len(self.src_len);
-        packet.set_table(self.table);
-        packet.set_tos(self.tos);
-        packet.set_action(self.action.into());
-        packet.set_flags(self.flags.bits());
+        let raw = RuleMessageBuffer::from(self);
+        buffer[..RULE_HEADER_LEN].copy_from_slice(raw.as_bytes());
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<RuleMessageBuffer<&'a T>>
-    for RuleHeader
-{
-    fn parse(buf: &RuleMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl RuleHeader {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) =
+            RuleMessageBuffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(payload.len(), RULE_HEADER_LEN)
+            })?;
         Ok(RuleHeader {
-            family: buf.family().into(),
-            dst_len: buf.dst_len(),
-            src_len: buf.src_len(),
-            tos: buf.tos(),
-            table: buf.table(),
-            action: buf.action().into(),
-            flags: RuleFlags::from_bits_retain(buf.flags()),
+            family: raw.family.into(),
+            dst_len: raw.dst_len,
+            src_len: raw.src_len,
+            tos: raw.tos,
+            table: raw.table,
+            action: raw.action.into(),
+            flags: RuleFlags::from_bits_retain(raw.flags),
         })
+    }
+}
+
+impl From<&RuleHeader> for RuleMessageBuffer {
+    fn from(header: &RuleHeader) -> Self {
+        Self {
+            family: header.family.into(),
+            dst_len: header.dst_len,
+            src_len: header.src_len,
+            tos: header.tos,
+            table: header.table,
+            reserve_1: 0,
+            reserve_2: 0,
+            action: header.action.into(),
+            flags: header.flags.bits(),
+        }
     }
 }

--- a/src/rule/message.rs
+++ b/src/rule/message.rs
@@ -2,7 +2,10 @@
 
 use netlink_packet_core::{DecodeError, Emitable, ErrorContext, Parseable};
 
-use super::{RuleAttribute, RuleHeader, RuleMessageBuffer};
+use super::{
+    attribute::VecRuleAttribute, header::RULE_HEADER_LEN, RuleAttribute,
+    RuleHeader,
+};
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
@@ -24,26 +27,13 @@ impl Emitable for RuleMessage {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<RuleMessageBuffer<&'a T>>
-    for RuleMessage
-{
-    fn parse(buf: &RuleMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl Parseable<[u8]> for RuleMessage {
+    fn parse(buf: &[u8]) -> Result<Self, DecodeError> {
         let header = RuleHeader::parse(buf)
             .context("failed to parse rule message header")?;
-        let attributes = Vec::<RuleAttribute>::parse(buf)
-            .context("failed to parse rule message NLAs")?;
+        let attributes = VecRuleAttribute::parse(&buf[RULE_HEADER_LEN..])
+            .context("failed to parse rule message NLAs")?
+            .0;
         Ok(RuleMessage { header, attributes })
-    }
-}
-
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<RuleMessageBuffer<&'a T>>
-    for Vec<RuleAttribute>
-{
-    fn parse(buf: &RuleMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
-        let mut attributes = vec![];
-        for nla_buf in buf.attributes() {
-            attributes.push(RuleAttribute::parse(&nla_buf?)?);
-        }
-        Ok(attributes)
     }
 }

--- a/src/rule/tests/fw_mark.rs
+++ b/src/rule/tests/fw_mark.rs
@@ -6,7 +6,6 @@ use crate::{
     route::RouteProtocol,
     rule::{
         flags::RuleFlags, RuleAction, RuleAttribute, RuleHeader, RuleMessage,
-        RuleMessageBuffer,
     },
     AddressFamily,
 };
@@ -44,10 +43,7 @@ fn test_ipv4_fwmark_suppress_prefixlength() {
             RuleAttribute::FwMask(0xffffffff),
         ],
     };
-    assert_eq!(
-        expected,
-        RuleMessage::parse(&RuleMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, RuleMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -91,10 +87,7 @@ fn test_ipv6_fwmark_suppress_ifgroup() {
             RuleAttribute::SuppressIfGroup(89),
         ],
     };
-    assert_eq!(
-        expected,
-        RuleMessage::parse(&RuleMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, RuleMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/rule/tests/iif_oif.rs
+++ b/src/rule/tests/iif_oif.rs
@@ -8,7 +8,6 @@ use crate::{
     route::RouteProtocol,
     rule::{
         flags::RuleFlags, RuleAction, RuleAttribute, RuleHeader, RuleMessage,
-        RuleMessageBuffer,
     },
     AddressFamily, IpProtocol,
 };
@@ -55,10 +54,7 @@ fn test_ipv4_iif_oif_prohibit() {
             ),
         ],
     };
-    assert_eq!(
-        expected,
-        RuleMessage::parse(&RuleMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, RuleMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -103,10 +99,7 @@ fn test_ipv6_iif_oif_ipproto() {
             RuleAttribute::IpProtocol(IpProtocol::Icmp),
         ],
     };
-    assert_eq!(
-        expected,
-        RuleMessage::parse(&RuleMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, RuleMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/rule/tests/l3mdev.rs
+++ b/src/rule/tests/l3mdev.rs
@@ -6,7 +6,7 @@ use crate::{
     route::RouteProtocol,
     rule::{
         flags::RuleFlags, RuleAction, RuleAttribute, RuleHeader, RuleMessage,
-        RuleMessageBuffer, RuleUidRange,
+        RuleUidRange,
     },
     AddressFamily,
 };
@@ -43,10 +43,7 @@ fn test_ipv4_l3mdev() {
             RuleAttribute::L3MDev(true),
         ],
     };
-    assert_eq!(
-        expected,
-        RuleMessage::parse(&RuleMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, RuleMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -92,10 +89,7 @@ fn test_ipv6_l3mdev_uid() {
             }),
         ],
     };
-    assert_eq!(
-        expected,
-        RuleMessage::parse(&RuleMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, RuleMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/rule/tests/on_boot_rules.rs
+++ b/src/rule/tests/on_boot_rules.rs
@@ -6,7 +6,6 @@ use crate::{
     route::RouteProtocol,
     rule::{
         flags::RuleFlags, RuleAction, RuleAttribute, RuleHeader, RuleMessage,
-        RuleMessageBuffer,
     },
     AddressFamily,
 };
@@ -39,10 +38,7 @@ fn test_ipv4_rule() {
             RuleAttribute::Priority(32766),
         ],
     };
-    assert_eq!(
-        expected,
-        RuleMessage::parse(&RuleMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, RuleMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -79,10 +75,7 @@ fn test_ipv6_rule() {
             RuleAttribute::Priority(32766),
         ],
     };
-    assert_eq!(
-        expected,
-        RuleMessage::parse(&RuleMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, RuleMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/rule/tests/sport_dport.rs
+++ b/src/rule/tests/sport_dport.rs
@@ -6,7 +6,7 @@ use crate::{
     route::{RouteProtocol, RouteRealm},
     rule::{
         flags::RuleFlags, RuleAction, RuleAttribute, RuleHeader, RuleMessage,
-        RuleMessageBuffer, RulePortRange,
+        RulePortRange,
     },
     AddressFamily, IpProtocol,
 };
@@ -57,10 +57,7 @@ fn test_ipv4_tcp_sport_dport_realm() {
             }),
         ],
     };
-    assert_eq!(
-        expected,
-        RuleMessage::parse(&RuleMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, RuleMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -116,10 +113,7 @@ fn test_ipv4_udp_sport_range_dport_range_reals_src_dst() {
             }),
         ],
     };
-    assert_eq!(
-        expected,
-        RuleMessage::parse(&RuleMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, RuleMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/rule/tests/src_dst.rs
+++ b/src/rule/tests/src_dst.rs
@@ -11,7 +11,6 @@ use crate::{
     route::RouteProtocol,
     rule::{
         flags::RuleFlags, RuleAction, RuleAttribute, RuleHeader, RuleMessage,
-        RuleMessageBuffer,
     },
     AddressFamily,
 };
@@ -53,10 +52,7 @@ fn test_ipv4_src_dst_blackhole() {
             ),
         ],
     };
-    assert_eq!(
-        expected,
-        RuleMessage::parse(&RuleMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, RuleMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 
@@ -107,10 +103,7 @@ fn test_ipv6_src_dst_goto() {
             ),
         ],
     };
-    assert_eq!(
-        expected,
-        RuleMessage::parse(&RuleMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, RuleMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
 

--- a/src/stats/af_spec.rs
+++ b/src/stats/af_spec.rs
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: MIT
 
+use std::mem::size_of;
+
 use netlink_packet_core::{
     DecodeError, DefaultNla, Emitable, ErrorContext, Nla, NlasIterator,
     Parseable, NLA_F_NESTED,
 };
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 const AF_MPLS: u16 = 28;
 const MPLS_STATS_LINK: u16 = 1;
@@ -23,52 +26,77 @@ pub struct MplsLinkStats {
     pub rx_noroute: u64,
 }
 
-const MPLS_LINK_STATS_LEN: usize = 72;
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct MplsLinkStatsBuffer {
+    rx_packets: u64,
+    tx_packets: u64,
+    rx_bytes: u64,
+    tx_bytes: u64,
+    rx_errors: u64,
+    tx_errors: u64,
+    rx_dropped: u64,
+    tx_dropped: u64,
+    rx_noroute: u64,
+}
 
-buffer!(MplsLinkStatsBuffer(MPLS_LINK_STATS_LEN) {
-    rx_packets: (u64, 0..8),
-    tx_packets: (u64, 8..16),
-    rx_bytes: (u64, 16..24),
-    tx_bytes: (u64, 24..32),
-    rx_errors: (u64, 32..40),
-    tx_errors: (u64, 40..48),
-    rx_dropped: (u64, 48..56),
-    tx_dropped: (u64, 56..64),
-    rx_noroute: (u64, 64..72),
-});
-
-impl<T: AsRef<[u8]>> Parseable<MplsLinkStatsBuffer<T>> for MplsLinkStats {
-    fn parse(buf: &MplsLinkStatsBuffer<T>) -> Result<Self, DecodeError> {
+impl MplsLinkStats {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) =
+            MplsLinkStatsBuffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    size_of::<MplsLinkStatsBuffer>(),
+                )
+            })?;
         Ok(Self {
-            rx_packets: buf.rx_packets(),
-            tx_packets: buf.tx_packets(),
-            rx_bytes: buf.rx_bytes(),
-            tx_bytes: buf.tx_bytes(),
-            rx_errors: buf.rx_errors(),
-            tx_errors: buf.tx_errors(),
-            rx_dropped: buf.rx_dropped(),
-            tx_dropped: buf.tx_dropped(),
-            rx_noroute: buf.rx_noroute(),
+            rx_packets: raw.rx_packets,
+            tx_packets: raw.tx_packets,
+            rx_bytes: raw.rx_bytes,
+            tx_bytes: raw.tx_bytes,
+            rx_errors: raw.rx_errors,
+            tx_errors: raw.tx_errors,
+            rx_dropped: raw.rx_dropped,
+            tx_dropped: raw.tx_dropped,
+            rx_noroute: raw.rx_noroute,
         })
+    }
+}
+
+impl From<&MplsLinkStats> for MplsLinkStatsBuffer {
+    fn from(value: &MplsLinkStats) -> Self {
+        Self {
+            rx_packets: value.rx_packets,
+            tx_packets: value.tx_packets,
+            rx_bytes: value.rx_bytes,
+            tx_bytes: value.tx_bytes,
+            rx_errors: value.rx_errors,
+            tx_errors: value.tx_errors,
+            rx_dropped: value.rx_dropped,
+            tx_dropped: value.tx_dropped,
+            rx_noroute: value.rx_noroute,
+        }
     }
 }
 
 impl Nla for MplsLinkStats {
     fn value_len(&self) -> usize {
-        MPLS_LINK_STATS_LEN
+        size_of::<MplsLinkStatsBuffer>()
     }
 
     fn emit_value(&self, buffer: &mut [u8]) {
-        let mut buf = MplsLinkStatsBuffer::new(buffer);
-        buf.set_rx_packets(self.rx_packets);
-        buf.set_tx_packets(self.tx_packets);
-        buf.set_rx_bytes(self.rx_bytes);
-        buf.set_tx_bytes(self.tx_bytes);
-        buf.set_rx_errors(self.rx_errors);
-        buf.set_tx_errors(self.tx_errors);
-        buf.set_rx_dropped(self.rx_dropped);
-        buf.set_tx_dropped(self.tx_dropped);
-        buf.set_rx_noroute(self.rx_noroute);
+        let raw = MplsLinkStatsBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 
     fn kind(&self) -> u16 {
@@ -143,12 +171,8 @@ fn parse_mpls_stats(payload: &[u8]) -> Result<MplsLinkStats, DecodeError> {
         let nla = nla.context("invalid NLA in MPLS stats")?;
         let kind = nla.kind() & !NLA_F_NESTED;
         if kind == MPLS_STATS_LINK {
-            let val = nla.value();
-            return MplsLinkStats::parse(
-                &MplsLinkStatsBuffer::new_checked(val)
-                    .context("invalid MPLS link stats")?,
-            )
-            .context("invalid MPLS link stats");
+            return MplsLinkStats::parse(nla.value())
+                .context("invalid MPLS link stats");
         }
     }
     Ok(MplsLinkStats::default())

--- a/src/stats/attribute.rs
+++ b/src/stats/attribute.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 use netlink_packet_core::{
-    DecodeError, DefaultNla, Emitable, ErrorContext, Nla, NlaBuffer, Parseable,
+    DecodeError, DefaultNla, Emitable, ErrorContext, Nla, NlaBuffer,
+    NlasIterator, Parseable,
 };
 
 use super::{
@@ -105,5 +106,17 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                     .context(format!("unknown IFLA_STATS type {kind}"))?,
             ),
         })
+    }
+}
+
+pub(crate) struct VecStatsAttribute(pub(crate) Vec<StatsAttribute>);
+
+impl Parseable<[u8]> for VecStatsAttribute {
+    fn parse(buf: &[u8]) -> Result<Self, DecodeError> {
+        let mut attributes = vec![];
+        for nla_buf in NlasIterator::new(buf) {
+            attributes.push(StatsAttribute::parse(&nla_buf?)?);
+        }
+        Ok(Self(attributes))
     }
 }

--- a/src/stats/bridge.rs
+++ b/src/stats/bridge.rs
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: MIT
 
+use std::mem::size_of;
+
 use netlink_packet_core::{
     DecodeError, DefaultNla, Emitable, ErrorContext, Nla, NlasIterator,
     Parseable, NLA_F_NESTED,
 };
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 /// Parsed bridge xstat value.
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -30,25 +33,16 @@ pub(crate) fn parse_bridge_xstats(
         let val = nla.value();
         result.push(match kind {
             BRIDGE_XSTATS_MCAST => BridgeXstat::Mcast(
-                BridgeMcastStats::parse(
-                    &BridgeMcastStatsBuffer::new_checked(val)
-                        .context("invalid bridge mcast stats")?,
-                )
-                .context("invalid bridge mcast stats")?,
+                BridgeMcastStats::parse(val)
+                    .context("invalid bridge mcast stats")?,
             ),
             BRIDGE_XSTATS_STP => BridgeXstat::Stp(
-                BridgeStpXstats::parse(
-                    &BridgeStpXstatsBuffer::new_checked(val)
-                        .context("invalid bridge stp stats")?,
-                )
-                .context("invalid bridge stp stats")?,
+                BridgeStpXstats::parse(val)
+                    .context("invalid bridge stp stats")?,
             ),
             BRIDGE_XSTATS_VLAN => BridgeXstat::Vlan(
-                BridgeVlanXstats::parse(
-                    &BridgeVlanXstatsBuffer::new_checked(val)
-                        .context("invalid bridge vlan stats")?,
-                )
-                .context("invalid bridge vlan stats")?,
+                BridgeVlanXstats::parse(val)
+                    .context("invalid bridge vlan stats")?,
             ),
             _ => BridgeXstat::Other(DefaultNla::parse(&nla)?),
         });
@@ -121,115 +115,140 @@ pub struct BridgeMcastStats {
     pub mcast_packets_tx: u64,
 }
 
-const BRIDGE_MCAST_STATS_LEN: usize = 240;
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct BridgeMcastStatsBuffer {
+    igmp_v1queries_rx: u64,
+    igmp_v1queries_tx: u64,
+    igmp_v2queries_rx: u64,
+    igmp_v2queries_tx: u64,
+    igmp_v3queries_rx: u64,
+    igmp_v3queries_tx: u64,
+    igmp_leaves_rx: u64,
+    igmp_leaves_tx: u64,
+    igmp_v1reports_rx: u64,
+    igmp_v1reports_tx: u64,
+    igmp_v2reports_rx: u64,
+    igmp_v2reports_tx: u64,
+    igmp_v3reports_rx: u64,
+    igmp_v3reports_tx: u64,
+    igmp_parse_errors: u64,
+    mld_v1queries_rx: u64,
+    mld_v1queries_tx: u64,
+    mld_v2queries_rx: u64,
+    mld_v2queries_tx: u64,
+    mld_leaves_rx: u64,
+    mld_leaves_tx: u64,
+    mld_v1reports_rx: u64,
+    mld_v1reports_tx: u64,
+    mld_v2reports_rx: u64,
+    mld_v2reports_tx: u64,
+    mld_parse_errors: u64,
+    mcast_bytes_rx: u64,
+    mcast_bytes_tx: u64,
+    mcast_packets_rx: u64,
+    mcast_packets_tx: u64,
+}
 
-buffer!(BridgeMcastStatsBuffer(BRIDGE_MCAST_STATS_LEN) {
-    igmp_v1queries_rx: (u64, 0..8),
-    igmp_v1queries_tx: (u64, 8..16),
-    igmp_v2queries_rx: (u64, 16..24),
-    igmp_v2queries_tx: (u64, 24..32),
-    igmp_v3queries_rx: (u64, 32..40),
-    igmp_v3queries_tx: (u64, 40..48),
-    igmp_leaves_rx: (u64, 48..56),
-    igmp_leaves_tx: (u64, 56..64),
-    igmp_v1reports_rx: (u64, 64..72),
-    igmp_v1reports_tx: (u64, 72..80),
-    igmp_v2reports_rx: (u64, 80..88),
-    igmp_v2reports_tx: (u64, 88..96),
-    igmp_v3reports_rx: (u64, 96..104),
-    igmp_v3reports_tx: (u64, 104..112),
-    igmp_parse_errors: (u64, 112..120),
-    mld_v1queries_rx: (u64, 120..128),
-    mld_v1queries_tx: (u64, 128..136),
-    mld_v2queries_rx: (u64, 136..144),
-    mld_v2queries_tx: (u64, 144..152),
-    mld_leaves_rx: (u64, 152..160),
-    mld_leaves_tx: (u64, 160..168),
-    mld_v1reports_rx: (u64, 168..176),
-    mld_v1reports_tx: (u64, 176..184),
-    mld_v2reports_rx: (u64, 184..192),
-    mld_v2reports_tx: (u64, 192..200),
-    mld_parse_errors: (u64, 200..208),
-    mcast_bytes_rx: (u64, 208..216),
-    mcast_bytes_tx: (u64, 216..224),
-    mcast_packets_rx: (u64, 224..232),
-    mcast_packets_tx: (u64, 232..240),
-});
-
-impl<T: AsRef<[u8]>> Parseable<BridgeMcastStatsBuffer<T>> for BridgeMcastStats {
-    fn parse(buf: &BridgeMcastStatsBuffer<T>) -> Result<Self, DecodeError> {
+impl BridgeMcastStats {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) = BridgeMcastStatsBuffer::ref_from_prefix(payload)
+            .map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    size_of::<BridgeMcastStatsBuffer>(),
+                )
+            })?;
         Ok(Self {
-            igmp_v1queries_rx: buf.igmp_v1queries_rx(),
-            igmp_v1queries_tx: buf.igmp_v1queries_tx(),
-            igmp_v2queries_rx: buf.igmp_v2queries_rx(),
-            igmp_v2queries_tx: buf.igmp_v2queries_tx(),
-            igmp_v3queries_rx: buf.igmp_v3queries_rx(),
-            igmp_v3queries_tx: buf.igmp_v3queries_tx(),
-            igmp_leaves_rx: buf.igmp_leaves_rx(),
-            igmp_leaves_tx: buf.igmp_leaves_tx(),
-            igmp_v1reports_rx: buf.igmp_v1reports_rx(),
-            igmp_v1reports_tx: buf.igmp_v1reports_tx(),
-            igmp_v2reports_rx: buf.igmp_v2reports_rx(),
-            igmp_v2reports_tx: buf.igmp_v2reports_tx(),
-            igmp_v3reports_rx: buf.igmp_v3reports_rx(),
-            igmp_v3reports_tx: buf.igmp_v3reports_tx(),
-            igmp_parse_errors: buf.igmp_parse_errors(),
-            mld_v1queries_rx: buf.mld_v1queries_rx(),
-            mld_v1queries_tx: buf.mld_v1queries_tx(),
-            mld_v2queries_rx: buf.mld_v2queries_rx(),
-            mld_v2queries_tx: buf.mld_v2queries_tx(),
-            mld_leaves_rx: buf.mld_leaves_rx(),
-            mld_leaves_tx: buf.mld_leaves_tx(),
-            mld_v1reports_rx: buf.mld_v1reports_rx(),
-            mld_v1reports_tx: buf.mld_v1reports_tx(),
-            mld_v2reports_rx: buf.mld_v2reports_rx(),
-            mld_v2reports_tx: buf.mld_v2reports_tx(),
-            mld_parse_errors: buf.mld_parse_errors(),
-            mcast_bytes_rx: buf.mcast_bytes_rx(),
-            mcast_bytes_tx: buf.mcast_bytes_tx(),
-            mcast_packets_rx: buf.mcast_packets_rx(),
-            mcast_packets_tx: buf.mcast_packets_tx(),
+            igmp_v1queries_rx: raw.igmp_v1queries_rx,
+            igmp_v1queries_tx: raw.igmp_v1queries_tx,
+            igmp_v2queries_rx: raw.igmp_v2queries_rx,
+            igmp_v2queries_tx: raw.igmp_v2queries_tx,
+            igmp_v3queries_rx: raw.igmp_v3queries_rx,
+            igmp_v3queries_tx: raw.igmp_v3queries_tx,
+            igmp_leaves_rx: raw.igmp_leaves_rx,
+            igmp_leaves_tx: raw.igmp_leaves_tx,
+            igmp_v1reports_rx: raw.igmp_v1reports_rx,
+            igmp_v1reports_tx: raw.igmp_v1reports_tx,
+            igmp_v2reports_rx: raw.igmp_v2reports_rx,
+            igmp_v2reports_tx: raw.igmp_v2reports_tx,
+            igmp_v3reports_rx: raw.igmp_v3reports_rx,
+            igmp_v3reports_tx: raw.igmp_v3reports_tx,
+            igmp_parse_errors: raw.igmp_parse_errors,
+            mld_v1queries_rx: raw.mld_v1queries_rx,
+            mld_v1queries_tx: raw.mld_v1queries_tx,
+            mld_v2queries_rx: raw.mld_v2queries_rx,
+            mld_v2queries_tx: raw.mld_v2queries_tx,
+            mld_leaves_rx: raw.mld_leaves_rx,
+            mld_leaves_tx: raw.mld_leaves_tx,
+            mld_v1reports_rx: raw.mld_v1reports_rx,
+            mld_v1reports_tx: raw.mld_v1reports_tx,
+            mld_v2reports_rx: raw.mld_v2reports_rx,
+            mld_v2reports_tx: raw.mld_v2reports_tx,
+            mld_parse_errors: raw.mld_parse_errors,
+            mcast_bytes_rx: raw.mcast_bytes_rx,
+            mcast_bytes_tx: raw.mcast_bytes_tx,
+            mcast_packets_rx: raw.mcast_packets_rx,
+            mcast_packets_tx: raw.mcast_packets_tx,
         })
+    }
+}
+
+impl From<&BridgeMcastStats> for BridgeMcastStatsBuffer {
+    fn from(value: &BridgeMcastStats) -> Self {
+        Self {
+            igmp_v1queries_rx: value.igmp_v1queries_rx,
+            igmp_v1queries_tx: value.igmp_v1queries_tx,
+            igmp_v2queries_rx: value.igmp_v2queries_rx,
+            igmp_v2queries_tx: value.igmp_v2queries_tx,
+            igmp_v3queries_rx: value.igmp_v3queries_rx,
+            igmp_v3queries_tx: value.igmp_v3queries_tx,
+            igmp_leaves_rx: value.igmp_leaves_rx,
+            igmp_leaves_tx: value.igmp_leaves_tx,
+            igmp_v1reports_rx: value.igmp_v1reports_rx,
+            igmp_v1reports_tx: value.igmp_v1reports_tx,
+            igmp_v2reports_rx: value.igmp_v2reports_rx,
+            igmp_v2reports_tx: value.igmp_v2reports_tx,
+            igmp_v3reports_rx: value.igmp_v3reports_rx,
+            igmp_v3reports_tx: value.igmp_v3reports_tx,
+            igmp_parse_errors: value.igmp_parse_errors,
+            mld_v1queries_rx: value.mld_v1queries_rx,
+            mld_v1queries_tx: value.mld_v1queries_tx,
+            mld_v2queries_rx: value.mld_v2queries_rx,
+            mld_v2queries_tx: value.mld_v2queries_tx,
+            mld_leaves_rx: value.mld_leaves_rx,
+            mld_leaves_tx: value.mld_leaves_tx,
+            mld_v1reports_rx: value.mld_v1reports_rx,
+            mld_v1reports_tx: value.mld_v1reports_tx,
+            mld_v2reports_rx: value.mld_v2reports_rx,
+            mld_v2reports_tx: value.mld_v2reports_tx,
+            mld_parse_errors: value.mld_parse_errors,
+            mcast_bytes_rx: value.mcast_bytes_rx,
+            mcast_bytes_tx: value.mcast_bytes_tx,
+            mcast_packets_rx: value.mcast_packets_rx,
+            mcast_packets_tx: value.mcast_packets_tx,
+        }
     }
 }
 
 impl Emitable for BridgeMcastStats {
     fn buffer_len(&self) -> usize {
-        BRIDGE_MCAST_STATS_LEN
+        size_of::<BridgeMcastStatsBuffer>()
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buf = BridgeMcastStatsBuffer::new(buffer);
-        buf.set_igmp_v1queries_rx(self.igmp_v1queries_rx);
-        buf.set_igmp_v1queries_tx(self.igmp_v1queries_tx);
-        buf.set_igmp_v2queries_rx(self.igmp_v2queries_rx);
-        buf.set_igmp_v2queries_tx(self.igmp_v2queries_tx);
-        buf.set_igmp_v3queries_rx(self.igmp_v3queries_rx);
-        buf.set_igmp_v3queries_tx(self.igmp_v3queries_tx);
-        buf.set_igmp_leaves_rx(self.igmp_leaves_rx);
-        buf.set_igmp_leaves_tx(self.igmp_leaves_tx);
-        buf.set_igmp_v1reports_rx(self.igmp_v1reports_rx);
-        buf.set_igmp_v1reports_tx(self.igmp_v1reports_tx);
-        buf.set_igmp_v2reports_rx(self.igmp_v2reports_rx);
-        buf.set_igmp_v2reports_tx(self.igmp_v2reports_tx);
-        buf.set_igmp_v3reports_rx(self.igmp_v3reports_rx);
-        buf.set_igmp_v3reports_tx(self.igmp_v3reports_tx);
-        buf.set_igmp_parse_errors(self.igmp_parse_errors);
-        buf.set_mld_v1queries_rx(self.mld_v1queries_rx);
-        buf.set_mld_v1queries_tx(self.mld_v1queries_tx);
-        buf.set_mld_v2queries_rx(self.mld_v2queries_rx);
-        buf.set_mld_v2queries_tx(self.mld_v2queries_tx);
-        buf.set_mld_leaves_rx(self.mld_leaves_rx);
-        buf.set_mld_leaves_tx(self.mld_leaves_tx);
-        buf.set_mld_v1reports_rx(self.mld_v1reports_rx);
-        buf.set_mld_v1reports_tx(self.mld_v1reports_tx);
-        buf.set_mld_v2reports_rx(self.mld_v2reports_rx);
-        buf.set_mld_v2reports_tx(self.mld_v2reports_tx);
-        buf.set_mld_parse_errors(self.mld_parse_errors);
-        buf.set_mcast_bytes_rx(self.mcast_bytes_rx);
-        buf.set_mcast_bytes_tx(self.mcast_bytes_tx);
-        buf.set_mcast_packets_rx(self.mcast_packets_rx);
-        buf.set_mcast_packets_tx(self.mcast_packets_tx);
+        let raw = BridgeMcastStatsBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }
 
@@ -245,43 +264,68 @@ pub struct BridgeStpXstats {
     pub tx_tcn: u64,
 }
 
-const BRIDGE_STP_XSTATS_LEN: usize = 48;
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct BridgeStpXstatsBuffer {
+    transition_blk: u64,
+    transition_fwd: u64,
+    rx_bpdu: u64,
+    tx_bpdu: u64,
+    rx_tcn: u64,
+    tx_tcn: u64,
+}
 
-buffer!(BridgeStpXstatsBuffer(BRIDGE_STP_XSTATS_LEN) {
-    transition_blk: (u64, 0..8),
-    transition_fwd: (u64, 8..16),
-    rx_bpdu: (u64, 16..24),
-    tx_bpdu: (u64, 24..32),
-    rx_tcn: (u64, 32..40),
-    tx_tcn: (u64, 40..48),
-});
-
-impl<T: AsRef<[u8]>> Parseable<BridgeStpXstatsBuffer<T>> for BridgeStpXstats {
-    fn parse(buf: &BridgeStpXstatsBuffer<T>) -> Result<Self, DecodeError> {
+impl BridgeStpXstats {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) = BridgeStpXstatsBuffer::ref_from_prefix(payload)
+            .map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    size_of::<BridgeStpXstatsBuffer>(),
+                )
+            })?;
         Ok(Self {
-            transition_blk: buf.transition_blk(),
-            transition_fwd: buf.transition_fwd(),
-            rx_bpdu: buf.rx_bpdu(),
-            tx_bpdu: buf.tx_bpdu(),
-            rx_tcn: buf.rx_tcn(),
-            tx_tcn: buf.tx_tcn(),
+            transition_blk: raw.transition_blk,
+            transition_fwd: raw.transition_fwd,
+            rx_bpdu: raw.rx_bpdu,
+            tx_bpdu: raw.tx_bpdu,
+            rx_tcn: raw.rx_tcn,
+            tx_tcn: raw.tx_tcn,
         })
+    }
+}
+
+impl From<&BridgeStpXstats> for BridgeStpXstatsBuffer {
+    fn from(value: &BridgeStpXstats) -> Self {
+        Self {
+            transition_blk: value.transition_blk,
+            transition_fwd: value.transition_fwd,
+            rx_bpdu: value.rx_bpdu,
+            tx_bpdu: value.tx_bpdu,
+            rx_tcn: value.rx_tcn,
+            tx_tcn: value.tx_tcn,
+        }
     }
 }
 
 impl Emitable for BridgeStpXstats {
     fn buffer_len(&self) -> usize {
-        BRIDGE_STP_XSTATS_LEN
+        size_of::<BridgeStpXstatsBuffer>()
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buf = BridgeStpXstatsBuffer::new(buffer);
-        buf.set_transition_blk(self.transition_blk);
-        buf.set_transition_fwd(self.transition_fwd);
-        buf.set_rx_bpdu(self.rx_bpdu);
-        buf.set_tx_bpdu(self.tx_bpdu);
-        buf.set_rx_tcn(self.rx_tcn);
-        buf.set_tx_tcn(self.tx_tcn);
+        let raw = BridgeStpXstatsBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }
 
@@ -297,44 +341,69 @@ pub struct BridgeVlanXstats {
     pub flags: u16,
 }
 
-const BRIDGE_VLAN_XSTATS_LEN: usize = 40;
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct BridgeVlanXstatsBuffer {
+    rx_bytes: u64,
+    rx_packets: u64,
+    tx_bytes: u64,
+    tx_packets: u64,
+    vid: u16,
+    flags: u16,
+    pad2: u32,
+}
 
-buffer!(BridgeVlanXstatsBuffer(BRIDGE_VLAN_XSTATS_LEN) {
-    rx_bytes: (u64, 0..8),
-    rx_packets: (u64, 8..16),
-    tx_bytes: (u64, 16..24),
-    tx_packets: (u64, 24..32),
-    vid: (u16, 32..34),
-    flags: (u16, 34..36),
-    pad2: (u32, 36..40),
-});
-
-impl<T: AsRef<[u8]>> Parseable<BridgeVlanXstatsBuffer<T>> for BridgeVlanXstats {
-    fn parse(buf: &BridgeVlanXstatsBuffer<T>) -> Result<Self, DecodeError> {
+impl BridgeVlanXstats {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) = BridgeVlanXstatsBuffer::ref_from_prefix(payload)
+            .map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    size_of::<BridgeVlanXstatsBuffer>(),
+                )
+            })?;
         Ok(Self {
-            rx_bytes: buf.rx_bytes(),
-            rx_packets: buf.rx_packets(),
-            tx_bytes: buf.tx_bytes(),
-            tx_packets: buf.tx_packets(),
-            vid: buf.vid(),
-            flags: buf.flags(),
+            rx_bytes: raw.rx_bytes,
+            rx_packets: raw.rx_packets,
+            tx_bytes: raw.tx_bytes,
+            tx_packets: raw.tx_packets,
+            vid: raw.vid,
+            flags: raw.flags,
         })
+    }
+}
+
+impl From<&BridgeVlanXstats> for BridgeVlanXstatsBuffer {
+    fn from(value: &BridgeVlanXstats) -> Self {
+        Self {
+            rx_bytes: value.rx_bytes,
+            rx_packets: value.rx_packets,
+            tx_bytes: value.tx_bytes,
+            tx_packets: value.tx_packets,
+            vid: value.vid,
+            flags: value.flags,
+            pad2: 0,
+        }
     }
 }
 
 impl Emitable for BridgeVlanXstats {
     fn buffer_len(&self) -> usize {
-        BRIDGE_VLAN_XSTATS_LEN
+        size_of::<BridgeVlanXstatsBuffer>()
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buf = BridgeVlanXstatsBuffer::new(buffer);
-        buf.set_rx_bytes(self.rx_bytes);
-        buf.set_rx_packets(self.rx_packets);
-        buf.set_tx_bytes(self.tx_bytes);
-        buf.set_tx_packets(self.tx_packets);
-        buf.set_vid(self.vid);
-        buf.set_flags(self.flags);
-        buf.set_pad2(0);
+        let raw = BridgeVlanXstatsBuffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/stats/header.rs
+++ b/src/stats/header.rs
@@ -1,28 +1,30 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_core::{
-    DecodeError, Emitable, NlaBuffer, NlasIterator, Parseable,
-};
+use netlink_packet_core::{DecodeError, Emitable};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use crate::AddressFamily;
 
-const STATS_HEADER_LEN: usize = 12;
+pub(crate) const STATS_HEADER_LEN: usize = 12;
 
-buffer!(StatsMessageBuffer(STATS_HEADER_LEN) {
-    family: (u8, 0),
-    pad1: (u8, 1),
-    pad2: (u16, 2..4),
-    ifindex: (u32, 4..8),
-    filter_mask: (u32, 8..STATS_HEADER_LEN),
-    payload: (slice, STATS_HEADER_LEN..),
-});
-
-impl<'a, T: AsRef<[u8]> + ?Sized> StatsMessageBuffer<&'a T> {
-    pub fn attributes(
-        &self,
-    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
-        NlasIterator::new(self.payload())
-    }
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct StatsMessageBuffer {
+    family: u8,
+    pad1: u8,
+    pad2: u16,
+    ifindex: u32,
+    filter_mask: u32,
 }
 
 // The kernel uses IFLA_STATS_FILTER_BIT(attr) = 1 << (attr - 1)
@@ -59,27 +61,39 @@ pub struct StatsHeader {
     pub filter_mask: StatsFilterMask,
 }
 
+impl StatsHeader {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) =
+            StatsMessageBuffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(payload.len(), STATS_HEADER_LEN)
+            })?;
+        Ok(StatsHeader {
+            family: raw.family.into(),
+            ifindex: raw.ifindex,
+            filter_mask: StatsFilterMask::from_bits_retain(raw.filter_mask),
+        })
+    }
+}
+
+impl From<&StatsHeader> for StatsMessageBuffer {
+    fn from(header: &StatsHeader) -> Self {
+        Self {
+            family: header.family.into(),
+            pad1: 0,
+            pad2: 0,
+            ifindex: header.ifindex,
+            filter_mask: header.filter_mask.bits(),
+        }
+    }
+}
+
 impl Emitable for StatsHeader {
     fn buffer_len(&self) -> usize {
         STATS_HEADER_LEN
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut packet = StatsMessageBuffer::new(buffer);
-        packet.set_family(self.family.into());
-        packet.set_pad1(0);
-        packet.set_pad2(0);
-        packet.set_ifindex(self.ifindex);
-        packet.set_filter_mask(self.filter_mask.bits());
-    }
-}
-
-impl<T: AsRef<[u8]>> Parseable<StatsMessageBuffer<T>> for StatsHeader {
-    fn parse(buf: &StatsMessageBuffer<T>) -> Result<Self, DecodeError> {
-        Ok(StatsHeader {
-            family: buf.family().into(),
-            ifindex: buf.ifindex(),
-            filter_mask: StatsFilterMask::from_bits_retain(buf.filter_mask()),
-        })
+        let raw = StatsMessageBuffer::from(self);
+        buffer[..STATS_HEADER_LEN].copy_from_slice(raw.as_bytes());
     }
 }

--- a/src/stats/message.rs
+++ b/src/stats/message.rs
@@ -2,7 +2,10 @@
 
 use netlink_packet_core::{DecodeError, Emitable, ErrorContext, Parseable};
 
-use crate::stats::{StatsAttribute, StatsHeader, StatsMessageBuffer};
+use crate::stats::{
+    attribute::VecStatsAttribute, header::STATS_HEADER_LEN, StatsAttribute,
+    StatsHeader,
+};
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
@@ -11,28 +14,15 @@ pub struct StatsMessage {
     pub attributes: Vec<StatsAttribute>,
 }
 
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<StatsMessageBuffer<&'a T>>
-    for StatsMessage
-{
-    fn parse(buf: &StatsMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
+impl Parseable<[u8]> for StatsMessage {
+    fn parse(buf: &[u8]) -> Result<Self, DecodeError> {
         Ok(Self {
             header: StatsHeader::parse(buf)
                 .context("failed to parse stats message header")?,
-            attributes: Vec::<StatsAttribute>::parse(buf)
-                .context("failed to parse stats message NLAs")?,
+            attributes: VecStatsAttribute::parse(&buf[STATS_HEADER_LEN..])
+                .context("failed to parse stats message NLAs")?
+                .0,
         })
-    }
-}
-
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<StatsMessageBuffer<&'a T>>
-    for Vec<StatsAttribute>
-{
-    fn parse(buf: &StatsMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
-        let mut attributes = vec![];
-        for nla_buf in buf.attributes() {
-            attributes.push(StatsAttribute::parse(&nla_buf?)?);
-        }
-        Ok(attributes)
     }
 }
 

--- a/src/stats/offload.rs
+++ b/src/stats/offload.rs
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: MIT
 
+use std::mem::size_of;
+
 use netlink_packet_core::{
     DecodeError, DefaultNla, Emitable, ErrorContext, Nla, NlasIterator,
     Parseable, NLA_F_NESTED,
 };
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use crate::link::Stats64;
 
@@ -71,11 +74,7 @@ pub(crate) fn parse_offload_xstats_inner(
                 HwStatsInfo::parse(val).context("invalid hw stats info")?,
             ),
             IFLA_OFFLOAD_XSTATS_L3_STATS => OffloadXstat::L3Stats(
-                HwStats64::parse(
-                    &HwStats64Buffer::new_checked(val)
-                        .context("invalid l3 stats")?,
-                )
-                .context("invalid l3 stats")?,
+                HwStats64::parse(val).context("invalid l3 stats")?,
             ),
             _ => OffloadXstat::Other(DefaultNla::parse(&nla)?),
         });
@@ -103,52 +102,77 @@ pub struct HwStats64 {
     pub multicast: u64,
 }
 
-const HW_STATS64_LEN: usize = 72;
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
+#[repr(C, packed)]
+pub struct HwStats64Buffer {
+    rx_packets: u64,
+    tx_packets: u64,
+    rx_bytes: u64,
+    tx_bytes: u64,
+    rx_errors: u64,
+    tx_errors: u64,
+    rx_dropped: u64,
+    tx_dropped: u64,
+    multicast: u64,
+}
 
-buffer!(HwStats64Buffer(HW_STATS64_LEN) {
-    rx_packets: (u64, 0..8),
-    tx_packets: (u64, 8..16),
-    rx_bytes: (u64, 16..24),
-    tx_bytes: (u64, 24..32),
-    rx_errors: (u64, 32..40),
-    tx_errors: (u64, 40..48),
-    rx_dropped: (u64, 48..56),
-    tx_dropped: (u64, 56..64),
-    multicast: (u64, 64..72),
-});
-
-impl<T: AsRef<[u8]>> Parseable<HwStats64Buffer<T>> for HwStats64 {
-    fn parse(buf: &HwStats64Buffer<T>) -> Result<Self, DecodeError> {
+impl HwStats64 {
+    pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
+        let (raw, _) =
+            HwStats64Buffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    size_of::<HwStats64Buffer>(),
+                )
+            })?;
         Ok(Self {
-            rx_packets: buf.rx_packets(),
-            tx_packets: buf.tx_packets(),
-            rx_bytes: buf.rx_bytes(),
-            tx_bytes: buf.tx_bytes(),
-            rx_errors: buf.rx_errors(),
-            tx_errors: buf.tx_errors(),
-            rx_dropped: buf.rx_dropped(),
-            tx_dropped: buf.tx_dropped(),
-            multicast: buf.multicast(),
+            rx_packets: raw.rx_packets,
+            tx_packets: raw.tx_packets,
+            rx_bytes: raw.rx_bytes,
+            tx_bytes: raw.tx_bytes,
+            rx_errors: raw.rx_errors,
+            tx_errors: raw.tx_errors,
+            rx_dropped: raw.rx_dropped,
+            tx_dropped: raw.tx_dropped,
+            multicast: raw.multicast,
         })
+    }
+}
+
+impl From<&HwStats64> for HwStats64Buffer {
+    fn from(value: &HwStats64) -> Self {
+        Self {
+            rx_packets: value.rx_packets,
+            tx_packets: value.tx_packets,
+            rx_bytes: value.rx_bytes,
+            tx_bytes: value.tx_bytes,
+            rx_errors: value.rx_errors,
+            tx_errors: value.tx_errors,
+            rx_dropped: value.rx_dropped,
+            tx_dropped: value.tx_dropped,
+            multicast: value.multicast,
+        }
     }
 }
 
 impl Emitable for HwStats64 {
     fn buffer_len(&self) -> usize {
-        HW_STATS64_LEN
+        size_of::<HwStats64Buffer>()
     }
 
     fn emit(&self, buffer: &mut [u8]) {
-        let mut buf = HwStats64Buffer::new(buffer);
-        buf.set_rx_packets(self.rx_packets);
-        buf.set_tx_packets(self.tx_packets);
-        buf.set_rx_bytes(self.rx_bytes);
-        buf.set_tx_bytes(self.tx_bytes);
-        buf.set_rx_errors(self.rx_errors);
-        buf.set_tx_errors(self.tx_errors);
-        buf.set_rx_dropped(self.rx_dropped);
-        buf.set_tx_dropped(self.tx_dropped);
-        buf.set_multicast(self.multicast);
+        let raw = HwStats64Buffer::from(self);
+        buffer.copy_from_slice(raw.as_bytes());
     }
 }
 

--- a/src/stats/tests/af_spec.rs
+++ b/src/stats/tests/af_spec.rs
@@ -5,7 +5,7 @@ use netlink_packet_core::{Emitable, Parseable};
 use crate::{
     stats::{
         AfSpecStat, AfSpecStats, MplsLinkStats, StatsAttribute,
-        StatsFilterMask, StatsHeader, StatsMessage, StatsMessageBuffer,
+        StatsFilterMask, StatsHeader, StatsMessage,
     },
     AddressFamily,
 };
@@ -44,10 +44,7 @@ fn test_parsing_af_spec_mpls() {
         ]))],
     };
 
-    assert_eq!(
-        expected,
-        StatsMessage::parse(&StatsMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, StatsMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
     expected.emit(&mut buf);

--- a/src/stats/tests/bond.rs
+++ b/src/stats/tests/bond.rs
@@ -5,7 +5,7 @@ use netlink_packet_core::{Emitable, Parseable};
 use crate::{
     stats::{
         Bond3adStats, BondXstat, LinkXstatGroup, StatsAttribute,
-        StatsFilterMask, StatsHeader, StatsMessage, StatsMessageBuffer,
+        StatsFilterMask, StatsHeader, StatsMessage,
     },
     AddressFamily,
 };
@@ -81,10 +81,7 @@ fn test_parsing_bond_xstats() {
         ])],
     };
 
-    assert_eq!(
-        expected,
-        StatsMessage::parse(&StatsMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, StatsMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
     expected.emit(&mut buf);

--- a/src/stats/tests/bridge.rs
+++ b/src/stats/tests/bridge.rs
@@ -6,7 +6,7 @@ use crate::{
     stats::{
         AfSpecStats, BridgeMcastStats, BridgeStpXstats, BridgeVlanXstats,
         BridgeXstat, HwStatsInfo, LinkXstatGroup, OffloadXstat, StatsAttribute,
-        StatsFilterMask, StatsHeader, StatsMessage, StatsMessageBuffer,
+        StatsFilterMask, StatsHeader, StatsMessage,
     },
     AddressFamily,
 };
@@ -65,10 +65,7 @@ fn test_parsing_bridge_xstats() {
         ])],
     };
 
-    assert_eq!(
-        expected,
-        StatsMessage::parse(&StatsMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, StatsMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
     expected.emit(&mut buf);
@@ -172,10 +169,7 @@ fn test_parsing_bridge_port_xstats() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        StatsMessage::parse(&StatsMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, StatsMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
     expected.emit(&mut buf);

--- a/src/stats/tests/message.rs
+++ b/src/stats/tests/message.rs
@@ -7,7 +7,7 @@ use netlink_packet_core::{
 use crate::{
     stats::{
         AfSpecStats, HwStatsInfo, OffloadXstat, StatsAttribute,
-        StatsFilterMask, StatsHeader, StatsMessage, StatsMessageBuffer,
+        StatsFilterMask, StatsHeader, StatsMessage,
     },
     AddressFamily, RouteNetlinkMessage,
 };
@@ -66,10 +66,7 @@ fn test_parsing_combined_stats() {
         ],
     };
 
-    assert_eq!(
-        expected,
-        StatsMessage::parse(&StatsMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, StatsMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
     expected.emit(&mut buf);
@@ -159,7 +156,7 @@ fn test_parsing_unknown_stats_attribute() {
         v
     };
 
-    let parsed = StatsMessage::parse(&StatsMessageBuffer::new(&raw)).unwrap();
+    let parsed = StatsMessage::parse(&raw).unwrap();
     assert_eq!(parsed.attributes.len(), 1);
     match &parsed.attributes[0] {
         StatsAttribute::Other(nla) => {

--- a/src/stats/tests/offload.rs
+++ b/src/stats/tests/offload.rs
@@ -5,7 +5,7 @@ use netlink_packet_core::{Emitable, Parseable};
 use crate::{
     stats::{
         HwStats64, HwStatsInfo, OffloadXstat, StatsAttribute, StatsFilterMask,
-        StatsHeader, StatsMessage, StatsMessageBuffer,
+        StatsHeader, StatsMessage,
     },
     AddressFamily,
 };
@@ -45,10 +45,7 @@ fn test_parsing_offload_xstats() {
         ])],
     };
 
-    assert_eq!(
-        expected,
-        StatsMessage::parse(&StatsMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, StatsMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
     expected.emit(&mut buf);
@@ -98,10 +95,7 @@ fn test_parsing_offload_l3_stats() {
         ])],
     };
 
-    assert_eq!(
-        expected,
-        StatsMessage::parse(&StatsMessageBuffer::new(&raw)).unwrap()
-    );
+    assert_eq!(expected, StatsMessage::parse(&raw).unwrap());
 
     let mut buf = vec![0; expected.buffer_len()];
     expected.emit(&mut buf);


### PR DESCRIPTION
Replace the remaining `buffer!()` macros with `zerocopy` crate for
neighbour, neighbour table, rule, nsid, prefix and stats modules,
following the link buffer conversion.

`VecNeighbourTableAttribute`, `VecRuleAttribute`, `VecNsidAttribute`,
`VecPrefixAttribute` and `VecStatsAttribute` are introduced to satisfy
the orphan rule on parsing attribute `Vec<T>` whose param-less
`Parseable<[u8]>` impl has no local type. The param-less
`RouteNetlinkMessageBuffer` is removed in favor of
`ParseableParametrized<[u8], u16>` on `RouteNetlinkMessage`, and the
redundant `*_LEN` constants are dropped in favor of `size_of()`.

Existing test cases cover the changes.