### PR TITLE
Fix BridgeId and TcU32Key

### DIFF
--- a/src/link/link_info/bridge.rs
+++ b/src/link/link_info/bridge.rs
@@ -593,9 +593,14 @@ pub struct BridgeIdBuffer {
 
 impl BridgeId {
     pub fn parse(payload: &[u8]) -> Result<Self, DecodeError> {
-        BridgeIdBuffer::ref_from_bytes(payload)
-            .map(|raw| Self::from(raw.clone()))
-            .map_err(|_| DecodeError::from("invalid BridgeId buffer"))
+        let (raw, _) =
+            BridgeIdBuffer::ref_from_prefix(payload).map_err(|_| {
+                DecodeError::buffer_too_small(
+                    payload.len(),
+                    std::mem::size_of::<BridgeIdBuffer>(),
+                )
+            })?;
+        Ok(Self::from(raw.clone()))
     }
 }
 

--- a/src/tc/filters/cls_u32.rs
+++ b/src/tc/filters/cls_u32.rs
@@ -299,6 +299,9 @@ pub struct TcU32Key {
     pub offmask: i32,
 }
 
+// Wire format of a `struct tc_u32_key`: `mask` and `val` are `__be32`
+// (always big-endian on the wire), while `off` and `offmask` are plain
+// native `int`.
 #[derive(
     Debug,
     PartialEq,
@@ -321,8 +324,8 @@ pub struct TcU32KeyBuffer {
 impl From<&TcU32Key> for TcU32KeyBuffer {
     fn from(key: &TcU32Key) -> Self {
         Self {
-            mask: key.mask,
-            val: key.val,
+            mask: key.mask.to_be(),
+            val: key.val.to_be(),
             off: key.off,
             offmask: key.offmask,
         }
@@ -349,8 +352,8 @@ impl TcU32Key {
                 )
             })?;
         Ok(Self {
-            mask: raw.mask,
-            val: raw.val,
+            mask: u32::from_be(raw.mask),
+            val: u32::from_be(raw.val),
             off: raw.off,
             offmask: raw.offmask,
         })

--- a/src/tc/tests/filter_u32.rs
+++ b/src/tc/tests/filter_u32.rs
@@ -74,15 +74,15 @@ fn test_get_filter_u32() {
                     keys: vec![
                         TcU32Key {
                             mask: 0xffffffff,
-                            val: u32::from_ne_bytes(
+                            val: u32::from_be_bytes(
                                 Ipv4Addr::new(192, 168, 190, 7).octets(),
                             ),
                             off: 16,
                             offmask: 0,
                         },
                         TcU32Key {
-                            mask: 0xffff0000,
-                            val: u32::from_be(36000),
+                            mask: 0x0000ffff,
+                            val: 36000,
                             off: 20,
                             offmask: 0,
                         },


### PR DESCRIPTION
* Allow future BridgeId hold more bytes by using `ref_from_prefix()`.
* Fix byte order of TcU32Key mask/val (should be big endian)